### PR TITLE
Add StreamableHttp support to MCP Client

### DIFF
--- a/external/mcpclient/package.json
+++ b/external/mcpclient/package.json
@@ -29,7 +29,7 @@
     "test": "npx jest"
   },
   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@modelcontextprotocol/sdk": "^1.13.0",
     "@microsoft/teams.ai": "2.0.0-preview.5",
     "@microsoft/teams.common": "2.0.0-preview.5"
   },

--- a/external/mcpclient/src/mcp-client-plugin.ts
+++ b/external/mcpclient/src/mcp-client-plugin.ts
@@ -11,9 +11,10 @@ import {
   McpClientPluginParams,
   McpClientPluginUseParams,
   McpClientToolDetails,
+  McpClientTransportType,
   ValueOrFactory,
 } from './mcp-client-types';
-import { buildSSEClientTransport } from './mcp-transport';
+import { buildSSEClientTransport, buildStreamableHttpClientTransport } from './mcp-transport';
 
 export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientPluginUseParams> {
   readonly name = 'mcpClient';
@@ -88,6 +89,7 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
     if (args.params?.availableTools && args.params.availableTools.length > 0) {
       this._cache[args.url] = {
         ...this._cache[args.url],
+        transport: args.params?.transport,
         // If the tools are being supplied, we assume they are up to date
         lastAttemptedFetch: Date.now(),
         availableTools: args.params.availableTools,
@@ -113,7 +115,7 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
         description: availableTool.description,
         parameters: availableTool.schema || {},
         handler: async (args: any) => {
-          const [client, transport] = await this.makeMcpClient(url, params?.headers);
+          const [client, transport] = await this.makeMcpClient(url, params?.headers, params?.transport);
           try {
             await client.connect(transport);
             const result = await client.callTool({
@@ -185,11 +187,11 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
   }
 
   private async getTools(
-    params: ({ url: string } & Pick<McpClientPluginParams, 'headers' | 'skipIfUnavailable'>)[]
+    params: ({ url: string } & Pick<McpClientPluginParams, 'headers' | 'skipIfUnavailable' | 'transport'>)[]
   ): Promise<Record<string, McpClientToolDetails[] | 'unavailable'>> {
     const toolCallResult = await Promise.all(
-      params.map(async ({ url, headers, skipIfUnavailable }) => {
-        const tools = await this.fetchTools(url, headers, skipIfUnavailable);
+      params.map(async ({ url, headers, skipIfUnavailable, transport }) => {
+        const tools = await this.fetchTools(url, headers, transport, skipIfUnavailable);
         return [url, tools];
       })
     );
@@ -199,10 +201,11 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
 
   private async fetchTools(
     url: string,
-    headers?: ValueOrFactory<Record<string, string>>,
-    skipIfUnavailable?: boolean
+    headers: ValueOrFactory<Record<string, string>> | undefined,
+    transportType: McpClientTransportType | undefined,
+    skipIfUnavailable: boolean | undefined
   ): Promise<McpClientToolDetails[] | 'unavailable'> {
-    const [client, transport] = await this.makeMcpClient(url, headers);
+    const [client, transport] = await this.makeMcpClient(url, headers, transportType);
     try {
       await client.connect(transport);
       const listToolsResult = await client.listTools();
@@ -226,11 +229,22 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
 
   private async makeMcpClient(
     serverUrl: string,
-    headers: ValueOrFactory<Record<string, string>> | undefined
+    headers: ValueOrFactory<Record<string, string>> | undefined,
+    transportType: McpClientTransportType | undefined,
   ) {
-    const transport = this.createTransport
-      ? this.createTransport(serverUrl)
-      : await buildSSEClientTransport(serverUrl, headers);
+    const buildTransport = () => {
+      if (this.createTransport) {
+        return this.createTransport(serverUrl);
+      }
+      switch (transportType) {
+        case 'sse':
+          return buildSSEClientTransport(serverUrl, headers);
+        case 'http':
+        default:
+          return buildStreamableHttpClientTransport(serverUrl, headers);
+      }
+    };
+    const transport = await buildTransport();
 
     const client = new Client(
       {

--- a/external/mcpclient/src/mcp-client-plugin.ts
+++ b/external/mcpclient/src/mcp-client-plugin.ts
@@ -239,7 +239,7 @@ export class McpClientPlugin implements ChatPromptPlugin<'mcpClient', McpClientP
       switch (transportType) {
         case 'sse':
           return buildSSEClientTransport(serverUrl, headers);
-        case 'http':
+        case 'streamable-http':
         default:
           return buildStreamableHttpClientTransport(serverUrl, headers);
       }

--- a/external/mcpclient/src/mcp-client-types.ts
+++ b/external/mcpclient/src/mcp-client-types.ts
@@ -12,6 +12,11 @@ export type McpClientToolDetails = {
 
 export type PromiseOrValue<T> = T | Promise<T>;
 export type ValueOrFactory<T> = T | (() => PromiseOrValue<T>);
+/**
+ * The type of transport to use
+ * Note that the sse transport will soon be deprecated because it was
+ * deprecated in the MCP SDK.
+ */
 export type McpClientTransportType = 'sse' | 'http';
 
 export type McpClientPluginParams = {

--- a/external/mcpclient/src/mcp-client-types.ts
+++ b/external/mcpclient/src/mcp-client-types.ts
@@ -12,8 +12,15 @@ export type McpClientToolDetails = {
 
 export type PromiseOrValue<T> = T | Promise<T>;
 export type ValueOrFactory<T> = T | (() => PromiseOrValue<T>);
+export type McpClientTransportType = 'sse' | 'http';
 
 export type McpClientPluginParams = {
+  /**
+   * The type of transport to use
+   * @default 'http'
+   */
+  transport?: McpClientTransportType;
+
   availableTools?: McpClientToolDetails[];
   /**
    * optional headers to pass in per request
@@ -34,7 +41,7 @@ export type McpClientPluginParams = {
   refetchTimeoutMs?: number;
 };
 
-export type McpClientPluginCachedValue = Pick<McpClientPluginParams, 'availableTools' | 'headers'>;
+export type McpClientPluginCachedValue = Pick<McpClientPluginParams, 'availableTools' | 'headers' | 'transport'>;
 
 /**
  * A map of Mcp client params keyed off of their corresponding urls
@@ -90,6 +97,12 @@ export type McpClientPluginUseParams = {
    * The url of the Mcp server to use
    */
   url: string;
+
+  /**
+   * The type of transport to use
+   * @default 'http'
+   */
+  transport?: McpClientTransportType;
 
   /**
    * The params to use for the Mcp server

--- a/external/mcpclient/src/mcp-client-types.ts
+++ b/external/mcpclient/src/mcp-client-types.ts
@@ -17,12 +17,12 @@ export type ValueOrFactory<T> = T | (() => PromiseOrValue<T>);
  * Note that the sse transport will soon be deprecated because it was
  * deprecated in the MCP SDK.
  */
-export type McpClientTransportType = 'sse' | 'http';
+export type McpClientTransportType = 'sse' | 'streamable-http';
 
 export type McpClientPluginParams = {
   /**
    * The type of transport to use
-   * @default 'http'
+   * @default 'streamable-http'
    */
   transport?: McpClientTransportType;
 
@@ -105,7 +105,7 @@ export type McpClientPluginUseParams = {
 
   /**
    * The type of transport to use
-   * @default 'http'
+   * @default 'streamable-http'
    */
   transport?: McpClientTransportType;
 

--- a/external/mcpclient/src/mcp-transport.ts
+++ b/external/mcpclient/src/mcp-transport.ts
@@ -1,4 +1,5 @@
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 import { ValueOrFactory } from './mcp-client-types';
 
@@ -28,6 +29,20 @@ export async function buildSSEClientTransport(
           ...init,
           headers,
         });
+      },
+    },
+  });
+}
+
+export async function buildStreamableHttpClientTransport(
+  url: string,
+  headers: ValueOrFactory<Record<string, string>> | undefined
+): Promise<StreamableHTTPClientTransport> {
+  const resolvedHeaders = typeof headers === 'function' ? await headers() : headers;
+  return new StreamableHTTPClientTransport(new URL(url), {
+    requestInit: {
+      headers: {
+        ...resolvedHeaders,
       },
     },
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,7 +219,7 @@
       "peerDependencies": {
         "@microsoft/teams.ai": "2.0.0-preview.5",
         "@microsoft/teams.common": "2.0.0-preview.5",
-        "@modelcontextprotocol/sdk": "^1.9.0"
+        "@modelcontextprotocol/sdk": "^1.13.0"
       }
     },
     "external/mcpclient/node_modules/glob": {
@@ -5118,14 +5118,15 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.2.tgz",
-      "integrity": "sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.0.tgz",
+      "integrity": "sha512-P5FZsXU0kY881F6Hbk9GhsYx02/KgWK1DYf7/tyE/1lcFKhDYPQR9iYjhQXJn+Sg6hQleMo3DB7h7+p4wgp2Lw==",
       "license": "MIT",
       "dependencies": {
+        "ajv": "^6.12.6",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
@@ -5137,6 +5138,28 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
@@ -11728,7 +11751,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -11765,7 +11787,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -17821,7 +17842,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21139,7 +21159,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -24054,7 +24073,7 @@
         "@microsoft/teams.dev": "2.0.0-preview.5",
         "@microsoft/teams.mcpclient": "2.0.0-preview.5",
         "@microsoft/teams.openai": "2.0.0-preview.5",
-        "@modelcontextprotocol/sdk": "^1.9.0"
+        "@modelcontextprotocol/sdk": "^1.13.0"
       },
       "devDependencies": {
         "@types/node": "^22.5.4",

--- a/tests/mcp/src/index.ts
+++ b/tests/mcp/src/index.ts
@@ -23,6 +23,10 @@ const mcpServerPlugin = new McpPlugin({
   {
     input: z.string().describe('the text to echo back'),
   },
+  {
+    readOnlyHint: true,
+    idempotentHint: true
+  },
   async ({ input }) => {
     return {
       content: [
@@ -67,6 +71,10 @@ mcpServerPlugin.tool(
   {
     input: z.string().describe('the text to echo back'),
     userAadObjectId: z.string().describe('the user to alert'),
+  },
+  {
+    readOnlyHint: true,
+    idempotentHint: true
   },
   async ({ input, userAadObjectId }, { authInfo }) => {
     if (!isAuthValid(authInfo)) {

--- a/tests/mcpclient/package.json
+++ b/tests/mcpclient/package.json
@@ -18,12 +18,12 @@
     "dev": "npx nodemon -w \"./src/**\" -e ts --exec \"node -r ts-node/register -r dotenv/config ./src/index.ts\""
   },
   "dependencies": {
-    "@microsoft/teams.apps": "2.0.0-preview.5",
     "@microsoft/teams.ai": "2.0.0-preview.5",
+    "@microsoft/teams.apps": "2.0.0-preview.5",
     "@microsoft/teams.dev": "2.0.0-preview.5",
-    "@microsoft/teams.openai": "2.0.0-preview.5",
     "@microsoft/teams.mcpclient": "2.0.0-preview.5",
-    "@modelcontextprotocol/sdk": "^1.9.0"
+    "@microsoft/teams.openai": "2.0.0-preview.5",
+    "@modelcontextprotocol/sdk": "^1.13.0"
   },
   "devDependencies": {
     "@types/node": "^22.5.4",

--- a/tests/mcpclient/src/index.ts
+++ b/tests/mcpclient/src/index.ts
@@ -42,6 +42,18 @@ const prompt = new ChatPrompt(
         'x-functions-key': process.env.AZURE_FUNCTION_KEY!,
       },
     },
+  }).usePlugin('mcpClient', {
+    url: 'https://aiacceleratormcp.azurewebsites.net/runtime/webhooks/mcp/sse',
+    params: {
+      headers: {
+        'x-functions-key': process.env.AZURE_FUNCTION_KEY!,
+      },
+    },
+  }).usePlugin('mcpClient', {
+    url: 'https://learn.microsoft.com/api/mcp',
+    params: {
+      transport: 'http',
+    },
   });
 
 app.on('message', async ({ send, activity }) => {

--- a/tests/mcpclient/src/index.ts
+++ b/tests/mcpclient/src/index.ts
@@ -51,9 +51,6 @@ const prompt = new ChatPrompt(
     },
   }).usePlugin('mcpClient', {
     url: 'https://learn.microsoft.com/api/mcp',
-    params: {
-      transport: 'http',
-    },
   });
 
 app.on('message', async ({ send, activity }) => {


### PR DESCRIPTION
Looks like SSE was deprecated and StreamableHttp was introduced to MCP Client.

This change makes SSE optional. Tested using https://github.com/MicrosoftDocs/mcp?tab=readme-ov-file#-installation--getting-started (which fails using SSE, but works using Http).

![image](https://github.com/user-attachments/assets/18623b06-2415-4379-bf11-babdf0789d80)

We can deprecate SSE out soon, but for now I provided an escape hatch by allowing devs to pass in `transport: "sse"` as a parameter for a given URL.

skip-test-verification - mcp test is changed, but the CLI doesn't use "tool" so it's unaffected.