### PR TITLE
Revert "For TSUP, we also type-check with no-emit"

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -2,7 +2,6 @@ name: Template Sync Verification
 on:
   workflow_dispatch:
   pull_request:
-    types: [edited, synchronize]
     paths:
       - "packages/cli/templates/typescript/**"
       - "tests/*/**"
@@ -43,41 +42,39 @@ jobs:
             if [[ $file == packages/cli/templates/typescript/* ]]; then
               dir=$(echo "$file" | sed -n 's|packages/cli/templates/typescript/\([^/]*\)/.*|\1|p')
               if [ ! -z "$dir" ]; then
+                # Append the file to the directory's list
                 template_dirs["$dir"]="${template_dirs["$dir"]}${file}"$'\n'
               fi
             elif [[ $file == tests/* ]]; then
               dir=$(echo "$file" | sed -n 's|tests/\([^/]*\)/.*|\1|p')
               if [ ! -z "$dir" ]; then
+                # Append the file to the directory's list
                 test_dirs["$dir"]="${test_dirs["$dir"]}${file}"$'\n'
               fi
             fi
           done
 
-          # Check template directories without matching test changes, but only if both directories exist
+          # Check template directories without matching test changes
           for dir in "${!template_dirs[@]}"; do
-            if [[ -d "tests/$dir" && -d "packages/cli/templates/typescript/$dir" ]]; then
-              if [[ -z "${test_dirs[$dir]}" ]]; then
-                echo "::error::Changes detected in template directory but no corresponding test changes found (use skip-test-verification in PR description to skip this check)"
-                echo "Template directory: packages/cli/templates/typescript/$dir"
-                echo "Changed files:"
-                echo "${template_dirs[$dir]}"
-                echo "Expected changes in: tests/$dir"
-                status=1
-              fi
+            if [[ -z "${test_dirs[$dir]}" ]]; then
+              echo "::error::Changes detected in template directory but no corresponding test changes found (use skip-test-verification in PR description to skip this check)"
+              echo "Template directory: packages/cli/templates/typescript/$dir"
+              echo "Changed files:"
+              echo "${template_dirs[$dir]}"
+              echo "Expected changes in: tests/$dir"
+              status=1
             fi
           done
 
-          # Check test directories without matching template changes, but only if both directories exist
+          # Check test directories without matching template changes
           for dir in "${!test_dirs[@]}"; do
-            if [[ -d "tests/$dir" && -d "packages/cli/templates/typescript/$dir" ]]; then
-              if [[ -z "${template_dirs[$dir]}" ]]; then
-                echo "::error::Changes detected in test directory but no corresponding template changes found (use skip-test-verification in PR description to skip this check)"
-                echo "Test directory: tests/$dir"
-                echo "Changed files:"
-                echo "${test_dirs[$dir]}"
-                echo "Expected changes in: packages/cli/templates/typescript/$dir"
-                status=1
-              fi
+            if [[ -z "${template_dirs[$dir]}" ]]; then
+              echo "::error::Changes detected in test directory but no corresponding template changes found (use skip-test-verification in PR description to skip this check)"
+              echo "Test directory: tests/$dir"
+              echo "Changed files:"
+              echo "${test_dirs[$dir]}"
+              echo "Expected changes in: packages/cli/templates/typescript/$dir"
+              status=1
             fi
           done
 

--- a/external/mcpclient/package.json
+++ b/external/mcpclient/package.json
@@ -25,7 +25,7 @@
     "clean": "npx rimraf ./dist",
     "lint": "npx eslint",
     "lint:fix": "npx eslint --fix",
-    "build": "npx tsc",
+    "build": "npx tsup",
     "test": "npx jest"
   },
   "peerDependencies": {
@@ -40,6 +40,7 @@
     "jest": "^29.7.0",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.2.5",
+    "tsup": "^8.4.0",
     "typescript": "^5.4.5"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,6 +198,7 @@
         "jest": "^29.7.0",
         "rimraf": "^6.0.1",
         "ts-jest": "^29.2.5",
+        "tsup": "^8.4.0",
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
@@ -21832,6 +21833,7 @@
         "jest": "^29.7.0",
         "rimraf": "^6.0.1",
         "ts-jest": "^29.2.5",
+        "tsup": "^8.4.0",
         "typescript": "^5.4.5"
       },
       "engines": {
@@ -23426,6 +23428,7 @@
         "jest": "^29.7.0",
         "rimraf": "^6.0.1",
         "ts-jest": "^29.2.5",
+        "tsup": "^8.4.0",
         "typescript": "^5.4.5"
       },
       "engines": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -30,7 +30,7 @@
     "clean": "npx rimraf ./dist",
     "lint": "npx eslint",
     "lint:fix": "npx eslint --fix",
-    "build": "npx tsc",
+    "build": "npx tsup",
     "test": "npx jest"
   },
   "peerDependencies": {
@@ -43,6 +43,7 @@
     "jest": "^29.7.0",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.2.5",
+    "tsup": "^8.4.0",
     "typescript": "^5.4.5"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,7 +31,7 @@
     "clean": "npx rimraf ./dist",
     "lint": "npx eslint",
     "lint:fix": "npx eslint --fix",
-    "build": "npx tsc --noEmit && npx tsup",
+    "build": "npx tsup",
     "test": "npx jest"
   },
   "dependencies": {

--- a/packages/cards/package.json
+++ b/packages/cards/package.json
@@ -31,7 +31,7 @@
     "clean": "npx rimraf ./dist",
     "lint": "npx eslint",
     "lint:fix": "npx eslint --fix",
-    "build": "npx tsc --noEmit && npx tsup",
+    "build": "npx tsup",
     "test": "npx jest"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,7 @@
     "clean": "npx rimraf ./dist",
     "lint": "npx eslint",
     "lint:fix": "npx eslint --fix",
-    "build": "npx tsc --noEmit && npx tsup",
+    "build": "npx tsup",
     "test": "npx jest"
   },
   "dependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,7 +33,7 @@
     "clean": "npx rimraf ./dist",
     "lint": "npx eslint",
     "lint:fix": "npx eslint --fix",
-    "build": "npx tsc --noEmit && npx tsup",
+    "build": "npx tsup",
     "test": "npx jest"
   },
   "dependencies": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -73,7 +73,7 @@
     "clean": "npx rimraf ./dist",
     "lint": "npx eslint",
     "lint:fix": "npx eslint --fix",
-    "build": "npx tsc --noEmit && npx tsup",
+    "build": "npx tsup",
     "test": "npx jest"
   },
   "dependencies": {

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -31,7 +31,7 @@
     "clean": "npx rimraf ./dist",
     "lint": "npx eslint",
     "lint:fix": "npx eslint --fix",
-    "build": "npx tsc",
+    "build": "npx tsup",
     "test": "npx jest"
   },
   "dependencies": {
@@ -49,6 +49,7 @@
     "jest": "^29.7.0",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.2.5",
+    "tsup": "^8.4.0",
     "typescript": "^5.4.5"
   }
 }

--- a/tests/botbuilder/package.json
+++ b/tests/botbuilder/package.json
@@ -13,7 +13,7 @@
     "clean": "npx rimraf ./dist",
     "lint": "npx eslint",
     "lint:fix": "npx eslint --fix",
-    "build": "npx tsc --noEmit && npx tsup",
+    "build": "npx tsup",
     "start": "node .",
     "dev": "npx nodemon -w \"./src/**\" -e ts --exec \"node -r ts-node/register -r dotenv/config ./src/index.ts\""
   },


### PR DESCRIPTION
This is breaking some tests. Investigating why. Will add this back once I figure it out

Reverts microsoft/teams.ts#233