### PR TITLE
[RFC] Add plugin events

### DIFF
--- a/packages/apps/src/app.plugins.ts
+++ b/packages/apps/src/app.plugins.ts
@@ -6,8 +6,8 @@ import {
   DependencyMetadata,
   PLUGIN_DEPENDENCIES_METADATA_KEY,
 } from './types/plugin/decorators/dependency';
-import { PLUGIN_METADATA_KEY, PluginOptions } from './types/plugin/decorators/plugin';
 import { EventMetadata, PLUGIN_EVENTS_METADATA_KEY } from './types/plugin/decorators/event';
+import { PLUGIN_METADATA_KEY, PluginOptions } from './types/plugin/decorators/plugin';
 
 /**
  * add a plugin
@@ -80,6 +80,10 @@ export function inject(this: App, plugin: IPlugin) {
     } else if (name === 'activity') {
       handler = (event: IPluginActivityEvent) => {
         this.onActivity(plugin as ISender, event);
+      };
+    } else if (name === 'custom') {
+      handler = (name: string, event: unknown) => {
+        this.pluginEvents.emit(name, event);
       };
     }
 

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -26,7 +26,14 @@ import { Router } from './router';
 import { IPlugin } from './types';
 
 import { configTab, func, tab } from './app.embed';
-import { event, onActivity, onActivityResponse, onActivitySent, onError } from './app.events';
+import {
+  event,
+  onActivity,
+  onActivityResponse,
+  onActivitySent,
+  onError,
+  pluginEvent,
+} from './app.events';
 import { onTokenExchange, onVerifyState } from './app.oauth';
 import { getMetadata, getPlugin, inject, plugin } from './app.plugins';
 import { $process } from './app.process';
@@ -170,6 +177,7 @@ export class App {
   protected router = new Router();
   protected tenantTokens = new LocalStorage<string>({}, { max: 20000 });
   protected events = new EventEmitter<IEvents>();
+  protected pluginEvents = new EventEmitter<Record<string, any>>();
   protected startedAt?: Date;
   protected port?: number;
 
@@ -395,6 +403,14 @@ export class App {
    * @param cb the callback to invoke
    */
   event = event;
+
+  /**
+   * subscribe to a plugin event
+   * @param plugin the plugin to subscribe to. The plugin must support events
+   * @param name the event to subscribe to
+   * @param cb the callback to invoke
+   */
+  pluginEvent = pluginEvent;
 
   /**
    * add a plugin

--- a/packages/apps/src/types/plugin/decorators/event.ts
+++ b/packages/apps/src/types/plugin/decorators/event.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 
 export const PLUGIN_EVENTS_METADATA_KEY = 'teams:plugin:events';
-export type PluginEventName = 'error' | 'activity';
+export type PluginEventName = 'error' | 'activity' | 'custom';
 export type EventMetadata = {
   /**
    * the property name

--- a/packages/apps/src/types/plugin/plugin.ts
+++ b/packages/apps/src/types/plugin/plugin.ts
@@ -27,11 +27,7 @@ export type OnErrorPluginEvent = (event: IErrorEvent) => void;
  */
 export type OnActivityPluginEvent = (event: IActivityEvent) => void;
 
-/**
- * a component for extending the base
- * `App` functionality
- */
-export interface IPlugin {
+export interface IBasePlugin {
   /**
    * lifecycle method called by the `App`
    * once during initialization
@@ -86,3 +82,26 @@ export interface IPlugin {
    */
   createStream?(ref: ConversationReference): IStreamer;
 }
+
+export type IPluginWithEvents<TEvents extends {}> = IBasePlugin & {
+  /**
+   * The event types that this plugin can emit. This is just a type, but we need it
+   * for the type system to pick it up.
+   */
+  __eventType: TEvents;
+
+  /**
+   *
+   * @param name key of the event described in TEvents
+   * @param arg the associated argument for the event
+   * @returns
+   */
+  emit: <Name extends keyof TEvents>(name: Name, arg: TEvents[Name]) => void;
+};
+
+/**
+ * a component for extending the base `App` functionality
+ */
+export type IPlugin<TEvents extends {} | undefined = undefined> = TEvents extends {}
+  ? IPluginWithEvents<TEvents>
+  : IBasePlugin;

--- a/packages/apps/src/types/plugin/sender.ts
+++ b/packages/apps/src/types/plugin/sender.ts
@@ -6,7 +6,7 @@ import { IPlugin } from './plugin';
 /**
  * a plugin that can send activities
  */
-export interface ISender extends IPlugin {
+export type ISender<TCustomEvents extends {} | undefined = undefined> = IPlugin<TCustomEvents> & {
   /**
    * called by the `App`
    * to send an activity
@@ -18,4 +18,4 @@ export interface ISender extends IPlugin {
    * to create a new activity stream
    */
   createStream(ref: ConversationReference): IStreamer;
-}
+};


### PR DESCRIPTION
Here, I'm proposing introducing `pluginEvents` as a core `App` concept.

# Why

Plugins are kind of our bread and butter. They make this whole system more extensible and keeps `app` relatively small and focused.
One thing missing from Plugins was the ability for plugins to `emit` an event and have the client application receive it. This concept already exists in `app` for core activity scenarios and other events, but it does not exist in plugins.

# What am I proposing

This change has the following changes:
1. Add a separate emitter for plugins - `app` currently has an event emitter for core events. The app uses them through `this.emit('eventName', eventArgs)`, and the client app can listen to it via `app.event('eventName', (eventArgs) => { ... })`. The even emitter here is type-safe, so `eventName` is a literal, and `evenArgs` corresponds to the associated type for `eventName`. I attempted to reuse this event emitter AND make it typesafe, but it was just too complicated, and after many hours of banging my head against it, I think the simpler and cleaner solution is to create a new `pluginEvent` event emitter in `app`.
Use it like this:
```ts
app.pluginEvent(A2APlugin, 'bar', (event) => {
  event.bar;
});
```
Note that the plugin definition has to be supplied in for typescript to pick up if the event name `bar` is valid for the associated plugin and what the type for `event` is.

2. Plugins now can supply associated EventTypes. This is to make typescript happy. Here is an example:
```ts
export interface Foo {
  bar: {
    bar: string;
  };
  baz: {
    baz: string;
  };
}

/**
 * the A2A plugin
 */
@Plugin({
  name: 'a2a',
  version: pkg.version,
  description: 'an open standard for connecting agents',
})
export class A2APlugin implements IPlugin<Foo> {
  __eventType!: Foo;

  @Event('custom')
  readonly emit!: <Name extends keyof Foo>(name: Name, arg: Foo[Name]) => void;

...
```

![Screen Recording 2025-04-19 at 10 53 52 PM](https://github.com/user-attachments/assets/5de4a520-00fc-418d-8987-f4ac72b52edd)


3. Notice that `@Event('custom')`? That basically is a new path for events to say I have custom events to emit. When you have this, you are hooking up to `pluginEvents` vs `events` event emitter.