### PR TITLE
add user token in activity context

### DIFF
--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -112,6 +112,7 @@ export async function $process<TPlugin extends IPlugin>(
     appId: this.id || '',
     log: this.log,
     tokens: this.tokens,
+    userToken: userToken,
     ref,
     storage: this.storage,
     isSignedIn: !!userToken,

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -76,6 +76,11 @@ export interface IActivityContextOptions<T extends Activity = Activity> {
   connectionName: string;
 
   /**
+   * the user token for the activity context
+   */
+  userToken?: string;
+
+  /**
    * extra data
    */
   [key: string]: any;


### PR DESCRIPTION
Here we assume that user-token is specifically for graph, but it might not be! It might be for some other thing (like github). This PR gives access to the rest of the app to the user token for a given activity.