### PR TITLE
Enable sending updates to streams before stream starts

### DIFF
--- a/packages/api/src/activities/typing.ts
+++ b/packages/api/src/activities/typing.ts
@@ -76,15 +76,22 @@ export class TypingActivity extends Activity<'typing'> implements ITypingActivit
       this.channelData = {};
     }
 
-    this.channelData.streamId = this.id;
-    this.channelData.streamType = 'streaming';
-    this.channelData.streamSequence = sequence;
+    if (!this.channelData.streamId) {
+      this.channelData.streamId = this.id;
+    }
+
+    if (!this.channelData.streamType) {
+      this.channelData.streamType = 'streaming';
+    }
+    if (!this.channelData.streamSequence) {
+      this.channelData.streamSequence = sequence;
+    }
 
     return this.addEntity({
       type: 'streaminfo',
       streamId: this.id,
-      streamType: 'streaming',
-      streamSequence: sequence,
+      streamType: this.channelData.streamType,
+      streamSequence: this.channelData.streamSequence,
     });
   }
 }

--- a/packages/apps/src/plugins/http/stream.ts
+++ b/packages/apps/src/plugins/http/stream.ts
@@ -6,6 +6,7 @@ import {
   ConversationReference,
   Entity,
   IMessageActivity,
+  ITypingActivity,
   MessageActivity,
   SentActivity,
   TypingActivity,
@@ -26,7 +27,7 @@ export class HttpStream implements IStreamer {
   protected attachments: Attachment[] = [];
   protected channelData: ChannelData = {};
   protected entities: Entity[] = [];
-  protected queue: Array<Partial<IMessageActivity>> = [];
+  protected queue: Array<Partial<IMessageActivity | ITypingActivity>> = [];
 
   private _result?: SentActivity;
   private _timeout?: NodeJS.Timeout;
@@ -39,7 +40,7 @@ export class HttpStream implements IStreamer {
     this._logger = logger?.child('stream') || new ConsoleLogger('@teams/http/stream');
   }
 
-  emit(activity: Partial<IMessageActivity> | string) {
+  emit(activity: Partial<IMessageActivity | ITypingActivity> | string) {
     if (this._timeout) {
       clearTimeout(this._timeout);
       this._timeout = undefined;
@@ -56,6 +57,14 @@ export class HttpStream implements IStreamer {
     this._timeout = setTimeout(this.flush.bind(this), 200);
   }
 
+  update(text: string) {
+    this.emit({
+      type: 'typing',
+      text: text,
+      channelData: { streamType: 'informative' }
+    });
+  }
+
   async close() {
     if (!this.index && !this.queue.length) {
       this._logger.debug('closed with no content');
@@ -69,6 +78,10 @@ export class HttpStream implements IStreamer {
 
     while (!this.id || this.queue.length) {
       await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+
+    if (this.text === '' && !this.attachments.length) {
+      this.text = 'Stream completed without content';
     }
 
     const activity = new MessageActivity(this.text)
@@ -108,18 +121,29 @@ export class HttpStream implements IStreamer {
       }
 
       let i = 0;
-      
+      const informativeUpdates: Partial<ITypingActivity>[] = [];
+
       while (this.queue.length && i < 10) {
         const activity = this.queue.shift();
 
         if (!activity) continue;
 
-        if (activity.text) {
-          this.text += activity.text;
+        if (activity.type === 'message') {
+          if (activity.text) {
+            this.text += activity.text;
+          }
+          if (activity.attachments) {
+            this.attachments = [...(this.attachments || []), ...activity.attachments];
+          }
+          if (activity.entities) {
+            this.entities = [...(this.entities || []), ...activity.entities];
+          }
         }
 
-        if (activity.attachments) {
-          this.attachments = [...(this.attachments || []), ...activity.attachments];
+        if (activity.type === 'typing') {
+          if (activity.channelData?.streamType === 'informative' && this.text === '') {
+            informativeUpdates.push(activity);
+          }
         }
 
         if (activity.channelData) {
@@ -129,28 +153,20 @@ export class HttpStream implements IStreamer {
           };
         }
 
-        if (activity.entities) {
-          this.entities = [...(this.entities || []), ...activity.entities];
-        }
-
         i++;
       }
 
       if (i === 0) return;
 
-      const activity = new TypingActivity({ id: this.id })
-        .withText(this.text)
-        .addStreamUpdate(this.index + 1);
+      // Send informative updates immediately
+      for (const informativeUpdate of informativeUpdates) {
+        const activity = new TypingActivity().withText(informativeUpdate.text || '').withChannelData({ streamType: 'informative' });
+        await this.send_activity(activity);
+      }
 
-      const res = await promises.retry(() => this.send(activity), {
-        logger: this._logger
-      });
-
-      this.events.emit('chunk', res);
-      this.index++;
-
-      if (!this.id) {
-        this.id = res.id;
+      if (this.text) {
+        const activity = new TypingActivity().withText(this.text);
+        await this.send_activity(activity);
       }
 
       if (this.queue.length) {
@@ -159,6 +175,22 @@ export class HttpStream implements IStreamer {
     } finally {
       this._flushing = false;
     }
+  }
+
+  protected async send_activity(activity: TypingActivity) {
+      if (this.id) {
+        activity.id = this.id;
+      }
+      activity.addStreamUpdate(this.index + 1);
+
+      const res = await promises.retry(() => this.send(activity as ActivityParams), {
+        logger: this._logger
+      });
+      this.events.emit('chunk', res);
+      this.index++;
+      if (!this.id) {
+        this.id = res.id;
+      }
   }
 
   protected async send(activity: ActivityParams) {

--- a/packages/apps/src/types/streamer.ts
+++ b/packages/apps/src/types/streamer.ts
@@ -30,6 +30,12 @@ export interface IStreamer {
   emit(activity: Partial<IMessageActivity | ITypingActivity> | string): void;
 
   /**
+   * send status updates before emitting (ex. "Thinking...")
+   * @param text the status text to send
+   */
+  update(text: string): void;
+
+  /**
    * close the stream
    */
   close(): SentActivity | undefined | Promise<SentActivity | undefined>;


### PR DESCRIPTION
To make typescript consistent with python and .net, 

- __IStreamer__ (`packages/apps/src/types/streamer.ts`): Interface definition for the update method

`__HttpStream__ (`packages/apps/src/plugins/http/stream.ts`)`: Added `update()` method implementation for sending informative updates
`__HttpStream__ (`packages/apps/src/plugins/http/stream.ts`)`: Changed flush logic to handle informative updates separately and send them immediately with withChannelData({ streamType: 'informative' })
- __TypingActivity__ (`packages/api/src/activities/typing.ts`): Changed logic to only assign `streamType' etc  if not set


https://github.com/user-attachments/assets/338b5b72-a564-4321-a58f-4b138f13e248
