### PR TITLE
Add respond

### DIFF
--- a/packages/apps/src/contexts/activity-signin.ts
+++ b/packages/apps/src/contexts/activity-signin.ts
@@ -6,10 +6,22 @@ import {
 
 import { IActivityContext } from './activity';
 
-export interface IActivitySignInContext
-  extends IActivityContext<ISignInTokenExchangeInvokeActivity | ISignInVerifyStateInvokeActivity> {
+export interface IActivitySignInTokenExchangeContext
+  extends IActivityContext<ISignInTokenExchangeInvokeActivity> {
   /**
    * the token response of the signin request
    */
   token: TokenResponse;
 }
+
+export interface IActivitySignInVerifyStateContext
+  extends IActivityContext<ISignInVerifyStateInvokeActivity> {
+  /**
+   * the token response of the signin request
+   */
+  token: TokenResponse;
+}
+
+export type IActivitySignInContext =
+  | IActivitySignInTokenExchangeContext
+  | IActivitySignInVerifyStateContext;


### PR DESCRIPTION
From our discussion here: https://teams.microsoft.com/l/message/19:c02487ae2b5844b58486a66945db2acc@thread.tacv2/1744235817658?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=1314f851-c930-4caa-b3e0-dbe9b8fe2737&parentMessageId=1744137804118&teamName=Spark%20%F0%9F%94%A5&channelName=Spark%20Discussions&createdTime=1744235817658

In an attempt to amke it easier to know what the user needs to send back. But this isn't that much more helpful either. I think we need to send back a giant list of overloads for `respond`.