### PR TITLE
[apps]: add channel filtered routes and unit test router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4678,145 +4678,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/@microsoft/api-extractor": {
-      "version": "7.52.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.8.tgz",
-      "integrity": "sha512-cszYIcjiNscDoMB1CIKZ3My61+JOhpERGlGr54i6bocvGLrcL/wo9o+RNXMBrb7XgLtKaizZWUpqRduQuHQLdg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@microsoft/api-extractor-model": "7.30.6",
-        "@microsoft/tsdoc": "~0.15.1",
-        "@microsoft/tsdoc-config": "~0.17.1",
-        "@rushstack/node-core-library": "5.13.1",
-        "@rushstack/rig-package": "0.5.3",
-        "@rushstack/terminal": "0.15.3",
-        "@rushstack/ts-command-line": "5.0.1",
-        "lodash": "~4.17.15",
-        "minimatch": "~3.0.3",
-        "resolve": "~1.22.1",
-        "semver": "~7.5.4",
-        "source-map": "~0.6.1",
-        "typescript": "5.8.2"
-      },
-      "bin": {
-        "api-extractor": "bin/api-extractor"
-      }
-    },
-    "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.30.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.6.tgz",
-      "integrity": "sha512-znmFn69wf/AIrwHya3fxX6uB5etSIn6vg4Q4RB/tb5VDDs1rqREc+AvMC/p19MUN13CZ7+V/8pkYPTj7q8tftg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@microsoft/tsdoc": "~0.15.1",
-        "@microsoft/tsdoc-config": "~0.17.1",
-        "@rushstack/node-core-library": "5.13.1"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@microsoft/teams-js": {
       "version": "2.36.0",
       "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-2.36.0.tgz",
@@ -4903,49 +4764,6 @@
     "node_modules/@microsoft/teams.openai": {
       "resolved": "packages/openai",
       "link": true
-    },
-    "node_modules/@microsoft/tsdoc": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
-      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@microsoft/tsdoc-config": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.1.tgz",
-      "integrity": "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@microsoft/tsdoc": "0.15.1",
-        "ajv": "~8.12.0",
-        "jju": "~1.4.0",
-        "resolve": "~1.22.2"
-      }
-    },
-    "node_modules/@microsoft/tsdoc-config/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
     },
     "node_modules/@modelcontextprotocol/inspector": {
       "version": "0.6.0",
@@ -6647,205 +6465,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rushstack/node-core-library": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.13.1.tgz",
-      "integrity": "sha512-5yXhzPFGEkVc9Fu92wsNJ9jlvdwz4RNb2bMso+/+TH0nMm1jDDDsOIf4l8GAkPxGuwPw5DH24RliWVfSPhlW/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ajv": "~8.13.0",
-        "ajv-draft-04": "~1.0.0",
-        "ajv-formats": "~3.0.1",
-        "fs-extra": "~11.3.0",
-        "import-lazy": "~4.0.0",
-        "jju": "~1.4.0",
-        "resolve": "~1.22.1",
-        "semver": "~7.5.4"
-      },
-      "peerDependencies": {
-        "@types/node": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/ajv": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@rushstack/rig-package": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.3.tgz",
-      "integrity": "sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "resolve": "~1.22.1",
-        "strip-json-comments": "~3.1.1"
-      }
-    },
-    "node_modules/@rushstack/terminal": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.15.3.tgz",
-      "integrity": "sha512-DGJ0B2Vm69468kZCJkPj3AH5nN+nR9SPmC0rFHtzsS4lBQ7/dgOwtwVxYP7W9JPDMuRBkJ4KHmWKr036eJsj9g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@rushstack/node-core-library": "5.13.1",
-        "supports-color": "~8.1.1"
-      },
-      "peerDependencies": {
-        "@types/node": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rushstack/terminal/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@rushstack/ts-command-line": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.0.1.tgz",
-      "integrity": "sha512-bsbUucn41UXrQK7wgM8CNM/jagBytEyJqXw/umtI8d68vFm1Jwxh1OtLrlW7uGZgjCWiiPH6ooUNa1aVsuVr3Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@rushstack/terminal": "0.15.3",
-        "@types/argparse": "1.0.38",
-        "argparse": "~1.0.9",
-        "string-argv": "~0.3.1"
-      }
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -7153,15 +6772,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/@types/argparse": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
-      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8424,43 +8034,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/ansi-colors": {
@@ -13458,18 +13031,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/import-lazy": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -15122,15 +14683,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/jju": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/jose": {
       "version": "4.15.9",
