### PR TITLE
minor auth fix

### DIFF
--- a/packages/apps/src/app.oauth.ts
+++ b/packages/apps/src/app.oauth.ts
@@ -36,7 +36,7 @@ export async function onTokenExchange(
       })
     );
 
-    this.events.emit('signin', { ...ctx, token });
+    this.events.emit('signin', { ...ctx, token, isSignedIn: true });
     return { status: 200 };
   } catch (error) {
     if (error instanceof AxiosError) {
@@ -84,8 +84,8 @@ export async function onVerifyState(
       })
     );
 
-    this.events.emit('signin', { ...ctx, token });
-    return { status: 200 };
+    this.events.emit('signin', { ...ctx, token, isSignedIn: true });
+    return { status: 200, body: {} };
   } catch (error) {
     if (error instanceof AxiosError) {
       if (error.status !== 404 && error.status !== 400 && error.status !== 412) {

--- a/packages/apps/src/app.oauth.ts
+++ b/packages/apps/src/app.oauth.ts
@@ -85,7 +85,7 @@ export async function onVerifyState(
     );
 
     this.events.emit('signin', { ...ctx, token, isSignedIn: true });
-    return { status: 200, body: {} };
+    return { status: 200 };
   } catch (error) {
     if (error instanceof AxiosError) {
       if (error.status !== 404 && error.status !== 400 && error.status !== 412) {

--- a/packages/cli/configs/ttk/oauth/README.md
+++ b/packages/cli/configs/ttk/oauth/README.md
@@ -1,0 +1,40 @@
+# Teams Toolkit Configuration: Oauth
+
+Use this if you want to enable user authentication in your Teams application.
+
+## How to update scopes
+
+1. In the `aad.manifest.json` file, update the `requiredResourceAccess` list to add the required scopes.
+
+2. In the `infra/botRegistration/azurebot.bicep` file, under the `botServicesMicrosoftGraphConnection` resource, update the `properties.scopes` string to be a comma-delimeted list of the required scopes.
+
+### Example
+
+If you want to add the `People.Read.All` and `User.ReadBasic.All` scopes.
+
+1. Your `requiredResourceAccess` property should look like:
+
+```json
+"requiredResourceAccess": [
+    {
+        "resourceAppId": "Microsoft Graph",
+        "resourceAccess": [
+            {
+                "id": "People.Read.All",
+                "type": "Scope"
+            }
+        ]
+    },
+    {
+        "resourceAppId": "Microsoft Graph",
+        "resourceAccess": [
+            {
+                "id": "User.ReadBasic.All",
+                "type": "Scope"
+            }
+        ]
+    },
+]
+```
+
+2. Update the `properties.scopes` to be `People.Read.All,User.ReadBasic.All`.

--- a/packages/cli/configs/ttk/oauth/aad.manifest.json.hbs
+++ b/packages/cli/configs/ttk/oauth/aad.manifest.json.hbs
@@ -21,7 +21,7 @@
       "resourceAppId": "Microsoft Graph",
       "resourceAccess": [
         {
-          "id": "User.Read",
+          "id": "User.ReadBasic.All",
           "type": "Scope"
         }
       ]

--- a/packages/cli/configs/ttk/oauth/infra/botRegistration/azurebot.bicep
+++ b/packages/cli/configs/ttk/oauth/infra/botRegistration/azurebot.bicep
@@ -49,7 +49,7 @@ resource botServicesMicrosoftGraphConnection 'Microsoft.BotService/botServices/c
     serviceProviderId: '30dd229c-58e3-4a48-bdfd-91ec48eb906c'
     clientId: botAadAppClientId
     clientSecret: botAddAppClientSecret
-    scopes: 'User.Read'
+    scopes: 'User.ReadBasic.All'
     parameters: [
       {
         key: 'tenantID'


### PR DESCRIPTION
* `User.Read` permission is too restrictive. `User.ReadBasic.All` allows for more access. Even restrictive tenants that require admin consent for most graph scopes are lenient with this one.
* `isSignedIn` was set to false when this event is emitted - when infact it shouldn't. 