### PR TITLE
Read port correctly in cloud deployments

### DIFF
--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -185,7 +185,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
   protected tenantTokens = new LocalStorage<string>({}, { max: 20000 });
   protected events = new EventEmitter<AppEvents<TPlugin>>();
   protected startedAt?: Date;
-  protected port?: number;
+  protected port?: number | string;
 
   private readonly _userAgent = `teams.ts[apps]/${pkg.version}`;
 
@@ -329,7 +329,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
    * @param port port to listen on
    */
   async start(port?: number | string) {
-    this.port = +(port || process.env.PORT || 3978);
+    this.port = port || process.env.PORT || 3978;
 
     try {
       await this.refreshTokens(true);

--- a/packages/apps/src/plugins/http/plugin.ts
+++ b/packages/apps/src/plugins/http/plugin.ts
@@ -83,7 +83,7 @@ export class HttpPlugin implements ISender {
   get port() {
     return this._port;
   }
-  protected _port?: number;
+  protected _port?: number | string;
 
   protected express: express.Application;
   protected pending: Record<string, express.Response> = {};

--- a/packages/apps/src/types/plugin/plugin-start-event.ts
+++ b/packages/apps/src/types/plugin/plugin-start-event.ts
@@ -7,5 +7,5 @@ export interface IPluginStartEvent {
    * the port given to the
    * `app.start()` method
    */
-  readonly port: number;
+  readonly port: number | string;
 }


### PR DESCRIPTION
On IISNode, process.env.PORT is a named pipe like `\\.\pipe\cab9024b-6962-4c74-96ec-d53160071338`