### PR TITLE
Fix config response type

### DIFF
--- a/packages/api/src/models/config/config-response.ts
+++ b/packages/api/src/models/config/config-response.ts
@@ -16,7 +16,7 @@ export type ConfigResponse = {
   /**
    * @member {ConfigResponseConfig} [config] The ConfigResponse config of BotConfigAuth or TaskModuleResponse
    */
-  config: ConfigAuth | TaskModuleResponse;
+  config: ConfigAuth | TaskModuleResponse['task'];
 
   /**
    * @member {string} [responseType] The type of response 'config'.


### PR DESCRIPTION
From: https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bot-configuration-experience?tabs=JS1%2Cteams-bot-sdk2%2Cteams-bot-sdk3
```ts
async handleTeamsConfigFetch(_context, _configData) {
    let response = {};
    const adaptiveCard = CardFactory.adaptiveCard(this.adaptiveCardForContinue());
    response = {
       config: {
          value: {
             card: adaptiveCard,
             height: 500,
             width: 600,
             title: 'test card',
          },
          type: 'continue',
       },
    };
    return response;
}
```

Notice how it's not config.task.value?

Tested it locally and it worked:
![image](https://github.com/user-attachments/assets/9b692452-9d52-46a7-9b3f-a6d47c2c1ecd)
![image](https://github.com/user-attachments/assets/7c0c5fe2-905b-4d9c-9fcb-6ae2ab1851c9)
