### PR TITLE
Use tenant-specific app-token for app-graph

### DIFF
--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -44,7 +44,7 @@ export async function $process<TPlugin extends IPlugin>(
 
   let appToken: string | undefined;
   try {
-    appToken = await this.getOrRefreshTenantToken(token.tenantId || 'common');
+    appToken = await this.getOrRefreshTenantToken(activity.conversation.tenantId ?? 'common');
   } catch (err) {
     // noop
   }

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -537,7 +537,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
 
   protected async getOrRefreshTenantToken(tenantId?: string) {
     let appToken =
-      this.tenantTokens.get(tenantId || 'common');
+      this.tenantTokens.get(tenantId || 'common') || this._tokens.graph?.toString();
     if (this.credentials && !appToken) {
       const { access_token } = await this.api.bots.token.getGraph({
         ...this.credentials,

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -537,7 +537,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
 
   protected async getOrRefreshTenantToken(tenantId?: string) {
     let appToken =
-      this.tenantTokens.get(tenantId || 'common') || this._tokens.graph?.toString();
+      this.tenantTokens.get(tenantId || 'common');
     if (this.credentials && !appToken) {
       const { access_token } = await this.api.bots.token.getGraph({
         ...this.credentials,


### PR DESCRIPTION
This fix updates the token used to be the tenant-specific token for app-graph.
Previously, we were using token.tenantId, but it turns out, the token that comes from SMBA doesn't actually contain `tid`. Here is an example:
<img width="714" height="632" alt="image" src="https://github.com/user-attachments/assets/30d471b7-38d9-460a-b5ca-fe3ec981c136" />

Notice how there's no `tid`?


With this change, I gave my bot RSC permissions to read chats and channel messages, and then used this to list out messages, and it was successfully able to.
```ts
if (activity.channelData?.team?.id) {
    const result = await appGraph.teams.channels(activity.channelData.team.id).messages(activity.channelData.channel!.id).list();
    console.log('channel-messages', result);
  } else {
    const result = await appGraph.chats.messages(activity.conversation.id).list();
    console.log('chat-messages', result);
  }
```