### PR TITLE
[RFC][WIP] Differentiate send and reply

### DIFF
--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -178,13 +178,19 @@ export class ActivityContext<T extends Activity = Activity> implements IActivity
   }
 
   async send(activity: ActivityLike) {
-    return await this._plugin.send(toActivityParams(activity), this.ref);
+    const ref = {
+      ...this.ref,
+      conversation: {
+        ...this.ref.conversation,
+        id: this.stripOutThreadId(this.ref.conversation.id),
+      },
+    };
+    return await this._plugin.send(toActivityParams(activity), ref);
   }
 
   async reply(activity: ActivityLike) {
-    activity = toActivityParams(activity);
-    activity.replyToId = this.activity.id;
-    return this.send(activity);
+    console.log('replying to activity', toActivityParams(activity), this.ref);
+    return await this._plugin.send(toActivityParams(activity), this.ref);
   }
 
   async signin(options?: Partial<SignInOptions>) {
@@ -284,5 +290,13 @@ export class ActivityContext<T extends Activity = Activity> implements IActivity
       signin: this.signin.bind(this),
       signout: this.signout.bind(this),
     };
+  }
+
+  private stripOutThreadId(conversationId: string): string {
+    const parts = conversationId.split(';');
+    if (parts.length > 1) {
+      return parts[0];
+    }
+    return conversationId;
   }
 }


### PR DESCRIPTION
This is an initial crack at differentiating `send` and `reply`. 

Currently, `send` sends the activity to the same `conversation` as the one that came in. No changes.
`reply` adds a `replyToId` to the activity before sending it.

Problems:
1. `send` - if the conversation id contains the message id (eg. `19:ff4030b352c34ba4aecb654aa25c6a27@thread.tacv2;messageid=1746121818956`), the backend will treat it as a reply and add it to the thread automatically.
2. `reply` - currently doesn't differ at all from `send`. I think the expected behavior was for reply to do a "quote-reply" like we do. But that's actually not possible.

In this PR, I am proposing two changes:
1. Send should send the message to the main channel / group chat.
2. Reply should include the reply in the thread in question - in 1:1 chat, this will be no different than `send` b/c it doesn't support threads.

```ts
app.on('message', async ({ send, reply, activity }) => {
   await send({ type: 'typing' });
   await send(`You said ${activity.text}`); // Sends to the main channel
   await reply(`You said ${activity.text}`); // Sends as a reply to the thread
}); 
```

Remaining work:
[x] - Test if this works
[ ] - Validate from backend team if the logic to get original channel is fine
[ ] - The plugin hooks only work for send, not replies. We should fix that right?
[ ] - This is kind of a breaking change, so we should get this in earlier, and fix all the docs to use `reply`.