### PR TITLE
Raw messages as part of the ChatMessageOutput

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16864,9 +16864,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.96.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.96.2.tgz",
-      "integrity": "sha512-R2XnxvMsizkROr7BV3uNp1q/3skwPZ7fmPjO1bXLnfB4Tu5xKxrT1EVwzjhxn0MZKBKAvOaGWS63jTMN6KrIXA==",
+      "version": "4.102.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.102.0.tgz",
+      "integrity": "sha512-CWk15CMhPSHNZnjz+6rwVYV551xaC8CwOd7/zxImrC1btEo37dX/Ii5tBKWfqqxqyzpJ6p3Y4bICzzKhW03WhQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -23519,11 +23519,11 @@
       "version": "0.0.1-preview.3",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/teams.ai": "2.0.0-preview.3",
-        "@microsoft/teams.apps": "2.0.0-preview.3",
-        "@microsoft/teams.cards": "2.0.0-preview.3",
-        "@microsoft/teams.dev": "2.0.0-preview.3",
-        "@microsoft/teams.openai": "2.0.0-preview.3",
+        "@microsoft/teams.ai": "*",
+        "@microsoft/teams.apps": "*",
+        "@microsoft/teams.cards": "*",
+        "@microsoft/teams.dev": "*",
+        "@microsoft/teams.openai": "*",
         "fuse.js": "^7.1.0"
       },
       "devDependencies": {

--- a/packages/ai/src/message.ts
+++ b/packages/ai/src/message.ts
@@ -8,12 +8,13 @@ export type UserMessage = {
   content: string | ContentPart[];
 };
 
-export type ModelMessage = {
+export type ModelMessage<TRaw extends Record<string, any> = Record<string, any>> = {
   role: 'model';
   audio?: MessageAudio;
   content?: string;
   context?: MessageContext;
   function_calls?: FunctionCall[];
+  raw?: TRaw;
 };
 
 export type SystemMessage = {

--- a/packages/ai/src/models/chat.ts
+++ b/packages/ai/src/models/chat.ts
@@ -36,11 +36,11 @@ export type ChatSendOptions<TOptions = Record<string, any>> = {
  * a conversational model for sending and receiving
  * messages
  */
-export interface IChatModel<TOptions = Record<string, any>> {
+export interface IChatModel<TOptions = Record<string, any>, TRawReturnType extends Record<string, any> = Record<string, any>> {
   /**
    * send a message to the model
    * @param input the message to send
    * @param options the send options
    */
-  send(input: Message, options?: ChatSendOptions<TOptions>): Promise<ModelMessage>;
+  send(input: Message, options?: ChatSendOptions<TOptions>): Promise<ModelMessage<TRawReturnType>>;
 }

--- a/packages/ai/src/prompts/chat-types.ts
+++ b/packages/ai/src/prompts/chat-types.ts
@@ -1,0 +1,162 @@
+import { ILogger } from '@microsoft/teams.common';
+
+import { Function, FunctionHandler } from '../function';
+import { IMemory } from '../memory';
+import { ContentPart, Message, ModelMessage } from '../message';
+import { IChatModel, TextChunkHandler } from '../models';
+import { Schema } from '../schema';
+import { ITemplate } from '../template';
+import { PromiseOrValue } from '../utils/types';
+
+import { IAiPlugin } from './plugin';
+
+export type ChatPromptOptions<TOptions extends Record<string, any> = Record<string, any>, TRawReturnType extends Record<string, any> = Record<string, any>> = {
+    /**
+     * the name of the prompt
+     */
+    readonly name?: string;
+
+    /**
+     * the description of the prompt
+     */
+    readonly description?: string;
+
+    /**
+     * the model to send messages to
+     */
+    readonly model: IChatModel<TOptions, TRawReturnType>;
+
+    /**
+     * the defining characteristics/objective
+     * of the prompt. This is commonly used to provide a system prompt.
+     * If you supply the system prompt as part of the messages,
+     * you do not need to supply this option.
+     */
+    readonly instructions?: string | string[] | ITemplate;
+
+    /**
+     * the `role` of the initial message
+     */
+    readonly role?: 'system' | 'user';
+
+    /**
+     * the conversation history
+     */
+    readonly messages?: Message[] | IMemory;
+
+    /**
+     * Logger instance to use for logging
+     * If not provided, a ConsoleLogger will be used
+     */
+    logger?: ILogger;
+};
+
+export type ChatPromptSendOptions<TOptions extends Record<string, any> = Record<string, any>> = {
+    /**
+     * the conversation history
+     */
+    readonly messages?: Message[] | IMemory;
+
+    /**
+     * the models request options
+     */
+    readonly request?: TOptions;
+
+    /**
+     * the callback to be called for each
+     * stream chunk
+     */
+    readonly onChunk?: TextChunkHandler;
+
+};
+
+/**
+ * a prompt that can interface with a
+ * chat model that provides utility like
+ * streaming and function calling
+ */
+export interface IChatPrompt<
+    TOptions extends Record<string, any> = Record<string, any>,
+    TRawReturnType extends Record<string, any> = Record<string, any>,
+    TChatPromptPlugins extends readonly ChatPromptPlugin<string, any>[] = []
+> {
+    /**
+     * the prompt name
+     */
+    readonly name: string;
+
+    /**
+     * the prompt description
+     */
+    readonly description: string;
+
+    /**
+     * the chat history
+     */
+    readonly messages: IMemory;
+
+    /**
+     * the registered functions
+     */
+    readonly functions: Array<Function>;
+
+    /**
+     * the chat model
+     */
+    plugins: TChatPromptPlugins;
+    /**
+     * add another chat prompt as a
+     */
+    use(prompt: IChatPrompt): this;
+    use(name: string, prompt: IChatPrompt): this;
+
+    /**
+     * add a function that can be called
+     * by the model
+     */
+    function(name: string, description: string, handler: FunctionHandler): this;
+    function(name: string, description: string, parameters: Schema, handler: FunctionHandler): this;
+
+    usePlugin<TPluginName extends TChatPromptPlugins[number]['name']>(
+        name: TPluginName,
+        args: Extract<TChatPromptPlugins[number], { name: TPluginName }>['onUsePlugin'] extends
+            | ((args: infer U) => void)
+            | undefined
+            ? U
+            : never
+    ): this;
+
+    /**
+     * call a function
+     */
+    call<A extends Record<string, any>, R = any>(name: string, args?: A): Promise<R>;
+
+    /**
+     * send a message to the model and get a response
+     */
+    send(
+        input: string | ContentPart[],
+        options?: ChatPromptSendOptions<TOptions>
+    ): Promise<ModelMessage<TRawReturnType>>;
+}
+
+export type ChatPromptPlugin<TPluginName extends string, TPluginUseArgs extends {}> = IAiPlugin<
+    TPluginName,
+    TPluginUseArgs,
+    Parameters<IChatPrompt['send']>[0],
+    ReturnType<IChatPrompt['send']>
+> & {
+    /**
+     * Optionally passed in to modify the functions array that
+     * is passed to the model
+     * @param functions
+     * @returns Functions
+     */
+    onBuildFunctions?: (functions: Function[]) => PromiseOrValue<Function[]>;
+    /**
+     * Optionally passed in to modify the system prompt before it is sent to the model.
+     * @param systemPrompt The system prompt string (or undefined)
+     * @returns The modified system prompt string (or undefined)
+     */
+    onBuildPrompt?: (systemPrompt: string | undefined) => PromiseOrValue<string | undefined>;
+};

--- a/packages/ai/src/prompts/chat.spec.ts
+++ b/packages/ai/src/prompts/chat.spec.ts
@@ -2,7 +2,8 @@ import { ContentPart, Message } from '../message';
 import { IChatModel } from '../models';
 import { Schema } from '../schema';
 
-import { ChatPrompt, ChatPromptPlugin } from './chat';
+import { ChatPrompt } from './chat';
+import { ChatPromptPlugin } from './chat-types';
 
 // Mock implementations
 const mockChatModel: IChatModel<any> = {
@@ -28,7 +29,7 @@ const mockPlugin: ChatPromptPlugin<'test', TestPluginArgs> = {
 type MockPlugins = readonly [typeof mockPlugin];
 
 describe('ChatPrompt', () => {
-  let chatPrompt: ChatPrompt<any, MockPlugins>;
+  let chatPrompt: ChatPrompt<any, any, MockPlugins>;
   const mockPlugins: MockPlugins = [mockPlugin] as const;
 
   beforeEach(() => {

--- a/packages/ai/src/prompts/chat.ts
+++ b/packages/ai/src/prompts/chat.ts
@@ -3,163 +3,14 @@ import { ConsoleLogger, ILogger } from '@microsoft/teams.common';
 import { Function, FunctionHandler } from '../function';
 import { LocalMemory } from '../local-memory';
 import { IMemory } from '../memory';
-import { ContentPart, Message, ModelMessage, SystemMessage, UserMessage } from '../message';
-import { IChatModel, TextChunkHandler } from '../models';
+import { ContentPart, SystemMessage, UserMessage } from '../message';
+import { IChatModel } from '../models';
 import { Schema } from '../schema';
 import { ITemplate } from '../template';
 import { StringTemplate } from '../templates';
-import { PromiseOrValue, WithRequired } from '../utils/types';
+import { WithRequired } from '../utils/types';
 
-import { IAiPlugin } from './plugin';
-
-export type ChatPromptOptions<TOptions extends Record<string, any> = Record<string, any>> = {
-  /**
-   * the name of the prompt
-   */
-  readonly name?: string;
-
-  /**
-   * the description of the prompt
-   */
-  readonly description?: string;
-
-  /**
-   * the model to send messages to
-   */
-  readonly model: IChatModel<TOptions>;
-
-  /**
-   * the defining characteristics/objective
-   * of the prompt. This is commonly used to provide a system prompt.
-   * If you supply the system prompt as part of the messages,
-   * you do not need to supply this option.
-   */
-  readonly instructions?: string | string[] | ITemplate;
-
-  /**
-   * the `role` of the initial message
-   */
-  readonly role?: 'system' | 'user';
-
-  /**
-   * the conversation history
-   */
-  readonly messages?: Message[] | IMemory;
-
-  /**
-   * Logger instance to use for logging
-   * If not provided, a ConsoleLogger will be used
-   */
-  logger?: ILogger;
-};
-
-export type ChatPromptSendOptions<TOptions extends Record<string, any> = Record<string, any>> = {
-  /**
-   * the conversation history
-   */
-  readonly messages?: Message[] | IMemory;
-
-  /**
-   * the models request options
-   */
-  readonly request?: TOptions;
-
-  /**
-   * the callback to be called for each
-   * stream chunk
-   */
-  readonly onChunk?: TextChunkHandler;
-};
-
-/**
- * a prompt that can interface with a
- * chat model that provides utility like
- * streaming and function calling
- */
-export interface IChatPrompt<
-  TOptions extends Record<string, any> = Record<string, any>,
-  TChatPromptPlugins extends readonly ChatPromptPlugin<string, any>[] = []
-> {
-  /**
-   * the prompt name
-   */
-  readonly name: string;
-
-  /**
-   * the prompt description
-   */
-  readonly description: string;
-
-  /**
-   * the chat history
-   */
-  readonly messages: IMemory;
-
-  /**
-   * the registered functions
-   */
-  readonly functions: Array<Function>;
-
-  /**
-   * the chat model
-   */
-  plugins: TChatPromptPlugins;
-  /**
-   * add another chat prompt as a
-   */
-  use(prompt: IChatPrompt): this;
-  use(name: string, prompt: IChatPrompt): this;
-
-  /**
-   * add a function that can be called
-   * by the model
-   */
-  function(name: string, description: string, handler: FunctionHandler): this;
-  function(name: string, description: string, parameters: Schema, handler: FunctionHandler): this;
-
-  usePlugin<TPluginName extends TChatPromptPlugins[number]['name']>(
-    name: TPluginName,
-    args: Extract<TChatPromptPlugins[number], { name: TPluginName }>['onUsePlugin'] extends
-      | ((args: infer U) => void)
-      | undefined
-      ? U
-      : never
-  ): this;
-
-  /**
-   * call a function
-   */
-  call<A extends Record<string, any>, R = any>(name: string, args?: A): Promise<R>;
-
-  /**
-   * send a message to the model and get a response
-   */
-  send(
-    input: string | ContentPart[],
-    options?: ChatPromptSendOptions<TOptions>
-  ): Promise<Pick<ModelMessage, 'content'> & Omit<ModelMessage, 'content'>>;
-}
-
-export type ChatPromptPlugin<TPluginName extends string, TPluginUseArgs extends {}> = IAiPlugin<
-  TPluginName,
-  TPluginUseArgs,
-  Parameters<IChatPrompt['send']>[0],
-  ReturnType<IChatPrompt['send']>
-> & {
-  /**
-   * Optionally passed in to modify the functions array that
-   * is passed to the model
-   * @param functions
-   * @returns Functions
-   */
-  onBuildFunctions?: (functions: Function[]) => PromiseOrValue<Function[]>;
-  /**
-   * Optionally passed in to modify the system prompt before it is sent to the model.
-   * @param systemPrompt The system prompt string (or undefined)
-   * @returns The modified system prompt string (or undefined)
-   */
-  onBuildPrompt?: (systemPrompt: string | undefined) => PromiseOrValue<string | undefined>;
-};
+import { ChatPromptOptions, ChatPromptPlugin, ChatPromptSendOptions, IChatPrompt } from './chat-types';
 
 /**
  * a prompt that can interface with a
@@ -168,8 +19,9 @@ export type ChatPromptPlugin<TPluginName extends string, TPluginUseArgs extends 
  */
 export class ChatPrompt<
   TOptions extends Record<string, any> = Record<string, any>,
+  TRawReturnType extends Record<string, any> = Record<string, any>,
   TChatPromptPlugins extends readonly ChatPromptPlugin<string, any>[] = [],
-> implements IChatPrompt<TOptions, TChatPromptPlugins> {
+> implements IChatPrompt<TOptions, TRawReturnType, TChatPromptPlugins> {
   get name() {
     return this._name;
   }
@@ -197,10 +49,10 @@ export class ChatPrompt<
 
   protected readonly _role: 'system' | 'user';
   protected readonly _template: ITemplate;
-  protected readonly _model: IChatModel<TOptions>;
+  protected readonly _model: IChatModel<TOptions, TRawReturnType>;
   protected readonly _log: ILogger;
 
-  constructor(options: ChatPromptOptions<TOptions>, plugins?: TChatPromptPlugins) {
+  constructor(options: ChatPromptOptions<TOptions, TRawReturnType>, plugins?: TChatPromptPlugins) {
     this._name = options.name || 'chat';
     this._description = options.description || 'an agent you can chat with';
     this._role = options.role || 'system';
@@ -427,7 +279,9 @@ export class ChatPrompt<
     for (const plugin of this.plugins) {
       if (plugin.onAfterSend) {
         this._log.debug(`Running onAfterSend for plugin "${plugin.name}"`);
-        output = await plugin.onAfterSend(output);
+        // Casting to the same type as the output, this is technically unsafe. We should be doing some validation with 
+        // the output of the plugin to ensure that it's adhering to the expected type.
+        output = await plugin.onAfterSend(output) as typeof output;
       }
     }
 

--- a/packages/ai/src/prompts/index.ts
+++ b/packages/ai/src/prompts/index.ts
@@ -1,7 +1,9 @@
 import { IAudioPrompt } from './audio';
-import { IChatPrompt } from './chat';
+import { IChatPrompt } from './chat-types';
 
 export type Prompt = IChatPrompt | IAudioPrompt;
 
-export * from './chat';
 export * from './audio';
+export * from './chat';
+export * from './chat-types';
+

--- a/tests/a2a/turbo.json
+++ b/tests/a2a/turbo.json
@@ -12,6 +12,7 @@
         "@microsoft/teams.common#build",
         "@microsoft/teams.dev#build",
         "@microsoft/teams.graph#build",
+        "@microsoft/teams.ai#build",
         "@microsoft/teams.openai#build",
         "@microsoft/teams.a2a#build"
       ]


### PR DESCRIPTION
This PR adds "raw" payloads as part of the final MessageOutput. Users may want this for something (like structured output).

skip-test-verification - I fixed the turbo.json for one of the tests.




#### PR Dependency Tree


* **PR #240** 👈
  * **PR #241**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)