### PR TITLE
Fix oauth overriding

### DIFF
--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -132,8 +132,8 @@ export class App<TPlugin extends IPlugin = IPlugin> {
 
   get oauth() {
     return {
-      ...this.options.oauth,
       ...DEFAULT_OAUTH_SETTINGS,
+      ...this.options.oauth,
     };
   }
 


### PR DESCRIPTION
Without this, we were ALWAYS forcing users to use `graph` as the oauth name.