### PR TITLE
Remove automatic token validation skipping on NODE_ENV === local

### DIFF
--- a/external/a2a/src/client/agent-client.ts
+++ b/external/a2a/src/client/agent-client.ts
@@ -71,7 +71,7 @@ export class AgentClient {
         this._agentCard = options.agentCard ?? null;
         this._fetchImpl = options.fetchImpl ?? fetch;
         this._a2aUrl = this._agentCard?.url ?? null;
-        this._logger = options.logger?.child('A2AClient') ?? new ConsoleLogger('A2AAgentClient');
+        this._logger = options.logger?.child('A2AAgentClient') ?? new ConsoleLogger('A2AAgentClient');
     }
 
     /**

--- a/packages/apps/src/middleware/jwt-validation-middleware.ts
+++ b/packages/apps/src/middleware/jwt-validation-middleware.ts
@@ -3,7 +3,7 @@ import express from 'express';
 import { Activity, Credentials, IToken, JsonWebToken } from '@microsoft/teams.api';
 import { ConsoleLogger, ILogger } from '@microsoft/teams.common';
 
-import { createServiceTokenValidator } from './auth/jwt-validator';
+import { createServiceTokenValidator, JwtValidator } from './auth/jwt-validator';
 
 export type JwtValidationParams = {
   credentials?: Credentials;
@@ -18,15 +18,19 @@ export function withJwtValidation(params: JwtValidationParams) {
   const { credentials, logger: inputLogger } = params;
   const logger = inputLogger?.child('jwt-validation-middleware') ?? new ConsoleLogger('jwt-validation-middleware');
 
-  // Create service token validator if credentials are provided and not in local env
-  const serviceTokenValidator = (process.env.NODE_ENV !== 'local' && credentials?.clientId)
-    ? createServiceTokenValidator(
+  // Create service token validator if credentials are provided
+  let serviceTokenValidator: JwtValidator | null;
+  if (credentials?.clientId) {
+    serviceTokenValidator = createServiceTokenValidator(
       credentials.clientId,
       credentials.tenantId,
       undefined,
       logger
-    )
-    : null;
+    );
+  } else {
+    logger.debug('No credentials provided, skipping service token validation');
+    serviceTokenValidator = null;
+  }
 
   return async (
     req: JwtValidatedRequest,

--- a/packages/apps/src/middleware/jwt-validation-middleware.ts
+++ b/packages/apps/src/middleware/jwt-validation-middleware.ts
@@ -33,37 +33,42 @@ export function withJwtValidation(params: JwtValidationParams) {
     res: express.Response,
     next: express.NextFunction
   ) => {
+    if (process.env.NODE_ENV === 'local') {
+      next();
+      return;
+    }
+
     const authorization = req.headers.authorization?.replace('Bearer ', '');
 
-    if (!authorization && process.env.NODE_ENV !== 'local') {
+    if (!authorization) {
       res.status(401).send('unauthorized');
       return;
     }
 
-    if (serviceTokenValidator) {
-      if (!authorization) {
-        res.status(401).send('unauthorized no authorization header');
-        return;
-      }
-
-      const activity: Activity = req.body;
-      // Use cached validator with per-request service URL validation
-      const validationResult = await serviceTokenValidator.validateAccessToken(authorization, activity.serviceUrl ? {
-        validateServiceUrl: { expectedServiceUrl: activity.serviceUrl }
-      } : undefined);
-
-      if (validationResult) {
-        logger.debug(`validated service token for activity ${activity.id}`);
-        // Store the validated token in the request for use in subsequent handlers
-        req.validatedToken = new JsonWebToken(authorization);
-        next();
-      } else {
-        res.status(401).send('Invalid token');
-        return;
-      }
+    if (!serviceTokenValidator) {
+      logger.debug('No service token validator configured, skipping validation');
+      next();
+      return;
     }
 
-    logger.debug('Skipping JWT validation in local environment');
-    next();
+    if (!authorization) {
+      res.status(401).send('unauthorized no authorization header');
+      return;
+    }
+
+    const activity: Activity = req.body;
+    // Use cached validator with per-request service URL validation
+    const validationResult = await serviceTokenValidator.validateAccessToken(authorization, activity.serviceUrl ? {
+      validateServiceUrl: { expectedServiceUrl: activity.serviceUrl }
+    } : undefined);
+
+    if (validationResult) {
+      logger.debug(`validated service token for activity ${activity.id}`);
+      // Store the validated token in the request for use in subsequent handlers
+      req.validatedToken = new JsonWebToken(authorization);
+      next();
+    } else {
+      res.status(401).send('Invalid token');
+    }
   };
 }

--- a/packages/apps/src/middleware/jwt-validation-middleware.ts
+++ b/packages/apps/src/middleware/jwt-validation-middleware.ts
@@ -34,6 +34,7 @@ export function withJwtValidation(params: JwtValidationParams) {
     next: express.NextFunction
   ) => {
     if (process.env.NODE_ENV === 'local') {
+      logger.debug('Skipping JWT validation in local environment');
       next();
       return;
     }

--- a/packages/apps/src/middleware/jwt-validation-middleware.ts
+++ b/packages/apps/src/middleware/jwt-validation-middleware.ts
@@ -51,11 +51,6 @@ export function withJwtValidation(params: JwtValidationParams) {
       return;
     }
 
-    if (!authorization) {
-      res.status(401).send('unauthorized no authorization header');
-      return;
-    }
-
     const activity: Activity = req.body;
     // Use cached validator with per-request service URL validation
     const validationResult = await serviceTokenValidator.validateAccessToken(authorization, activity.serviceUrl ? {

--- a/packages/apps/src/middleware/jwt-validation-middleware.ts
+++ b/packages/apps/src/middleware/jwt-validation-middleware.ts
@@ -33,12 +33,6 @@ export function withJwtValidation(params: JwtValidationParams) {
     res: express.Response,
     next: express.NextFunction
   ) => {
-    if (process.env.NODE_ENV === 'local') {
-      logger.debug('Skipping JWT validation in local environment');
-      next();
-      return;
-    }
-
     const authorization = req.headers.authorization?.replace('Bearer ', '');
 
     if (!authorization) {


### PR DESCRIPTION
We were disabling auth if NODE_ENV === local. Now we are not.
1. If you are using devtools, this has no effect.
2. If you use teams-test-tool, you can pass in `skipAuth: process.env.NODE_ENV === local ? true : false` as a flag to disable auth when constructing the `App`