### PR TITLE
Add ability to add custom headers to MCP clients

### DIFF
--- a/external/mcpclient/src/mcp-client-plugin.ts
+++ b/external/mcpclient/src/mcp-client-plugin.ts
@@ -3,7 +3,7 @@ import { Client, ClientOptions } from '@modelcontextprotocol/sdk/client/index.js
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 
-type McpClientServerDetails = {
+type McpClientToolDetails = {
   name: string;
   description: string;
   schema: Schema;
@@ -12,7 +12,8 @@ type McpClientServerDetails = {
 type PromiseOrValue<T> = T | Promise<T>;
 type ValueOrFactory<T> = T | (() => PromiseOrValue<T>);
 
-type McpClientPluginArgs = {
+type McpClientPluginParams = {
+  availableTools?: McpClientToolDetails[];
   /**
    * optional headers to pass in per request
    */
@@ -40,26 +41,10 @@ type McpClientPluginArgs = {
   onError?: (error: any) => PromiseOrValue<any>;
 };
 
-type AllOrNothing<T extends Record<string, any>> = T | Partial<Record<keyof T, never>>;
-
-export type McpClientPluginParams = McpClientPluginArgs & AllOrNothing<McpClientServerDetails>;
-
-const getServerDetails = (params: McpClientPluginParams): McpClientServerDetails | null => {
-  if (params.schema != null) {
-    return {
-      name: params.name,
-      description: params.description,
-      schema: params.schema,
-    };
-  }
-
-  return null;
-};
-
 /**
  * A map of Mcp client params keyed off of their corresponding urls
  */
-export type McpClientPluginParamsCache = Record<string, McpClientPluginParams[]>;
+export type McpClientPluginParamsCache = Record<string, McpClientPluginParams>;
 
 /**
  * A function that creates a transport for the Mcp client
@@ -104,7 +89,7 @@ export interface McpClientPluginUseParams {
    * If not provided, the client will fetch the params from the server
    * or use the cached params if provided
    */
-  params?: McpClientPluginParams[];
+  params?: McpClientPluginParams;
 }
 
 export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientPluginUseParams> {
@@ -132,7 +117,7 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
   }
   protected _cache: McpClientPluginParamsCache;
 
-  private readonly _mcpServerUrlsByParams: Record<string, McpClientPluginParams[] | undefined> = {};
+  private readonly _mcpServerUrlsByParams: Record<string, McpClientPluginParams | undefined> = {};
 
   private createTransport: CreateTransport | null;
 
@@ -151,7 +136,7 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     this.createTransport = createTransport ?? null;
   }
 
-  onUsePlugin(args: { url: string; params?: McpClientPluginParams[] }) {
+  onUsePlugin(args: { url: string; params?: McpClientPluginParams }) {
     this._mcpServerUrlsByParams[args.url] = args.params;
   }
 
@@ -159,8 +144,9 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     // First, handle all fetching needs
     const fetchNeeded = Object.entries(this._mcpServerUrlsByParams)
       .map(([url, params]) => {
-        const paramsToFetch = (params ?? this._cache[url] ?? []).some(getServerDetails);
-        if (!paramsToFetch) {
+        const paramsToFetch =
+          params?.availableTools ?? this._cache[url].availableTools ?? undefined;
+        if (paramsToFetch == null) {
           return url;
         }
         return null;
@@ -171,7 +157,10 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     if (fetchNeeded.length > 0) {
       const tools = await this.getTools(fetchNeeded);
       for (const [url, params] of Object.entries(tools)) {
-        this._cache[url] = params;
+        this._cache[url] = {
+          ...this._cache[url],
+          availableTools: params,
+        };
       }
     }
 
@@ -179,34 +168,33 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     const allFunctions: Function[] = [];
 
     for (const [url, params] of Object.entries(this._mcpServerUrlsByParams)) {
-      const resolvedParams = (params ?? this._cache[url] ?? []).filter(
-        (p): p is McpClientServerDetails & McpClientPluginArgs => p.schema != null
-      );
+      const resolvedParams = params ?? this._cache[url];
+      const paramsWithOtherArgs =
+        resolvedParams?.availableTools?.map((serverDetail) => {
+          const { availableTools, ...otherParams } = resolvedParams;
+          return {
+            ...serverDetail,
+            otherParams,
+          };
+        }) ?? [];
 
-      const functions = resolvedParams.map((param) => ({
+      const functions = paramsWithOtherArgs.map((param) => ({
         name: param.name,
         description: param.description,
         parameters: param.schema || {},
         handler: async (args: any) => {
-          const [client, transport] = this.makeMcpClientPlugin(url, param.headers);
+          const [client, transport] = await this.makeMcpClientPlugin(
+            url,
+            param.otherParams.headers
+          );
           try {
             await client.connect(transport);
             const result = await client.callTool({
               name: param.name,
               arguments: args,
             });
-            if (param.onSuccess) {
-              return await param.onSuccess(result.content);
-            }
 
             return result.content;
-          } catch (e) {
-            console.error(e);
-            if (param.onError) {
-              return await param.onError(e);
-            }
-
-            throw e;
           } finally {
             await client.close();
           }
@@ -219,7 +207,7 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     return incomingFunctions.concat(allFunctions);
   }
 
-  async getTools(urls: string[]): Promise<McpClientPluginParamsCache> {
+  async getTools(urls: string[]): Promise<Record<string, McpClientToolDetails[]>> {
     const toolCallResult = await Promise.all(
       urls.map(async (url) => {
         const tools = await this.fetchTools(url);
@@ -230,8 +218,11 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     return Object.fromEntries(toolCallResult);
   }
 
-  private async fetchTools(url: string, headers?: ValueOrFactory<Record<string, string>>): Promise<McpClientPluginParams[]> {
-    const [client, transport] = this.makeMcpClientPlugin(url, headers);
+  private async fetchTools(
+    url: string,
+    headers?: ValueOrFactory<Record<string, string>>
+  ): Promise<McpClientToolDetails[]> {
+    const [client, transport] = await this.makeMcpClientPlugin(url, headers);
     try {
       await client.connect(transport);
       const tools = await client.listTools();
@@ -248,8 +239,16 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     }
   }
 
-  private makeMcpClientPlugin(serverUrl: string, headers: ValueOrFactory<Record<string, string>> | undefined) {
-    const transport = this.createTransport?(serverUrl) ?? await buildSSEClientTransport(serverUrl, headers);
+  private async makeMcpClientPlugin(
+    serverUrl: string,
+    headers: ValueOrFactory<Record<string, string>> | undefined
+  ) {
+    let transport: Transport;
+    if (this.createTransport != null) {
+      transport = this.createTransport(serverUrl);
+    } else {
+      transport = await buildSSEClientTransport(serverUrl, headers);
+    }
 
     const client = new Client(
       {
@@ -266,9 +265,9 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
 const buildSSEClientTransport = async (
   url: string,
   headers: ValueOrFactory<Record<string, string>> | undefined
-) => {
+): Promise<SSEClientTransport> => {
   const resolvedHeaders = typeof headers === 'function' ? await headers() : headers;
-  // We need to include headers like this because of 
+  // We need to include headers like this because of
   // https://github.com/modelcontextprotocol/typescript-sdk/issues/118
   return new SSEClientTransport(new URL(url), {
     requestInit: {

--- a/external/mcpclient/src/mcp-client-plugin.ts
+++ b/external/mcpclient/src/mcp-client-plugin.ts
@@ -3,10 +3,57 @@ import { Client, ClientOptions } from '@modelcontextprotocol/sdk/client/index.js
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 
-export type McpClientPluginParams = {
+type McpClientServerDetails = {
   name: string;
   description: string;
   schema: Schema;
+};
+
+type PromiseOrValue<T> = T | Promise<T>;
+type ValueOrFactory<T> = T | (() => PromiseOrValue<T>);
+
+type McpClientPluginArgs = {
+  /**
+   * optional headers to pass in per request
+   */
+  headers?: ValueOrFactory<Record<string, string>>;
+
+  /**
+   * an optional function to call on a successful response
+   * @param response the response from the server
+   * @returns a value to be treated as a successful response
+   *
+   * Use this to intercept successful responses and override them
+   */
+  onSuccess?: (response: unknown) => PromiseOrValue<any>;
+
+  /**
+   * an optional function to call on an error response.
+   * If the function returns a value, it will override the error
+   * and be treated as a successful response
+   * If it throws, it'll be treated as an error
+   *
+   * Use this to intercept errors and handle them in a custom way
+   * @param error the error from the server
+   * @returns a successful response override
+   */
+  onError?: (error: any) => PromiseOrValue<any>;
+};
+
+type AllOrNothing<T extends Record<string, any>> = T | Partial<Record<keyof T, never>>;
+
+export type McpClientPluginParams = McpClientPluginArgs & AllOrNothing<McpClientServerDetails>;
+
+const getServerDetails = (params: McpClientPluginParams): McpClientServerDetails | null => {
+  if (params.schema != null) {
+    return {
+      name: params.name,
+      description: params.description,
+      schema: params.schema,
+    };
+  }
+
+  return null;
 };
 
 /**
@@ -87,7 +134,7 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
 
   private readonly _mcpServerUrlsByParams: Record<string, McpClientPluginParams[] | undefined> = {};
 
-  private createTransport: CreateTransport;
+  private createTransport: CreateTransport | null;
 
   constructor(options?: McpClientPluginOptions) {
     const {
@@ -101,8 +148,7 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     this._version = version || '0.0.0';
     this._cache = cache || {};
     this._clientOptions = clientOptions;
-    this.createTransport =
-      createTransport ?? ((url: string) => new SSEClientTransport(new URL(url)));
+    this.createTransport = createTransport ?? null;
   }
 
   onUsePlugin(args: { url: string; params?: McpClientPluginParams[] }) {
@@ -113,8 +159,8 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     // First, handle all fetching needs
     const fetchNeeded = Object.entries(this._mcpServerUrlsByParams)
       .map(([url, params]) => {
-        const paramsToFetch = params ?? this._cache[url] ?? undefined;
-        if (paramsToFetch == null) {
+        const paramsToFetch = (params ?? this._cache[url] ?? []).some(getServerDetails);
+        if (!paramsToFetch) {
           return url;
         }
         return null;
@@ -133,21 +179,34 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     const allFunctions: Function[] = [];
 
     for (const [url, params] of Object.entries(this._mcpServerUrlsByParams)) {
-      const resolvedParams = params ?? this._cache[url] ?? [];
+      const resolvedParams = (params ?? this._cache[url] ?? []).filter(
+        (p): p is McpClientServerDetails & McpClientPluginArgs => p.schema != null
+      );
 
       const functions = resolvedParams.map((param) => ({
         name: param.name,
         description: param.description,
         parameters: param.schema || {},
         handler: async (args: any) => {
-          const [client, transport] = this.makeMcpClientPlugin(url);
+          const [client, transport] = this.makeMcpClientPlugin(url, param.headers);
           try {
             await client.connect(transport);
             const result = await client.callTool({
               name: param.name,
               arguments: args,
             });
+            if (param.onSuccess) {
+              return await param.onSuccess(result.content);
+            }
+
             return result.content;
+          } catch (e) {
+            console.error(e);
+            if (param.onError) {
+              return await param.onError(e);
+            }
+
+            throw e;
           } finally {
             await client.close();
           }
@@ -171,8 +230,8 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     return Object.fromEntries(toolCallResult);
   }
 
-  private async fetchTools(url: string): Promise<McpClientPluginParams[]> {
-    const [client, transport] = this.makeMcpClientPlugin(url);
+  private async fetchTools(url: string, headers?: ValueOrFactory<Record<string, string>>): Promise<McpClientPluginParams[]> {
+    const [client, transport] = this.makeMcpClientPlugin(url, headers);
     try {
       await client.connect(transport);
       const tools = await client.listTools();
@@ -189,8 +248,8 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     }
   }
 
-  private makeMcpClientPlugin(serverUrl: string) {
-    const transport = this.createTransport(serverUrl);
+  private makeMcpClientPlugin(serverUrl: string, headers: ValueOrFactory<Record<string, string>> | undefined) {
+    const transport = this.createTransport?(serverUrl) ?? await buildSSEClientTransport(serverUrl, headers);
 
     const client = new Client(
       {
@@ -203,3 +262,31 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     return [client, transport] as const;
   }
 }
+
+const buildSSEClientTransport = async (
+  url: string,
+  headers: ValueOrFactory<Record<string, string>> | undefined
+) => {
+  const resolvedHeaders = typeof headers === 'function' ? await headers() : headers;
+  // We need to include headers like this because of 
+  // https://github.com/modelcontextprotocol/typescript-sdk/issues/118
+  return new SSEClientTransport(new URL(url), {
+    requestInit: {
+      headers: {
+        ...resolvedHeaders,
+      },
+    },
+    eventSourceInit: {
+      fetch(input: Request | URL | string, init?: RequestInit) {
+        const headers = new Headers({
+          ...resolvedHeaders,
+          ...init?.headers,
+        });
+        return fetch(input, {
+          ...init,
+          headers,
+        });
+      },
+    },
+  });
+};


### PR DESCRIPTION
Previously, if you wanted to add custom headers to MCP clients, you'd need to recreate the transport. But adding custom headers is very common and we should support it out of the box.

In this PR we do just that.