@@ -20086,18 +19638,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-argv": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.6.19"
       }
     },
     "node_modules/string-length": {

--- a/packages/apps/src/app.routing.ts
+++ b/packages/apps/src/app.routing.ts
@@ -2,23 +2,19 @@ import { Activity, InvokeResponse } from '@microsoft/teams.api';
 
 import { App } from './app';
 import { IActivityContext } from './contexts';
-import { IRoutes } from './routes';
+import { Routes } from './routes';
 import { IPlugin, RouteHandler } from './types';
 import { PluginAdditionalContext } from './types/app-routing';
-
-type AppPlugin<TApp extends App> = TApp extends App<infer TPlugin> ? TPlugin : never;
-
-export type AppRoutingHandler<Name extends keyof IRoutes, TApp extends App<any>> = Exclude<IRoutes<PluginAdditionalContext<AppPlugin<TApp>>>[Name], undefined>;
 
 /**
  * subscribe to an event
  * @param name event to subscribe to
  * @param cb callback to invoke
  */
-export function on<TPlugin extends IPlugin, Name extends keyof IRoutes,>(
+export function on<TPlugin extends IPlugin, Name extends keyof Routes>(
   this: App<TPlugin>,
   name: Name,
-  cb: Exclude<IRoutes<PluginAdditionalContext<TPlugin>>[Name], undefined>
+  cb: Exclude<Routes<PluginAdditionalContext<TPlugin>>[Name], undefined>
 ) {
   this.router.on(name, cb);
   return this;
@@ -32,7 +28,7 @@ export function on<TPlugin extends IPlugin, Name extends keyof IRoutes,>(
 export function message<TPlugin extends IPlugin>(
   this: App<TPlugin>,
   pattern: string | RegExp,
-  cb: Exclude<IRoutes<PluginAdditionalContext<TPlugin>>['message'], undefined>
+  cb: Exclude<Routes<PluginAdditionalContext<TPlugin>>['message'], undefined>
 ) {
   this.router.register<'message'>({
     select: (activity) => {

--- a/packages/apps/src/router.spec.ts
+++ b/packages/apps/src/router.spec.ts
@@ -1,0 +1,296 @@
+import { Account, MessageActivity, TypingActivity } from '@microsoft/teams.api';
+
+import { Router } from './router';
+
+describe('Router', () => {
+  it('should select when bot is mentioned', () => {
+      const router = new Router();
+      const handler = jest.fn();
+      const bot: Account = {
+        id: '1',
+        role: 'bot',
+        name: 'bot',
+      };
+
+      const user: Account = {
+        id: '2',
+        role: 'user',
+        name: 'user',
+      };
+
+      router.on('mention', handler);
+
+      expect(router.select(new MessageActivity())).toHaveLength(0);
+      expect(router.select(new MessageActivity().withRecipient(bot).addMention(user))).toHaveLength(0);
+      expect(router.select(new MessageActivity().withRecipient(bot).addMention(bot))).toHaveLength(1);
+  });
+
+  describe('type', () => {
+    it('should select type filtered routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('activity', handler);
+      router.on('message', handler);
+      router.on('typing', handler);
+
+      expect(router.select(new MessageActivity())).toHaveLength(2);
+      expect(router.select(new TypingActivity())).toHaveLength(2);
+    });
+  });
+
+  describe('conversationUpdate', () => {
+    it('should select "channelData.eventType" filtered routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('conversationUpdate', handler);
+      router.on('channelShared', handler);
+      router.on('teamDeleted', handler);
+
+      expect(router.select({
+        type: 'conversationUpdate',
+        channelData: {
+          eventType: 'channelShared'
+        }
+      } as any)).toHaveLength(2);
+
+      expect(router.select({
+        type: 'conversationUpdate',
+        channelData: {
+          eventType: 'teamDeleted'
+        }
+      } as any)).toHaveLength(2);
+    });
+  });
+
+  describe('installationUpdate', () => {
+    it('should select action filtered routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('installationUpdate', handler);
+      router.on('install.add', handler);
+      router.on('install.remove', handler);
+
+      expect(router.select({
+        type: 'installationUpdate',
+        action: 'add',
+      } as any)).toHaveLength(2);
+
+      expect(router.select({
+        type: 'installationUpdate',
+        action: 'remove'
+      } as any)).toHaveLength(2);
+    });
+  });
+
+  describe('messageDelete', () => {
+    it('should select "channelData.eventType" filtered routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('messageDelete', handler);
+      router.on('softDeleteMessage', handler);
+
+      expect(router.select({
+        type: 'messageDelete',
+      } as any)).toHaveLength(1);
+
+      expect(router.select({
+        type: 'messageDelete',
+        channelData: {
+          eventType: 'softDeleteMessage'
+        }
+      } as any)).toHaveLength(2);
+    });
+  });
+
+  describe('messageUpdate', () => {
+    it('should select "channelData.eventType" filtered routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('messageUpdate', handler);
+      router.on('undeleteMessage', handler);
+      router.on('editMessage', handler);
+
+      expect(router.select({
+        type: 'messageUpdate',
+      } as any)).toHaveLength(1);
+
+      expect(router.select({
+        type: 'messageUpdate',
+        channelData: {
+          eventType: 'undeleteMessage'
+        }
+      } as any)).toHaveLength(2);
+
+      expect(router.select({
+        type: 'messageUpdate',
+        channelData: {
+          eventType: 'editMessage'
+        }
+      } as any)).toHaveLength(2);
+    });
+  });
+
+  describe('event', () => {
+    it('should select name filtered routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('event', handler);
+      router.on('meetingStart', handler);
+      router.on('readReceipt', handler);
+
+      expect(router.select({
+        type: 'event',
+        name: 'application/vnd.microsoft.meetingStart'
+      } as any)).toHaveLength(2);
+
+      expect(router.select({
+        type: 'event',
+        name: 'application/vnd.microsoft.readReceipt'
+      } as any)).toHaveLength(2);
+
+      expect(router.select({
+        type: 'event',
+        name: 'application/vnd.microsoft.meetingEnd'
+      } as any)).toHaveLength(1);
+    });
+  });
+
+  describe('invoke', () => {
+    it('should select name filtered routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('invoke', handler);
+      router.on('message.ext.open', handler);
+      router.on('card.action', handler);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'composeExtension/fetchTask'
+      } as any)).toHaveLength(2);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'adaptiveCard/action'
+      } as any)).toHaveLength(2);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'task/fetch'
+      } as any)).toHaveLength(1);
+    });
+
+    it('should select file consent routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('invoke', handler);
+      router.on('file.consent', handler);
+      router.on('file.consent.accept', handler);
+      router.on('file.consent.decline', handler);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'fileConsent/invoke',
+        value: { action: 'accept' }
+      } as any)).toHaveLength(3);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'fileConsent/invoke',
+        value: { action: 'decline' }
+      } as any)).toHaveLength(3);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'task/fetch'
+      } as any)).toHaveLength(1);
+    });
+
+    it('should select message extension submit action routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('invoke', handler);
+      router.on('message.ext.submit', handler);
+      router.on('message.ext.edit', handler);
+      router.on('message.ext.send', handler);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'composeExtension/submitAction',
+        value: { botMessagePreviewAction: 'edit' }
+      } as any)).toHaveLength(3);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'composeExtension/submitAction',
+        value: { botMessagePreviewAction: 'send' }
+      } as any)).toHaveLength(3);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'task/fetch'
+      } as any)).toHaveLength(1);
+    });
+
+    it('should select message submit action routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('invoke', handler);
+      router.on('message.submit', handler);
+      router.on('message.submit.feedback', handler);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'message/submitAction',
+        value: { actionName: 'feedback' }
+      } as any)).toHaveLength(3);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'message/submitAction',
+        value: { actionName: 'send' }
+      } as any)).toHaveLength(2);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'task/fetch'
+      } as any)).toHaveLength(1);
+    });
+  });
+
+  describe('channel', () => {
+    it('should select channel filtered routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('msteams.activity', handler);
+      router.on('webchat.activity', handler);
+      router.on('activity', handler);
+
+      expect(router.select(new MessageActivity().withChannelId('msteams'))).toHaveLength(2);
+      expect(router.select(new TypingActivity().withChannelId('test'))).toHaveLength(1);
+    });
+
+    it('should select channel/type filtered routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('msteams.message', handler);
+      router.on('webchat.message', handler);
+      router.on('message', handler);
+
+      expect(router.select(new MessageActivity().withChannelId('msteams'))).toHaveLength(2);
+      expect(router.select(new MessageActivity().withChannelId('webchat'))).toHaveLength(2);
+      expect(router.select(new MessageActivity().withChannelId('test'))).toHaveLength(1);
+    });
+  });
+});

