### PR TITLE
Add optional conversation ref parameter to `send` and fix tenant app graph token during app.process

### DIFF
--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -124,8 +124,8 @@ export async function $process<TPlugin extends IPlugin>(
   }
 
   const send = context.send.bind(context);
-  context.send = async (activity: ActivityLike) => {
-    const res = await send(activity);
+  context.send = async (activity: ActivityLike, conversationRef?: ConversationReference) => {
+    const res = await send(activity, conversationRef);
 
     this.onActivitySent(sender, {
       ...ref,

--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -125,7 +125,6 @@ export async function $process<TPlugin extends IPlugin>(
 
   const send = context.send.bind(context);
   context.send = async (activity: ActivityLike, conversationRef?: ConversationReference) => {
-    ;
     const res = await send(activity, conversationRef);
 
     this.onActivitySent(sender, {

--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -125,10 +125,11 @@ export async function $process<TPlugin extends IPlugin>(
 
   const send = context.send.bind(context);
   context.send = async (activity: ActivityLike, conversationRef?: ConversationReference) => {
-    const res = await send(activity, conversationRef);
+    const targetConversationRef = conversationRef ?? ref;
+    const res = await send(activity, targetConversationRef);
 
     this.onActivitySent(sender, {
-      ...ref,
+      ...targetConversationRef,
       sender,
       activity: res,
     });

--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -125,11 +125,11 @@ export async function $process<TPlugin extends IPlugin>(
 
   const send = context.send.bind(context);
   context.send = async (activity: ActivityLike, conversationRef?: ConversationReference) => {
-    const targetConversationRef = conversationRef ?? ref;
-    const res = await send(activity, targetConversationRef);
+    ;
+    const res = await send(activity, conversationRef);
 
     this.onActivitySent(sender, {
-      ...targetConversationRef,
+      ...(conversationRef ?? ref),
       sender,
       activity: res,
     });

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -544,10 +544,10 @@ export class App<TPlugin extends IPlugin = IPlugin> {
         tenantId: tenantId,
       });
 
-      this.log.debug(`refreshing tenant token for ${tenantId || 'common'}, token: ${access_token}`);
+      this.log.debug(`refreshing tenant token for ${tenantId}`);
 
       appToken = access_token;
-      this.tenantTokens.set(tenantId || 'common', access_token);
+      this.tenantTokens.set(tenantId, access_token);
     }
 
     return appToken;

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -535,14 +535,16 @@ export class App<TPlugin extends IPlugin = IPlugin> {
     return res.token;
   }
 
-  protected async getOrRefreshTenantToken(tenantId?: string) {
+  protected async getOrRefreshTenantToken(tenantId: string) {
     let appToken =
-      this.tenantTokens.get(tenantId || 'common') || this._tokens.graph?.toString();
-    if (this.credentials && !appToken) {
+      this.tenantTokens.get(tenantId);
+    if (this.credentials && !this.tenantTokens.get(tenantId)) {
       const { access_token } = await this.api.bots.token.getGraph({
         ...this.credentials,
         tenantId: tenantId,
       });
+
+      this.log.debug(`refreshing tenant token for ${tenantId || 'common'}, token: ${access_token}`);
 
       appToken = access_token;
       this.tenantTokens.set(tenantId || 'common', access_token);

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -126,8 +126,9 @@ export interface IActivityContext<T extends Activity = Activity>
   /**
    * send an activity to the conversation
    * @param activity activity to send
+   * @param conversationRef optional conversation reference to send the activity to. By default, it will use the activity's conversation reference.
    */
-  send: (activity: ActivityLike) => Promise<SentActivity>;
+  send: (activity: ActivityLike, conversationRef?: ConversationReference) => Promise<SentActivity>;
 
   /**
    * reply to the inbound activity
@@ -199,8 +200,8 @@ export class ActivityContext<T extends Activity = Activity>
     }
   }
 
-  async send(activity: ActivityLike) {
-    return await this._plugin.send(toActivityParams(activity), this.ref);
+  async send(activity: ActivityLike, conversationRef?: ConversationReference) {
+    return await this._plugin.send(toActivityParams(activity), conversationRef ?? this.ref);
   }
 
   async reply(activity: ActivityLike) {
@@ -286,7 +287,7 @@ export class ActivityContext<T extends Activity = Activity>
             ],
           }),
         ],
-      }
+      }, convo
     );
   }
 


### PR DESCRIPTION
1. Just tested out `send` for the group oauth scenario, and we need to plumb conversation ref through to `send` for this to work. 
2. Also tested out the app-graph scenario, and it was defaulting to using `this._tokens.graph?.toString()` which wasn't working in calling graph successfully.

Tested both scenarios now, and both are working correctly now.