### PR TITLE
Do not send empty invoke bodies

### DIFF
--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -158,7 +158,7 @@ export async function $process<TPlugin extends IPlugin>(
     await context.stream.close();
 
     if (!res || !isInvokeResponse(res)) {
-      res = { status: 200, body: res };
+      res = { status: 200, body: res ?? {} };
     }
 
     this.onActivityResponse(sender, {

--- a/tests/ai/README.md
+++ b/tests/ai/README.md
@@ -42,7 +42,7 @@ OPENAI_API_KEY=<sk-your_openai_api_key>
 | Scenario               | Usage                                             | Description                                                 |
 | ---------------------- | ------------------------------------------------- | ----------------------------------------------------------- |
 | Simple LLM check       | `hi`                                              | This is to show basic ChatPrompts working                   |
-| Streaming              | `streaming <your query>`                          | Shows streaming working                                     |
+| Streaming              | `stream <your query>`                             | Shows streaming working                                     |
 | Function calling       | `pokemon <your pokemon query>`                    | Shows function calling working                              |
 | Multi-Function calling | `weather <what is my weather like?>`              | Shows multi-function calling working                        |
 | Feedback               | `feedback <any text>`                             | Shows feedback loop                                         |

--- a/tests/ai/src/index.ts
+++ b/tests/ai/src/index.ts
@@ -35,12 +35,13 @@ const model = new OpenAIChatModel({
 
 // Handle "hi" message
 // :snippet-start: simple-chat
-app.on('message', async ({ send, activity, next }) => {
+app.on('message', async ({ send, activity, next, log }) => {
   // :remove-start:
   if (activity.text.toLowerCase() !== 'hi') {
     await next();
     return;
   }
+  log.info('Received "hi" message, responding with AI-generated response');
   // :remove-end:
   const model = new OpenAIChatModel({
     apiKey: process.env.AZURE_OPENAI_API_KEY || process.env.OPENAI_API_KEY,
@@ -66,6 +67,7 @@ app.on('message', async ({ send, activity, next }) => {
 // Handle "<supported-command> <query>" message
 app.on('message', async ({ send, activity, next, log }) => {
   if (activity.text.toLowerCase().startsWith('docs ')) {
+    log.info('Received "docs" command, handling documentation search');
     await handleDocumentationSearch(
       model,
       {
@@ -95,6 +97,7 @@ app.on('message', async ({ send, activity, next, log }) => {
   if (!handler) {
     log.warn(`Command ${commandName} does not have a supplied handler`);
   } else {
+    log.info(`Received "${commandName}" command, executing handler`);
     await handler(
       model,
       {
@@ -109,19 +112,20 @@ app.on('message', async ({ send, activity, next, log }) => {
 
 // Handle messages that start with stream <query>
 // :snippet-start: streaming-chat
-app.on('message', async ({ stream, send, activity, next }) => {
+app.on('message', async ({ stream, send, activity, next, log }) => {
   // :remove-start:
   const commandAndQuery = streamCommand(activity.text);
   if (!commandAndQuery) {
     await next();
     return;
   }
+  log.info('Received "stream" command, processing query');
   const { query } = commandAndQuery;
   // :remove-end:
   // const query = activity.text;
 
   const prompt = new ChatPrompt({
-    instructions: 'You are a friendly assistant who responds in terse language',
+    instructions: 'You are a friendly assistant who responds in extremely verbose language',
     model,
   });
 


### PR DESCRIPTION
For feedback loop, if we send empty responses, the backend complains, throwing a `Invalid response. Payload cannot be null` and this error screen:

<img width="571" height="291" alt="image" src="https://github.com/user-attachments/assets/e61b46f8-c27d-4ed1-a8b3-c51f1f500cec" />

Digging into service [code](https://skype.visualstudio.com/SCC/_git/async_messaging_botapiservice?path=/Library/Dialects/BFC/BotActivityParsing/BotActivityParser.cs&version=GBmaster&_a=contents&line=95&lineStyle=plain&lineEnd=96&lineStartColumn=1&lineEndColumn=1), it looks like we always throw if payload is null. So in this PR, i'm returning an empty body if there is no body.

skip-test-verification - test change, not template.
