### PR TITLE
Send undefined instead of null

### DIFF
--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -158,7 +158,7 @@ export async function $process<TPlugin extends IPlugin>(
     await context.stream.close();
 
     if (!res || !isInvokeResponse(res)) {
-      res = { status: 200, body: res ?? {} };
+      res = { status: 200, body: res };
     }
 
     this.onActivityResponse(sender, {

--- a/packages/apps/src/plugins/http/plugin.ts
+++ b/packages/apps/src/plugins/http/plugin.ts
@@ -176,7 +176,7 @@ export class HttpPlugin implements ISender {
     }
 
     if (!res.headersSent) {
-      res.status(response.status || 200).send(JSON.stringify(response.body || null));
+      res.status(response.status || 200).send(JSON.stringify(response.body));
     }
 
     delete this.pending[activity.id];
@@ -231,6 +231,7 @@ export class HttpPlugin implements ISender {
   ) {
     const activity: Activity = req.body;
     let token: IToken | undefined;
+    console.log(`Received message ${JSON.stringify(activity, null, 2)}`);
     if (req.validatedToken) {
       token = req.validatedToken;
     } else {


### PR DESCRIPTION
In #296 we made it so that we set empty object for empty responses. Turns out the problem was with the body that we're sending. We coalesce to null for undefined objects, but we should really just send undefined. The backend does a check for Content-Length == 0, which is not true for Null, but is true for undefined.