### PR TITLE
[Client] Add graph client and methods to prewarm, test, and request scope consent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21473,7 +21473,8 @@
       "peerDependencies": {
         "@microsoft/teams-js": "^2.35.0",
         "@microsoft/teams.api": "*",
-        "@microsoft/teams.common": "*"
+        "@microsoft/teams.common": "*",
+        "@microsoft/teams.graph": "*"
       }
     },
     "packages/client/node_modules/glob": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -43,6 +43,7 @@
   "peerDependencies": {
     "@microsoft/teams.api": "*",
     "@microsoft/teams.common": "*",
+    "@microsoft/teams.graph": "*",
     "@microsoft/teams-js": "^2.35.0"
   },
   "devDependencies": {

--- a/packages/client/src/graph-utils.spec.ts
+++ b/packages/client/src/graph-utils.spec.ts
@@ -1,0 +1,61 @@
+const httpClientMock = jest.fn();
+
+import { buildGraphClient } from './graph-utils';
+
+jest.mock('@microsoft/teams.common/http', () => {
+  return {
+    ...jest.requireActual('@microsoft/teams.common/http'),
+    Client: httpClientMock,
+  };
+});
+
+const mockLogger = {
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  log: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+};
+
+const mockMsalInstance = {
+  acquireTokenSilent: jest.fn().mockResolvedValue({ accessToken: 'mockAccessToken' }),
+  acquireTokenPopup: jest.fn(),
+};
+
+describe('buildGraphClient', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds a graph client', () => {
+    const client = buildGraphClient(() => ({ msalInstance: mockMsalInstance }), mockLogger);
+    expect(httpClientMock).toHaveBeenCalledWith({
+      interceptors: [{ request: expect.any(Function) }],
+    });
+    expect(client).toBeDefined();
+  });
+
+  it('attaches a bearer token to requests', async () => {
+    const setHeaderMock = jest.fn();
+    const mockContext = {
+      config: {
+        headers: {
+          set: setHeaderMock,
+        },
+      },
+    };
+
+    buildGraphClient(() => ({ msalInstance: mockMsalInstance }), mockLogger);
+    expect(httpClientMock).toHaveBeenCalledWith({
+      interceptors: [{ request: expect.any(Function) }],
+    });
+
+    const requestInterceptor = httpClientMock.mock.calls[0][0].interceptors[0].request;
+    const result = await requestInterceptor(mockContext);
+
+    expect(result).toEqual(mockContext.config);
+    expect(setHeaderMock).toHaveBeenCalledWith('Authorization', 'Bearer mockAccessToken');
+    expect(mockMsalInstance.acquireTokenSilent).toHaveBeenCalledWith({ scopes: ['.default'] });
+  });
+});

--- a/packages/client/src/graph-utils.ts
+++ b/packages/client/src/graph-utils.ts
@@ -1,0 +1,33 @@
+import * as http from '@microsoft/teams.common/http';
+import { ILogger } from '@microsoft/teams.common/logging';
+import * as graph from '@microsoft/teams.graph';
+
+import { acquireMsalAccessToken } from './msal-utils';
+
+export function buildGraphClient(
+  getMsalInstance: () => { msalInstance: Parameters<typeof acquireMsalAccessToken>[0] },
+  logger: ILogger
+): graph.Client {
+  {
+    const graphRequestAccessTokenInterceptor = async (ctx: http.RequestContext) => {
+      const { msalInstance } = getMsalInstance();
+
+      // The developer should already have made sure that the user has consented to the scope
+      // needed for the graph API they're calling, so requesting '.default' should be sufficient.
+      const accessToken = await acquireMsalAccessToken(
+        msalInstance,
+        { scopes: ['.default'] },
+        logger
+      );
+
+      ctx.config.headers.set('Authorization', `Bearer ${accessToken}`);
+      return ctx.config;
+    };
+
+    return new graph.Client(
+      new http.Client({
+        interceptors: [{ request: graphRequestAccessTokenInterceptor }],
+      })
+    );
+  }
+}

--- a/packages/client/turbo.json
+++ b/packages/client/turbo.json
@@ -5,7 +5,11 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**"],
       "cache": false,
-      "dependsOn": ["@microsoft/teams.api#build", "@microsoft/teams.common#build"]
+      "dependsOn": [
+        "@microsoft/teams.api#build",
+        "@microsoft/teams.common#build",
+        "@microsoft/teams.graph#build"
+      ]
     }
   }
 }


### PR DESCRIPTION
This change builds & exposes a graph.client from the client App object. A request interceptor is added to the HTTP client used to request and attach a MSAL token to the request.

Different graph APIs require different scope consent, and to help the developer ensure that consent is in place, it also adds
 - an App option to prewarm consent for necessary scopes. The developer can provide a specific set of scopes, disable prewarming if they wish, or just rely on the default behavior to request consent for the .default graph scope
 - a method to test if a set of scopes are already consented to
 - a method to request consent for a set of scopes, if consent has not already been given

How tested:
 - Unit tests on all behavior
 - Built the cli, apps and client packages and scaffolded a new app with npx "file:.\packages\cli\microsoft-teams.cli-0.2.12.tgz" new graphTest -t tab --ttk embed; ran the app with TTK to make sure the app builds and launches, and that the app requests consent for the default scope when opening the tab
 - Tried out disabling prewarming and verified that I was prompted for .default when making a graph call
 - Prewarmed specific scopes and verified results
 - Verified that hasConsentForScopes() returns expected results whether or not consent is given
 - Verified that ensureConsentForScopes() prompts for consent if needed; returns false if the user cancels the prompt; and does not prompt when consent is already given
 - Verified that `await app.graph.me.presence.get()` returns my presence when I've given the required consent
 - Verified that logging is captured when we fail to get a token, when the graph call fails (e.g. for lack of consent), when consent is cancelled etc.