### PR TITLE
Allow binding to correct port

### DIFF
--- a/packages/cli/src/project/attributes/ttk.ts
+++ b/packages/cli/src/project/attributes/ttk.ts
@@ -1,9 +1,9 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
-import fs from 'node:fs';
 
-import { IProjectAttribute } from '../project-attribute';
 import { Compound, Copy, FileJsonSet, FileYamlSet, If } from '../operations';
+import { IProjectAttribute } from '../project-attribute';
 
 export class TeamsToolkitAttribute implements IProjectAttribute {
   readonly id: string;
@@ -27,13 +27,13 @@ export class TeamsToolkitAttribute implements IProjectAttribute {
         targetDir,
         'package.json',
         'scripts.dev:teamsfx',
-        'npx env-cmd --silent -f .env npm run dev'
+        "NODE_OPTIONS='--inspect=9239' npx env-cmd --silent -f .env npm run dev"
       ),
       new FileJsonSet(
         targetDir,
         'package.json',
         'scripts.dev:teamsfx:testtool',
-        'npx env-cmd --silent -f .env npm run dev'
+        "NODE_OPTIONS='--inspect=9239' npx env-cmd --silent -f .env npm run dev"
       ),
       new FileJsonSet(
         targetDir,

--- a/packages/cli/src/project/attributes/ttk.ts
+++ b/packages/cli/src/project/attributes/ttk.ts
@@ -27,13 +27,13 @@ export class TeamsToolkitAttribute implements IProjectAttribute {
         targetDir,
         'package.json',
         'scripts.dev:teamsfx',
-        "NODE_OPTIONS='--inspect=9239' npx env-cmd --silent -f .env npm run dev"
+        "NODE_OPTIONS='--inspect=9239' npx env-cmd -f .env npm run dev"
       ),
       new FileJsonSet(
         targetDir,
         'package.json',
         'scripts.dev:teamsfx:testtool',
-        "NODE_OPTIONS='--inspect=9239' npx env-cmd --silent -f .env npm run dev"
+        "NODE_OPTIONS='--inspect=9239' npx env-cmd -f .env npm run dev"
       ),
       new FileJsonSet(
         targetDir,


### PR DESCRIPTION
closes #158

Currently our ttk configs do all the setup, but the breakpoint binding wasn't happening. This requires an inspect port to be opened up when running the application. This PR adds that.