### PR TITLE
[apps] fix streaming retry logic

### DIFF
--- a/packages/apps/src/plugins/http/plugin.ts
+++ b/packages/apps/src/plugins/http/plugin.ts
@@ -121,7 +121,7 @@ export class HttpPlugin implements ISender {
         reject(err);
       });
 
-      this._server.listen(port, () => {        
+      this._server.listen(port, () => {
         this.logger.info(`listening on port ${port} 🚀`);
         resolve();
       });
@@ -194,7 +194,8 @@ export class HttpPlugin implements ISender {
           token: this.botToken,
         })
       ),
-      ref
+      ref,
+      this.logger
     );
   }
 

--- a/packages/apps/src/utils/promises/retry.ts
+++ b/packages/apps/src/utils/promises/retry.ts
@@ -18,19 +18,19 @@ export type RetryOptions = {
   readonly logger?: ILogger;
 };
 
-export async function retry<T = any>(promise: () => Promise<T>, options?: RetryOptions) {
+export async function retry<T = any>(factory: () => Promise<T>, options?: RetryOptions) {
   const max = options?.max ?? 5;
   const delay = options?.delay ?? 500;
   const log = options?.logger?.child('retry');
 
   try {
-    return await promise();
+    return await factory();
   } catch (err) {
     if (max > 0) {
       log?.debug(`delaying ${delay}ms...`);
       await new Promise((resolve) => setTimeout(resolve, delay));
       log?.debug('retrying...');
-      return retry(promise, {
+      return retry(factory, {
         max: max - 1,
         delay: delay * 2,
         logger: options?.logger,

--- a/packages/apps/src/utils/promises/retry.ts
+++ b/packages/apps/src/utils/promises/retry.ts
@@ -1,3 +1,5 @@
+import { ILogger } from '@microsoft/teams.common';
+
 export type RetryOptions = {
   /**
    * the max number of retry attempts
@@ -7,23 +9,35 @@ export type RetryOptions = {
 
   /**
    * the delay in ms per retry
-   * @default 200
    */
   readonly delay?: number;
+
+  /**
+   * the logger to use
+   */
+  readonly logger?: ILogger;
 };
 
-export async function retry<T = any>(promise: Promise<T>, options?: RetryOptions) {
-  const max = options?.max || 3;
-  const delay = options?.delay || 200;
+export async function retry<T = any>(promise: () => Promise<T>, options?: RetryOptions) {
+  const max = options?.max ?? 5;
+  const delay = options?.delay ?? 500;
+  const log = options?.logger?.child('retry');
 
   try {
-    return await promise;
+    return await promise();
   } catch (err) {
     if (max > 0) {
+      log?.debug(`delaying ${delay}ms...`);
       await new Promise((resolve) => setTimeout(resolve, delay));
-      return retry(promise, { max: max - 1, delay: delay * 2 });
+      log?.debug('retrying...');
+      return retry(promise, {
+        max: max - 1,
+        delay: delay * 2,
+        logger: options?.logger,
+      });
     }
 
+    log?.error(err);
     throw err;
   }
 }


### PR DESCRIPTION
promises cannot be reused after they have rejected, this PR fixes the streaming rate limit retry logic to account for this.