### PR TITLE
Send group Oauth requests to personal scope

### DIFF
--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -265,6 +265,7 @@ export class ActivityContext<T extends Activity = Activity>
         type: 'message',
         inputHint: 'acceptingInput',
         recipient: this.activity.from,
+        conversation: convo.conversation,
         attachments: [
           cardAttachment('oauth', {
             text: oauthCardText,


### PR DESCRIPTION
When an oauth request comes, we create a 1:1 chat to send it to them. But we weren't actually sending the message there.

This was accidentally fine because we added support for Group SSO.

But i'm not sure if that's GA'd so creating this PR to not forget and check with the team. If it is released, we can remove the code to create that 1:1 chat.