--- a/packages/apps/src/router.ts
+++ b/packages/apps/src/router.ts
@@ -1,17 +1,17 @@
 import { Activity, InvokeResponse } from '@microsoft/teams.api';
 
 import { IActivityContext } from './contexts';
-import { EVENT_ALIASES, INVOKE_ALIASES, IRoutes } from './routes';
+import { EVENT_ALIASES, INVOKE_ALIASES, Routes } from './routes';
 import { RouteHandler } from './types';
 
-type Route<Name extends keyof IRoutes = keyof IRoutes, TExtraCtx extends Record<string, any> = Record<string, any>> = {
+type Route<Name extends keyof Routes = keyof Routes, TExtraCtx extends Record<string, any> = Record<string, any>> = {
   readonly name?: Name;
   readonly select: (activity: Activity) => boolean;
-  readonly callback: IRoutes<TExtraCtx>[Name];
+  readonly callback: Routes<TExtraCtx>[Name];
 };
 
 export class Router<TExtraCtx extends Record<string, any> = Record<string, any>> {
-  protected readonly routes: Route<keyof IRoutes, TExtraCtx>[] = [];
+  protected readonly routes: Route<keyof Routes, TExtraCtx>[] = [];
 
   /**
    * select routes that match the inbound activity
@@ -27,7 +27,7 @@ export class Router<TExtraCtx extends Record<string, any> = Record<string, any>>
    * register a new route
    * @param route the route to register
    */
-  register<Name extends keyof IRoutes>(route: Route<Name, TExtraCtx>) {
+  register<Name extends keyof Routes>(route: Route<Name, TExtraCtx>) {
     this.routes.push(route);
     return this;
   }
@@ -50,58 +50,65 @@ export class Router<TExtraCtx extends Record<string, any> = Record<string, any>>
    * @param event event to subscribe to
    * @param callback the callback to invoke
    */
-  on<Name extends keyof IRoutes>(event: Name, callback: Exclude<IRoutes<TExtraCtx>[Name], undefined>) {
+  on<Name extends keyof Routes>(event: Name, callback: Exclude<Routes<TExtraCtx>[Name], undefined>) {
     this.register({
       name: event,
       select: (activity) => {
-        if (event === 'activity') {
+        let ev = event as string;
+        const channelPrefix = `${activity.channelId}.`;
+
+        if (ev.startsWith(channelPrefix)) {
+          ev = ev.substring(channelPrefix.length);
+        }
+
+        if (ev === 'activity') {
           return true;
         }
 
-        if (event === activity.type) {
+        if (ev === activity.type) {
           return true;
         }
 
         if (activity.type === 'conversationUpdate') {
-          return event === activity.channelData?.eventType;
+          return ev === activity.channelData?.eventType;
         }
 
         if (activity.type === 'installationUpdate') {
-          return event === `install.${activity.action}`;
+          return ev === `install.${activity.action}`;
         }
 
         if (activity.type === 'messageDelete') {
-          return event === activity.channelData?.eventType;
+          return ev === activity.channelData?.eventType;
         }
 
         if (activity.type === 'messageUpdate') {
-          return event === activity.channelData?.eventType;
+          return ev === activity.channelData?.eventType;
         }
 
         if (activity.type === 'event') {
-          return event === EVENT_ALIASES[activity.name];
+          return ev === EVENT_ALIASES[activity.name];
         }
 
         if (activity.type === 'invoke') {
-          if (event === INVOKE_ALIASES[activity.name]) {
+          if (ev === INVOKE_ALIASES[activity.name]) {
             return true;
           }
 
           if (activity.name === 'fileConsent/invoke') {
-            return event === `file.consent.${activity.value.action}`;
+            return ev === `file.consent.${activity.value.action}`;
           }
 
           if (activity.name === 'composeExtension/submitAction') {
-            return event === `message.ext.${activity.value.botMessagePreviewAction}`;
+            return ev === `message.ext.${activity.value.botMessagePreviewAction}`;
           }
 
           if (activity.name === 'message/submitAction') {
-            return event === `message.submit.${activity.value.actionName}`;
+            return ev === `message.submit.${activity.value.actionName}`;
           }
         }
 
         // custom routes
-        if (event === 'mention' && activity.entities?.some((e) => e.type === 'mention')) {
+        if (ev === 'mention' && activity.entities?.some((e) => e.type === 'mention')) {
           return (
             activity.entities?.find(
               (e) => e.type === 'mention' && e.mentioned.id === activity.recipient.id

--- a/packages/apps/src/routes/conversation-update.ts
+++ b/packages/apps/src/routes/conversation-update.ts
@@ -4,7 +4,7 @@ import { IActivityContext } from '../contexts';
 import { RouteHandler } from '../types';
 
 export type ConversationUpdateActivityRoutes<TExtraCtx extends Record<string, any> = Record<string, any>> = {
-  [K in IConversationUpdateActivity['channelData']['eventType']as K]?: RouteHandler<
+  [K in IConversationUpdateActivity['channelData']['eventType'] as K]?: RouteHandler<
     IActivityContext<IConversationUpdateActivity, TExtraCtx>,
     void
   >;

--- a/packages/apps/src/routes/event.ts
+++ b/packages/apps/src/routes/event.ts
@@ -4,7 +4,7 @@ import { IActivityContext } from '../contexts';
 import { RouteHandler } from '../types';
 
 export type EventActivityRoutes<TExtraCtx extends Record<string, any> = Record<string, any>> = {
-  [K in EventActivity['name']as EventAliases[K]]?: RouteHandler<
+  [K in EventActivity['name'] as EventAliases[K]]?: RouteHandler<
     IActivityContext<Extract<EventActivity, { name: K }>, TExtraCtx>,
     void
   >;

--- a/packages/apps/src/routes/index.ts
+++ b/packages/apps/src/routes/index.ts
@@ -23,6 +23,10 @@ export interface IRoutes<TExtraCtx extends Record<string, any> = Record<string, 
   activity?: RouteHandler<IActivityContext<Activity, TExtraCtx>>;
 }
 
+export type Routes<TExtraCtx extends Record<string, any> = Record<string, any>> = {
+  [K in keyof IRoutes as K | `${'webchat' | 'msteams'}.${K}`]?: IRoutes<TExtraCtx>[K];
+};
+
 export * from './activity';
 export * from './conversation-update';
 export * from './event';

--- a/packages/apps/src/routes/install.ts
+++ b/packages/apps/src/routes/install.ts
@@ -4,7 +4,7 @@ import { IActivityContext } from '../contexts';
 import { RouteHandler } from '../types';
 
 export type InstallActivityRoutes<TExtraCtx extends Record<string, any> = Record<string, any>> = {
-  [K in InstallUpdateActivity['action']as `install.${K}`]?: RouteHandler<
+  [K in InstallUpdateActivity['action'] as `install.${K}`]?: RouteHandler<
     IActivityContext<Extract<InstallUpdateActivity, { action: K }>, TExtraCtx>,
     void
   >;

--- a/packages/apps/src/routes/message-delete.ts
+++ b/packages/apps/src/routes/message-delete.ts
@@ -4,7 +4,7 @@ import { IActivityContext } from '../contexts';
 import { RouteHandler } from '../types';
 
 export type MessageDeleteActivityRoutes<TExtraCtx extends Record<string, any> = Record<string, any>> = {
-  [K in IMessageDeleteActivity['channelData']['eventType']as K]?: RouteHandler<
+  [K in IMessageDeleteActivity['channelData']['eventType'] as K]?: RouteHandler<
     IActivityContext<IMessageDeleteActivity, TExtraCtx>,
     void
   >;

--- a/packages/apps/src/routes/message-update.ts
+++ b/packages/apps/src/routes/message-update.ts
@@ -4,7 +4,7 @@ import { IActivityContext } from '../contexts';
 import { RouteHandler } from '../types';
 
 export type MessageUpdateActivityRoutes<TExtraCtx extends Record<string, any> = Record<string, any>> = {
-  [K in IMessageUpdateActivity['channelData']['eventType']as K]?: RouteHandler<
+  [K in IMessageUpdateActivity['channelData']['eventType'] as K]?: RouteHandler<
     IActivityContext<IMessageUpdateActivity, TExtraCtx>,
     void
   >;

--- a/packages/apps/src/types/app-routing.ts
+++ b/packages/apps/src/types/app-routing.ts
@@ -2,7 +2,7 @@ import { IPlugin } from './plugin';
 import { UnionToIntersection } from './union-to-intersection';
 
 import type { App } from '../app';
-import type { IRoutes } from '../routes';
+import type { Routes } from '../routes';
 
 /**
  * Extracts the events from a plugin if it extends PluginWithEvents
@@ -14,4 +14,4 @@ export type PluginAdditionalContext<T> = UnionToIntersection<
 
 type AppPlugin<TApp extends App> = TApp extends App<infer TPlugin> ? TPlugin : never;
 
-export type AppRoutingHandler<Name extends keyof IRoutes, TApp extends App<any>> = Exclude<IRoutes<PluginAdditionalContext<AppPlugin<TApp>>>[Name], undefined>;
+export type AppRoutingHandler<Name extends keyof Routes, TApp extends App<any>> = Exclude<Routes<PluginAdditionalContext<AppPlugin<TApp>>>[Name], undefined>;

--- a/tests/echo/src/index.ts
+++ b/tests/echo/src/index.ts
@@ -26,7 +26,7 @@ const myConversationIdStorage = new Map<string, string>();
 // Installation is just one place to get the conversation id. All activities
 // have the conversation id, so you can use any activity to get it.
 app.on('install.add', async ({ activity, send }) => {
-  // Save the conversation id in 
+  // Save the conversation id in
   myConversationIdStorage.set(activity.from.aadObjectId!, activity.conversation.id);
 
   await send('Hi! I am going to remind you to say something to me soon!');


### PR DESCRIPTION
a few people have brought up that it would be nice to be able to handle routes on a per channel basis, this PR adds channel specific routes for each existing route, and unit tests the router.
<img width="526" height="265" alt="Screenshot 2025-08-22 123012" src="https://github.com/user-attachments/assets/8872d35f-1a44-44ec-b67e-168b6b78d999" />
