### PR TITLE
Enable build output caching for graph projects

### DIFF
--- a/packages/graph-endpoints-beta/turbo.json
+++ b/packages/graph-endpoints-beta/turbo.json
@@ -3,9 +3,9 @@
   "tasks": {
     "build": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"],
-      "cache": false,
-      "dependsOn": ["@microsoft/teams.common#build", "@microsoft/teams.graph-tools#build", "@microsoft/teams.graph-endpoints#build"]
+      "outputs": ["dist/**", "!dist/cache/**"],
+      "cache": true,
+      "dependsOn": ["@microsoft/teams.graph-tools#build"]
     }
   }
 }

--- a/packages/graph-endpoints/turbo.json
+++ b/packages/graph-endpoints/turbo.json
@@ -3,9 +3,9 @@
   "tasks": {
     "build": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"],
-      "cache": false,
-      "dependsOn": ["@microsoft/teams.common#build", "@microsoft/teams.graph-tools#build"]
+      "outputs": ["dist/**", "!dist/cache/**"],
+      "cache": true,
+      "dependsOn": ["@microsoft/teams.graph-tools#build"]
     }
   }
 }

--- a/packages/graph/turbo.json
+++ b/packages/graph/turbo.json
@@ -3,8 +3,8 @@
   "tasks": {
     "build": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"],
-      "cache": false,
+      "outputs": ["dist/**", "!dist/cache/**"],
+      "cache": true,
       "dependsOn": ["@microsoft/teams.common#build"]
     }
   }


### PR DESCRIPTION
This takes Alex's suggestion from https://github.com/microsoft/teams.ts/pull/305 to enable build output caching in the graph projects and avoid redundant rebuilds.