### PR TITLE
Add support for injecting custom http.Server into HttpPlugin

### DIFF
--- a/packages/apps/src/plugins/http/plugin.ts
+++ b/packages/apps/src/plugins/http/plugin.ts
@@ -116,15 +116,14 @@ export class HttpPlugin implements ISender {
     });
 
     return await new Promise<void>((resolve, reject) => {
-      this._server = this._server.listen(port, async () => {        
-        this.logger.info(`listening on port ${port} 🚀`);
-        resolve();
-      });
-
       this._server.on('error', (err) => {
         this.$onError({ error: err });
         reject(err);
-        return;
+      });
+
+      this._server.listen(port, () => {        
+        this.logger.info(`listening on port ${port} 🚀`);
+        resolve();
       });
     });
   }

--- a/packages/apps/src/plugins/http/plugin.ts
+++ b/packages/apps/src/plugins/http/plugin.ts
@@ -82,9 +82,10 @@ export class HttpPlugin implements ISender {
   protected express: express.Application;
   protected pending: Record<string, express.Response> = {};
 
-  constructor() {
+  constructor(server?: http.Server) {
     this.express = express();
-    this._server = http.createServer(this.express);
+    this._server = server || http.createServer();
+    this._server.on('request', this.express);
     this.get = this.express.get.bind(this.express);
     this.post = this.express.post.bind(this.express);
     this.patch = this.express.patch.bind(this.express);
@@ -115,15 +116,15 @@ export class HttpPlugin implements ISender {
     });
 
     return await new Promise<void>((resolve, reject) => {
-      this._server = this.express.listen(port, async (err) => {
-        if (err) {
-          this.$onError({ error: err });
-          reject(err);
-          return;
-        }
-
+      this._server = this._server.listen(port, async () => {        
         this.logger.info(`listening on port ${port} 🚀`);
         resolve();
+      });
+
+      this._server.on('error', (err) => {
+        this.$onError({ error: err });
+        reject(err);
+        return;
       });
     });
   }


### PR DESCRIPTION
add optional `server?: http.Server` to the HttpPlugin constructor.

Notes:
- `http.CreateServer(this.express)` takes `this.express` and adds it as a 'request' listener to the underlying server that's being created. [src](https://nodejs.org/api/http.html#httpcreateserveroptions-requestlistener)
- `express.listen` is equivalent to `server.listen` except it creates a brand new server object (http.Server). [src](https://expressjs.com/en/5x/api.html#app.listen)