### PR TITLE
[ChatPrompt] Add plugin hooks for before and after function calls

### DIFF
--- a/packages/ai/src/prompts/chat.spec.ts
+++ b/packages/ai/src/prompts/chat.spec.ts
@@ -218,6 +218,144 @@ describe('ChatPrompt', () => {
       expect(mockAfterSend2).toHaveBeenCalledWith({ content: 'mock response1', role: 'model' });
       expect(response.content).toBe('mock response12');
     });
+
+    it('should call onBeforeFunctionCall hook when calling a function', async () => {
+      const mockBeforeFunctionCall = jest.fn();
+      const pluginWithBeforeFunctionCall: ChatPromptPlugin<'test', TestPluginArgs> = {
+        ...mockPlugin,
+        onBeforeFunctionCall: mockBeforeFunctionCall,
+      };
+      const prompt = new ChatPrompt(
+        {
+          name: 'test-prompt',
+          model: mockChatModel,
+        },
+        [pluginWithBeforeFunctionCall] as const
+      );
+
+      const handler = jest.fn().mockResolvedValue('function result');
+      const args = { param: 'test' };
+      prompt.function('testFn', 'Test function', handler);
+      await prompt.call('testFn', args);
+
+      expect(mockBeforeFunctionCall).toHaveBeenCalledWith('testFn', args);
+    });
+
+    it('should call onAfterFunctionCall hook with function result', async () => {
+      const mockAfterFunctionCall = jest.fn((_name, _args, result) => result);
+      const pluginWithAfterFunctionCall: ChatPromptPlugin<'test', TestPluginArgs> = {
+        ...mockPlugin,
+        onAfterFunctionCall: mockAfterFunctionCall,
+      };
+      const prompt = new ChatPrompt(
+        {
+          name: 'test-prompt',
+          model: mockChatModel,
+        },
+        [pluginWithAfterFunctionCall] as const
+      );
+
+      const expectedResult = 'function result';
+      const handler = jest.fn().mockResolvedValue(expectedResult);
+      const args = { param: 'test' };
+      prompt.function('testFn', 'Test function', handler);
+      await prompt.call('testFn', args);
+
+      expect(mockAfterFunctionCall).toHaveBeenCalledWith('testFn', args, expectedResult);
+    });
+
+    it('should allow onAfterFunctionCall to modify the result', async () => {
+      const modifiedResult = 'modified result';
+      const mockAfterFunctionCall = jest.fn().mockReturnValue(modifiedResult);
+      const pluginWithAfterFunctionCall: ChatPromptPlugin<'test', TestPluginArgs> = {
+        ...mockPlugin,
+        onAfterFunctionCall: mockAfterFunctionCall,
+      };
+      const prompt = new ChatPrompt(
+        {
+          name: 'test-prompt',
+          model: mockChatModel,
+        },
+        [pluginWithAfterFunctionCall] as const
+      );
+
+      const handler = jest.fn().mockResolvedValue('original result');
+      prompt.function('testFn', 'Test function', handler);
+      const result = await prompt.call('testFn', { param: 'test' });
+
+      expect(result).toBe(modifiedResult);
+    });
+
+    it('should chain multiple plugins function call hooks in order', async () => {
+      const mockBeforeFunctionCall1 = jest.fn();
+      const mockBeforeFunctionCall2 = jest.fn();
+      const mockAfterFunctionCall1 = jest.fn((_name, _args, result) => `${result}1`);
+      const mockAfterFunctionCall2 = jest.fn((_name, _args, result) => `${result}2`);
+
+      const plugin1: ChatPromptPlugin<'test1', TestPluginArgs> = {
+        name: 'test1',
+        onBeforeFunctionCall: mockBeforeFunctionCall1,
+        onAfterFunctionCall: mockAfterFunctionCall1,
+      };
+      const plugin2: ChatPromptPlugin<'test2', TestPluginArgs> = {
+        name: 'test2',
+        onBeforeFunctionCall: mockBeforeFunctionCall2,
+        onAfterFunctionCall: mockAfterFunctionCall2,
+      };
+
+      const prompt = new ChatPrompt(
+        {
+          name: 'test-prompt',
+          model: mockChatModel,
+        },
+        [plugin1, plugin2] as const
+      );
+
+      const handler = jest.fn().mockResolvedValue('result');
+      const args = { param: 'test' };
+      prompt.function('testFn', 'Test function', handler);
+      const result = await prompt.call('testFn', args);
+
+      // Verify hooks were called in order
+      expect(mockBeforeFunctionCall1).toHaveBeenCalledWith('testFn', args);
+      expect(mockBeforeFunctionCall2).toHaveBeenCalledWith('testFn', args);
+      expect(mockAfterFunctionCall1).toHaveBeenCalledWith('testFn', args, 'result');
+      expect(mockAfterFunctionCall2).toHaveBeenCalledWith('testFn', args, 'result1');
+      expect(result).toBe('result12');
+    });
+
+    it('should support async function call hooks', async () => {
+      const mockBeforeFunctionCall = jest.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+      const mockAfterFunctionCall = jest.fn().mockImplementation(async (_name, _args, result) => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return `${result} async`;
+      });
+
+      const pluginWithAsyncHooks: ChatPromptPlugin<'test', TestPluginArgs> = {
+        ...mockPlugin,
+        onBeforeFunctionCall: mockBeforeFunctionCall,
+        onAfterFunctionCall: mockAfterFunctionCall,
+      };
+
+      const prompt = new ChatPrompt(
+        {
+          name: 'test-prompt',
+          model: mockChatModel,
+        },
+        [pluginWithAsyncHooks] as const
+      );
+
+      const handler = jest.fn().mockResolvedValue('result');
+      const args = { param: 'test' };
+      prompt.function('testFn', 'Test function', handler);
+      const result = await prompt.call('testFn', args);
+
+      expect(mockBeforeFunctionCall).toHaveBeenCalledWith('testFn', args);
+      expect(mockAfterFunctionCall).toHaveBeenCalledWith('testFn', args, 'result');
+      expect(result).toBe('result async');
+    });
   });
 
   describe('send', () => {

--- a/packages/ai/src/prompts/chat.spec.ts
+++ b/packages/ai/src/prompts/chat.spec.ts
@@ -282,7 +282,7 @@ describe('ChatPrompt', () => {
         { role: 'user', content: 'Hello' },
         expect.objectContaining({
           functions: {
-            customFn: customFunction,
+            customFn: expect.anything(),
             testFunction: expect.objectContaining({
               name: 'testFunction',
               description: 'A test function',

--- a/packages/ai/src/prompts/chat.ts
+++ b/packages/ai/src/prompts/chat.ts
@@ -276,7 +276,26 @@ export class ChatPrompt<
       throw new Error(`function "${name}" not found`);
     }
 
-    return await fn.handler(args || {});
+    const processedArgs = args || {};
+
+    // Execute beforeFunctionCall hooks
+    for (const plugin of this.plugins) {
+      if (plugin.onBeforeFunctionCall) {
+        await plugin.onBeforeFunctionCall(name, processedArgs);
+      }
+    }
+
+    // Call the function
+    let result = await fn.handler(processedArgs);
+
+    // Execute afterFunctionCall hooks
+    for (const plugin of this.plugins) {
+      if (plugin.onAfterFunctionCall) {
+        result = await plugin.onAfterFunctionCall(name, processedArgs, result);
+      }
+    }
+
+    return result;
   }
 
   async send(input: string | ContentPart[], options: ChatPromptSendOptions<TOptions> = {}) {
@@ -318,7 +337,31 @@ export class ChatPrompt<
 
     const fnMap = functions.reduce(
       (acc, fn) => {
-        acc[fn.name] = fn;
+        acc[fn.name] = {
+          ...fn,
+          handler: async (args: any) => {
+            const processedArgs = args || {};
+
+            // Execute beforeFunctionCall hooks
+            for (const plugin of this.plugins) {
+              if (plugin.onBeforeFunctionCall) {
+                await plugin.onBeforeFunctionCall(fn.name, processedArgs);
+              }
+            }
+
+            // Call the function
+            let result = await fn.handler(processedArgs);
+
+            // Execute afterFunctionCall hooks
+            for (const plugin of this.plugins) {
+              if (plugin.onAfterFunctionCall) {
+                result = await plugin.onAfterFunctionCall(fn.name, processedArgs, result);
+              }
+            }
+
+            return result;
+          },
+        };
         return acc;
       },
       {} as Record<string, Function>

--- a/packages/ai/src/prompts/chat.ts
+++ b/packages/ai/src/prompts/chat.ts
@@ -206,10 +206,10 @@ export class ChatPrompt<
     this._plugins = plugins || ([] as unknown as TChatPromptPlugins);
   }
 
-  use(prompt: ChatPrompt): this;
-  use(name: string, prompt: ChatPrompt): this;
+  use(prompt: IChatPrompt): this;
+  use(name: string, prompt: IChatPrompt): this;
   use(...args: any[]) {
-    const prompt: ChatPrompt = args.length === 1 ? args[0] : args[1];
+    const prompt: IChatPrompt = args.length === 1 ? args[0] : args[1];
     const name: string = args.length === 1 ? prompt.name : args[0];
     this._functions[name] = {
       name,
@@ -271,31 +271,10 @@ export class ChatPrompt<
 
   async call<A extends { [key: string]: any }, R = any>(name: string, args?: A): Promise<R> {
     const fn = this._functions[name];
-
     if (!fn) {
       throw new Error(`function "${name}" not found`);
     }
-
-    const processedArgs = args || {};
-
-    // Execute beforeFunctionCall hooks
-    for (const plugin of this.plugins) {
-      if (plugin.onBeforeFunctionCall) {
-        await plugin.onBeforeFunctionCall(name, processedArgs);
-      }
-    }
-
-    // Call the function
-    let result = await fn.handler(processedArgs);
-
-    // Execute afterFunctionCall hooks
-    for (const plugin of this.plugins) {
-      if (plugin.onAfterFunctionCall) {
-        result = await plugin.onAfterFunctionCall(name, processedArgs, result);
-      }
-    }
-
-    return result;
+    return this.executeFunction(name, fn, args);
   }
 
   async send(input: string | ContentPart[], options: ChatPromptSendOptions<TOptions> = {}) {
@@ -339,28 +318,7 @@ export class ChatPrompt<
       (acc, fn) => {
         acc[fn.name] = {
           ...fn,
-          handler: async (args: any) => {
-            const processedArgs = args || {};
-
-            // Execute beforeFunctionCall hooks
-            for (const plugin of this.plugins) {
-              if (plugin.onBeforeFunctionCall) {
-                await plugin.onBeforeFunctionCall(fn.name, processedArgs);
-              }
-            }
-
-            // Call the function
-            let result = await fn.handler(processedArgs);
-
-            // Execute afterFunctionCall hooks
-            for (const plugin of this.plugins) {
-              if (plugin.onAfterFunctionCall) {
-                result = await plugin.onAfterFunctionCall(fn.name, processedArgs, result);
-              }
-            }
-
-            return result;
-          },
+          handler: (args: any) => this.executeFunction(fn.name, fn, args),
         };
         return acc;
       },
@@ -402,5 +360,32 @@ export class ChatPrompt<
     }
 
     return output;
+  }
+
+  protected async executeFunction<R = any>(
+    name: string,
+    fn: Function,
+    args?: Record<string, any>
+  ): Promise<R> {
+    const processedArgs = args || {};
+
+    // Execute beforeFunctionCall hooks
+    for (const plugin of this.plugins) {
+      if (plugin.onBeforeFunctionCall) {
+        await plugin.onBeforeFunctionCall(name, processedArgs);
+      }
+    }
+
+    // Call the function
+    let result = await fn.handler(processedArgs);
+
+    // Execute afterFunctionCall hooks
+    for (const plugin of this.plugins) {
+      if (plugin.onAfterFunctionCall) {
+        result = await plugin.onAfterFunctionCall(name, processedArgs, result);
+      }
+    }
+
+    return result;
   }
 }

--- a/packages/ai/src/prompts/plugin.ts
+++ b/packages/ai/src/prompts/plugin.ts
@@ -31,4 +31,24 @@ export interface IAiPlugin<
   onAfterSend?: (
     response: Awaited<TAfterSendResponse>
   ) => Awaited<TAfterSendResponse> | Promise<Awaited<TAfterSendResponse>>;
+
+  /**
+   * Called before a function is executed, allowing modification of the arguments
+   * @param functionName the name of the function being called
+   * @param args the arguments being passed to the function
+   */
+  onBeforeFunctionCall?: (functionName: string, args: Record<string, any>) => void | Promise<void>;
+
+  /**
+   * Called after a function is executed, allowing modification of the result
+   * @param functionName the name of the function that was called
+   * @param args the arguments that were passed to the function
+   * @param result the result returned by the function
+   * @returns the modified result
+   */
+  onAfterFunctionCall?: (
+    functionName: string,
+    args: Record<string, any>,
+    result: any
+  ) => any | Promise<any>;
 }


### PR DESCRIPTION
Adding beforeFunction hook, and afterFunction hook. 
beforeFunction - It allows the function log or modify the arguments before its sent to actual handler. 
afterFunction - Once the function results, then it allows you to log or modify the result after the actual handler returns.