### PR TITLE
Stop using pokemon mcp, and use github mcp

### DIFF
--- a/tests/mcpclient/src/index.ts
+++ b/tests/mcpclient/src/index.ts
@@ -30,7 +30,7 @@ const prompt = new ChatPrompt(
   // Alternatively, you can use a different server hosted somewhere else
   // Here we are using the mcp server hosted on an Azure Function
   .usePlugin("mcpClient", {
-    url: "https://pokemonmcp.azurewebsites.net/runtime/webhooks/mcp/sse",
+    url: "https://githubmcpnew.azurewebsites.net/runtime/webhooks/mcp/sse",
     params: {
       headers: {
         // If your server requires authentication, you can pass in Bearer or other


### PR DESCRIPTION
We were told to use github mcp instead...

![MCP](https://github.com/user-attachments/assets/1a389339-2cc3-4a1b-989c-eec66341e2b1)

Here is my azure function github mcp server - https://github.com/heyitsaamir/GithubMCPAzureFunction