### PR TITLE
If no service token validator is there, skip middlware

### DIFF
--- a/packages/apps/src/middleware/jwt-validation-middleware.ts
+++ b/packages/apps/src/middleware/jwt-validation-middleware.ts
@@ -37,18 +37,18 @@ export function withJwtValidation(params: JwtValidationParams) {
     res: express.Response,
     next: express.NextFunction
   ) => {
-    const authorization = req.headers.authorization?.replace('Bearer ', '');
-
-    if (!authorization) {
-      res.status(401).send('unauthorized');
-      return;
-    }
-
     if (!serviceTokenValidator) {
       logger.debug('No service token validator configured, skipping validation');
       next();
       return;
     }
+
+    const authorization = req.headers.authorization?.replace('Bearer ', '');
+    if (!authorization) {
+      res.status(401).send('unauthorized');
+      return;
+    }
+
 
     const activity: Activity = req.body;
     // Use cached validator with per-request service URL validation


### PR DESCRIPTION
Right now if no serviceTokenValidator is present (b/c of various reasons), we throw a 401 instead of just skipping hte middleware. This defeats the purpose of an optional serviceTokenValidator