### PR TITLE
Add error logging for mcp client if function calling fails

### DIFF
--- a/external/mcpclient/src/mcp-client-plugin.ts
+++ b/external/mcpclient/src/mcp-client-plugin.ts
@@ -122,6 +122,8 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
             });
 
             return result.content;
+          } catch (e) {
+            this.log.error(`Error calling tool ${availableTool.name} on ${url}:`, e);
           } finally {
             await client.close();
           }


### PR DESCRIPTION
Without this, if the MCP client failed, we were not logging verbose error messages.



#### PR Dependency Tree


* **PR #242** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)