### PR TITLE
[App] Add send() method to app function handler props

### DIFF
--- a/packages/apps/src/contexts/client.ts
+++ b/packages/apps/src/contexts/client.ts
@@ -10,14 +10,19 @@ export interface IClientContext {
   readonly appSessionId: string;
 
   /**
-   * The Microsoft Entra tenant ID of the current user.
+   * The Microsoft Entra tenant ID of the current user, extracted from request auth  token.
    */
-  readonly tenantId?: string;
+  readonly tenantId: string;
 
   /**
-   * The Microsoft Entra object id of the current user.
+   * The Microsoft Entra object id of the current user, extracted from the request auth token.
    */
-  readonly userId?: string;
+  readonly userId: string;
+
+  /**
+   * The name of the current user, extracted from the request auth token.
+   */
+  readonly userName: string;
 
   /**
    * The Microsoft Teams ID for the team with which the content is associated.
@@ -41,7 +46,7 @@ export interface IClientContext {
   readonly chatId?: string;
 
   /**
-   * Meeting Id used by tab when running in meeting context
+   * Meeting ID used by tab when running in meeting context
    */
   readonly meetingId?: string;
 
@@ -56,8 +61,9 @@ export interface IClientContext {
    * such as scrolling to or activating a specific piece of content.
    */
   readonly subPageId?: string;
+
   /**
    * The MSAL entra token.
    */
-  readonly authToken?: string;
+  readonly authToken: string;
 }

--- a/packages/apps/src/contexts/function.ts
+++ b/packages/apps/src/contexts/function.ts
@@ -1,3 +1,4 @@
+import { ActivityLike, SentActivity } from '@microsoft/teams.api';
 import { ILogger } from '@microsoft/teams.common';
 
 import { ApiClient, GraphClient } from '../api';
@@ -24,4 +25,20 @@ export interface IFunctionContext<T = any> extends IClientContext {
    * the function payload
    */
   data: T;
+
+  /**
+   * Attempts to find the ID of the conversation in which the app is being used, and verifies that the bot and the
+   * user making the function call are both present in the conversation. Depending on the conversation type, this
+   * is the ID of a chat (for group chats, 1:1 chats and channel meetings), a channel, a meeting, or a user-bot
+   * conversation (when the app is hosted in personal scope).
+   * Returns undefined if the conversation ID cannot be determined or is invalid.
+   */
+  getCurrentConversationId: () => Promise<string | undefined>;
+
+  /**
+   * send an activity to the current conversation.
+   * Returns null if the conversation ID cannot be determined or is invalid.
+   * @param activity activity to send
+   */
+  send: (activity: ActivityLike) => Promise<SentActivity | null>;
 }

--- a/packages/apps/src/utils/function-context.spec.ts
+++ b/packages/apps/src/utils/function-context.spec.ts
@@ -1,0 +1,143 @@
+import { getConversationIdResolver } from './function-context';
+
+const mockLog = {
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+const mockApp = (overrides: any = {}) => ({
+  id: 'bot-id',
+  api: {
+    conversations: {
+      members: jest.fn().mockReturnThis(),
+      getById: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+  ...overrides,
+});
+
+describe('getConversationIdResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns conversationId if user is a member', async () => {
+    const app = mockApp();
+    app.api.conversations.getById = jest
+      .fn()
+      .mockResolvedValue({ id: 'user-id' });
+    const context = { userId: 'user-id', channelId: 'conv-123' };
+    const resolver = getConversationIdResolver(
+      app as any,
+      mockLog as any,
+      context as any
+    );
+    const id = await resolver();
+    expect(id).toBe('conv-123');
+    expect(app.api.conversations.members).toHaveBeenCalledWith('conv-123');
+    expect(app.api.conversations.getById).toHaveBeenCalledWith('user-id');
+  });
+
+  it('returns undefined if member lookup fails', async () => {
+    const app = mockApp();
+    app.api.conversations.getById = jest
+      .fn()
+      .mockRejectedValue(new Error('not found'));
+    const context = { userId: 'user-id', channelId: 'conv-123' };
+    const resolver = getConversationIdResolver(
+      app as any,
+      mockLog as any,
+      context as any
+    );
+    const id = await resolver();
+    expect(id).toBeUndefined();
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      'either the bot or the user are not in this conversation',
+      { conversationId: 'conv-123', userId: 'user-id' }
+    );
+  });
+
+  it('returns undefined if user is not a member', async () => {
+    const app = mockApp();
+    app.api.conversations.getById = jest.fn().mockReturnValue(null);
+    const context = { userId: 'user-id', channelId: 'conv-123' };
+    const resolver = getConversationIdResolver(
+      app as any,
+      mockLog as any,
+      context as any
+    );
+    const id = await resolver();
+    expect(id).toBeUndefined();
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      'either the bot or the user are not in this conversation',
+      { conversationId: 'conv-123', userId: 'user-id' }
+    );
+  });
+
+  it('creates a conversation if no conversationId is present', async () => {
+    const app = mockApp();
+    app.api.conversations.create = jest
+      .fn()
+      .mockResolvedValue({ id: 'new-conv-id' });
+    const context = {
+      userId: 'user-id',
+      userName: 'Test User',
+      tenantId: 'tenant-1',
+    };
+    const resolver = getConversationIdResolver(
+      app as any,
+      mockLog as any,
+      context as any
+    );
+    const id = await resolver();
+    expect(id).toBe('new-conv-id');
+    expect(app.api.conversations.create).toHaveBeenCalledWith({
+      bot: { id: 'bot-id' },
+      members: [{ id: 'user-id', role: 'user', name: 'Test User' }],
+      tenantId: 'tenant-1',
+      isGroup: false,
+    });
+  });
+
+  it('returns undefined and logs error if conversation creation fails', async () => {
+    const app = mockApp();
+    app.api.conversations.create = jest
+      .fn()
+      .mockRejectedValue(new Error('fail'));
+    const context = {
+      userId: 'user-id',
+      userName: 'Test User',
+      tenantId: 'tenant-1',
+    };
+    const resolver = getConversationIdResolver(
+      app as any,
+      mockLog as any,
+      context as any
+    );
+    const id = await resolver();
+    expect(id).toBeUndefined();
+    expect(mockLog.error).toHaveBeenCalledWith(
+      'failed to create conversation with user',
+      { userId: 'user-id' }
+    );
+  });
+
+  it('caches the resolved conversation id', async () => {
+    const app = mockApp();
+    app.api.conversations.getById = jest
+      .fn()
+      .mockResolvedValue({ id: 'user-id' });
+    const context = { userId: 'user-id', channelId: 'conv-123' };
+    const resolver = getConversationIdResolver(
+      app as any,
+      mockLog as any,
+      context as any
+    );
+    const id1 = await resolver();
+    const id2 = await resolver();
+    expect(id1).toBe('conv-123');
+    expect(id2).toBe('conv-123');
+    expect(app.api.conversations.getById).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/apps/src/utils/function-context.ts
+++ b/packages/apps/src/utils/function-context.ts
@@ -1,0 +1,65 @@
+import { ILogger } from '@microsoft/teams.common';
+
+import { App } from '../app';
+import { IFunctionContext } from '../contexts';
+import { IPlugin } from '../types';
+
+export function getConversationIdResolver<TPlugin extends IPlugin>(
+  app: App<TPlugin>,
+  log: ILogger,
+  context: Pick<
+    IFunctionContext,
+    'channelId' | 'chatId' | 'meetingId' | 'userId' | 'userName' | 'tenantId'
+  >
+): () => Promise<string | undefined> {
+  let state: { id?: string } | undefined;
+
+  const { userId, userName, tenantId } = context;
+  const conversationId = context.chatId ?? context.channelId;
+
+  return async () => {
+    if (state) {
+      // This conversation has already been resolved.
+      return state.id;
+    }
+
+    if (!conversationId) {
+      // Conversation ID can be missing if the app is running in a personal scope. In this case, create
+      // a conversation between the bot and the user. This will either create a new conversation or return
+      // a pre-existing one.
+      try {
+        const conversation = await app.api.conversations.create({
+          bot: { id: app.id },
+          members: [{ id: userId, role: 'user', name: userName }],
+          tenantId: tenantId,
+          isGroup: false,
+        });
+        state = { id: conversation.id };
+      } catch {
+        state = { id: undefined };
+        log.error('failed to create conversation with user', {
+          userId,
+        });
+      }
+    } else {
+      // Validate that the bot and user are both members of the conversation.
+      try {
+        const member = await app.api.conversations
+          .members(conversationId)
+          .getById(userId);
+        state = { id: !member ? undefined : conversationId };
+      } catch {
+        state = { id: undefined };
+      }
+
+      if (!state.id) {
+        log.warn('either the bot or the user are not in this conversation', {
+          conversationId,
+          userId,
+        });
+      }
+    }
+
+    return state.id;
+  };
+}

--- a/packages/apps/src/utils/index.ts
+++ b/packages/apps/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * as promises from './promises';
+export * as functionContext from './function-context';


### PR DESCRIPTION
## What
This adds a `send` method to the app function handler props to let the function handler post an activity to the conversation where the tab app that invoked the function is active - just as we already have for the `app.on('message')` handler. Also exposes a `getCurrentConversationId()` method that the function handler can use if they need to conversation ID for other purposes - e.g. to call some graph API or what have you.

## How tested

### Setup
I set up a simple react tab app that invokes a function like so:
```
export default function App() {
  const [app, setApp] = React.useState<client.App | null>(null);
  React.useEffect(() => {
    (async () => {
      const app = new client.App(clientId, {
        logger: new ConsoleLogger('@tests/tab', { level: 'debug' }),
      });

      await app.start();
      setApp(app);
    })();
  }, []);

  const callFunction = React.useCallback(async () => {
    await app?.exec<string>('send-function-test');
  }, [app]);

  return (
    <div className="App">
        <button disabled={!app} onClick={callFunction}>Click me</button>
    </div>
  );
}
```

On the bot side, the function handler is:
```
app.function('send-function-test', async ({send, getCurrentConversationId}) => {
  await send(`message sent to ${await getCurrentConversationId()}`);
});
```

### Tests
Installed the app and tested the feature in 
 - group chat
 - meeting chat
 - channel chat
 - channel meeting chat
 - private scope

