### PR TITLE
Update tests projects to use the new Graph calling pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ $: npm run test
 - [`@microsoft/teams.dev`](./packages/dev/README.md)
 - [`@microsoft/teams.devtools`](./packages/devtools/README.md)
 - [`@microsoft/teams.graph`](./packages/graph/README.md)
+- [`@microsoft/teams.graph-endpoints`](./packages/graph-endpoints/README.md)
+- [`@microsoft/teams.graph-endpoints-beta`](./packages/graph-endpoints-beta/README.md)
 - [`@microsoft/teams.openai`](./packages/openai/README.md)
 
 ## External Packages
@@ -88,11 +90,12 @@ $: npm run test
 > ⚠️ **WARNING** these apps are changed often and are not intended to be used outside the
 > projects monorepo. To easily setup a new project please use the **templates** available via
 > the `@microsoft/teams.cli` and follow the
-> [Getting Started](https://microsoft.github.io/teams-ai/2.getting-started/1.create-application.html) documentation!
+> [Getting Started](https://microsoft.github.io/teams-ai/typescript/getting-started) documentation!
 
 - [`@tests/echo`](./tests/echo/README.md)
-- [`@tests/botbuilder`](./tests/botbuilder/README.md)
 - [`@tests/auth`](./tests/auth/README.md)
+- [`@tests/botbuilder`](./tests/botbuilder/README.md)
+- [`@tests/graph`](./tests/graph/README.md)
 - [`@tests/lights`](./tests/lights/README.md)
 - [`@tests/tab`](./tests/tab/README.md)
 - [`@tests/mcp`](./tests/mcp/README.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24567,7 +24567,8 @@
         "@microsoft/teams.cards": "2.0.0-preview.9",
         "@microsoft/teams.common": "2.0.0-preview.9",
         "@microsoft/teams.dev": "2.0.0-preview.9",
-        "@microsoft/teams.graph": "2.0.0-preview.9"
+        "@microsoft/teams.graph": "2.0.0-preview.9",
+        "@microsoft/teams.graph-endpoints": "2.0.0-preview.9"
       },
       "devDependencies": {
         "@microsoft/teams.config": "2.0.0-preview.9",
@@ -24977,6 +24978,7 @@
         "@microsoft/teams.common": "2.0.0-preview.9",
         "@microsoft/teams.dev": "2.0.0-preview.9",
         "@microsoft/teams.graph": "2.0.0-preview.9",
+        "@microsoft/teams.graph-endpoints": "2.0.0-preview.9",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },

--- a/packages/cli/templates/typescript/graph/package.json.hbs
+++ b/packages/cli/templates/typescript/graph/package.json.hbs
@@ -21,7 +21,8 @@
     "@microsoft/teams.cards": "preview",
     "@microsoft/teams.common": "preview",
     "@microsoft/teams.dev": "preview",
-    "@microsoft/teams.graph": "preview"
+    "@microsoft/teams.graph": "preview",
+    "@microsoft/teams.graph-endpoints": "preview",
   },
   "devDependencies": {
     "@types/node": "^22.5.4",

--- a/packages/cli/templates/typescript/graph/src/index.ts
+++ b/packages/cli/templates/typescript/graph/src/index.ts
@@ -2,26 +2,27 @@ import { MessageActivity } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
 import { AdaptiveCard, CodeBlock } from '@microsoft/teams.cards';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
+import * as endpoints from '@microsoft/teams.graph-endpoints';
 
 const app = new App({
   plugins: [new DevtoolsPlugin()],
 });
 
-app.on("message", async ({ log, signin, isSignedIn }) => {
+app.on('message', async ({ log, signin, isSignedIn }) => {
   if (!isSignedIn) {
     await signin();
     return;
   }
 
-  log.info("user already signed in!");
+  log.info('user already signed in!');
 });
 
 app.event('signin', async ({ send, userGraph }) => {
-  const me = await userGraph.me.get();
+  const me = await userGraph.call(endpoints.me.get);
 
   await send(
     new MessageActivity(`hello ${me.displayName} 👋!`).addCard(
-      "adaptive",
+      'adaptive',
       new AdaptiveCard(
         new CodeBlock({
           codeSnippet: JSON.stringify(me, null, 2),

--- a/packages/cli/templates/typescript/tab/package.json.hbs
+++ b/packages/cli/templates/typescript/tab/package.json.hbs
@@ -24,6 +24,7 @@
     "@microsoft/teams.common": "preview",
     "@microsoft/teams.dev": "preview",
     "@microsoft/teams.graph": "preview",
+    "@microsoft/teams.graph-endpoints": "preview",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/cli/templates/typescript/tab/src/Tab/App.css
+++ b/packages/cli/templates/typescript/tab/src/Tab/App.css
@@ -1,4 +1,43 @@
+body {
+  margin: 0px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
+}
+
+a {
+  color: white;
+}
+
+h1 {
+  font-size: 3rem;
+}
+
 .App {
   color: white;
+  background-color: #282c34;
+  display: flex;
+  flex-direction: column;
+  row-gap: 1rem;
+  justify-content: start;
+  align-items: center;
+  height: 100vh;
+  overflow: hidden auto;
+}
+
+.App > * {
+  max-width: calc(100% - 4rem);
+}
+
+.actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  column-gap: 1rem;
+}
+
+.result {
+  color: white;
   background-color: black;
+  padding: 0 1rem;
+  overflow: auto;
 }

--- a/packages/cli/templates/typescript/tab/src/Tab/App.tsx
+++ b/packages/cli/templates/typescript/tab/src/Tab/App.tsx
@@ -1,33 +1,107 @@
 import React from 'react';
 import * as client from '@microsoft/teams.client';
 import { ConsoleLogger } from '@microsoft/teams.common';
+import * as endpoints from '@microsoft/teams.graph-endpoints';
+import * as teamsJs from '@microsoft/teams-js';
 
 import './App.css';
 
+const clientId = import.meta.env.VITE_CLIENT_ID;
+
 export default function App() {
-  const [greeting, setGreeting] = React.useState('');
+  const [content, setContent] = React.useState('');
+  const [app, setApp] = React.useState<client.App | null>(null);
 
   React.useEffect(() => {
     (async () => {
-      const clientId = import.meta.env.VITE_CLIENT_ID;
-      const tenantId = import.meta.env.VITE_TENANT_ID;
+
+      // initialize the app and prompt for Graph scope consent, if not already granted
       const app = new client.App(clientId, {
-        tenantId,
         logger: new ConsoleLogger('@tests/tab', { level: 'debug' }),
+        msalOptions: {
+          prewarmScopes: ['User.Read', 'Presence.ReadWrite', 'Team.ReadBasic.All']
+        }
       });
 
       await app.start();
-
-      const result = await app.exec<string>('hello-world');
-      setGreeting(result);
+      app.log.info('app started');
+      setApp(app);
     })();
   }, []);
 
+  const showTeamsJsContext = React.useCallback(async () => {
+    if (!app) {
+      return;
+    }
+
+    const context = await teamsJs.app.getContext();
+    setContent(JSON.stringify(context, null, 2));
+  }, [app]);
+
+
+  const postChatMessage = React.useCallback(async () => {
+    if (!app) {
+      return;
+    }
+
+    // get the bot to post a message to the current chat, whichever that is
+    const { conversationId } = await app.exec<{ conversationId: string }>('post-to-chat', { message: 'Hello from the client!' });
+    setContent(`Message posted to conversation ${conversationId}`);
+  }, [app]);
+
+
+  const whoAmI = React.useCallback(async () => {
+    if (!app) {
+      return;
+    }
+
+    // get the current user from the Microsoft Graph
+    const me = await app.graph.call(endpoints.me.get);
+    setContent(JSON.stringify(me, null, 2));
+  }, [app]);
+
+
+  const togglePresentationMode = React.useCallback(async () => {
+    if (!app) {
+      return;
+    }
+
+    // get current presence from the Microsoft Graph
+    const { availability } = await app.graph.call(endpoints.me.presence.get);
+    const isAvailable = availability === 'Available';
+
+    // toggle between Dnd/Presenting and Available/Available
+    const newPresence = {
+      sessionId: clientId,
+      availability: isAvailable ? 'DoNotDisturb' : 'Available',
+      activity: isAvailable ? 'Presenting' : 'Available'
+    };
+    await app.graph.call(endpoints.me.presence.setPresence.create, newPresence);
+    setContent(`You're now ${newPresence.activity}`);
+
+  }, [app]);
+
   return (
     <div className="App">
-      <pre>
-        <code>{greeting}</code>
-      </pre>
+      <h1>👋 Welcome</h1>
+      <p>This test app lets you try out some of the features offered by Teams AI Library v2 for Teams Tab app developers.</p>
+
+      <div className="actions">
+        <button disabled={!app} onClick={showTeamsJsContext}>Show TeamsJs context</button>
+        <button disabled={!app} onClick={postChatMessage}>Post chat message</button>
+        <button disabled={!app} onClick={whoAmI}>Who am I?</button>
+        <button disabled={!app} onClick={togglePresentationMode}>Toggle presentation mode</button>
+      </div>
+
+      {content && (
+        <div className='result'>
+          <pre>
+            <code>{content}</code>
+          </pre>
+        </div>
+      )}
+
+      <p>For more information, please refer to the <a href='https://microsoft.github.io/teams-ai' rel='noopener noreferrer' target='_blank'>Teams AI documentation</a>.</p>
     </div>
   );
 }

--- a/packages/cli/templates/typescript/tab/src/index.ts
+++ b/packages/cli/templates/typescript/tab/src/index.ts
@@ -1,16 +1,30 @@
 import path from 'path';
 
 import { App } from '@microsoft/teams.apps';
+import { ConsoleLogger } from '@microsoft/teams.common/logging';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 const app = new App({
+  logger: new ConsoleLogger('@tests/tab', { level: 'debug' }),
   plugins: [new DevtoolsPlugin()],
 });
 
 app.tab('test', path.resolve('dist/client'));
-app.function('hello-world', async ({ log, data }) => {
-  log.info(data);
-  return 'Hello, world!';
+
+app.function<{}, { message: string }>(
+  'post-to-chat',
+  async ({ data, send, getCurrentConversationId }) => {
+    // post to the current conversation; return the conversation ID to the caller
+    await send(data.message);
+    return {
+      conversationId: await getCurrentConversationId(),
+    };
+  },
+);
+
+app.on('message', async ({ activity, reply }) => {
+  // simple echo bot
+  reply(`You said: ${activity.text}`);
 });
 
 (async () => {

--- a/packages/client/src/app.spec.ts
+++ b/packages/client/src/app.spec.ts
@@ -486,11 +486,22 @@ describe('App', () => {
 
   describe('graph', () => {
     it('should invoke the graph client', async () => {
-      const get = jest.fn();
-      buildGraphClientSpy.mockReturnValue({ me: { get } });
+      const call = jest.fn();
+
+      const getPresence = (): {
+        method: 'get';
+        path: '/me/presence';
+        paramDefs: [];
+      } => ({
+        method: 'get',
+        path: '/me/presence',
+        paramDefs: [],
+      });
+
+      buildGraphClientSpy.mockReturnValue({ call });
       const app = new App(mockClientId);
-      await app.graph.me.get();
-      expect(get).toHaveBeenCalledTimes(1);
+      await app.graph.call(getPresence);
+      expect(call).toHaveBeenCalledTimes(1);
     });
 
     it('throws if invoked before the app is started', () => {

--- a/tests/graph/README.md
+++ b/tests/graph/README.md
@@ -16,7 +16,7 @@ Use this if you want to enable user authentication in your Teams application.
 
 1. In the `aad.manifest.json` file, update the `requiredResourceAccess` list to add the required scopes.
 
-2. In the `infra/botRegistration/azurebot.bicep` file, under the `botServicesMicrosoftGraphConnection` resource, update the `properties.scopes` string to be a comma-delimeted list of the required scopes.
+2. In the `infra/botRegistration/azurebot.bicep` file, under the `botServicesMicrosoftGraphConnection` resource, update the `properties.scopes` string to be a comma-delimited list of the required scopes.
 
 ### Example
 

--- a/tests/graph/package.json
+++ b/tests/graph/package.json
@@ -26,7 +26,8 @@
     "@microsoft/teams.cards": "2.0.0-preview.9",
     "@microsoft/teams.common": "2.0.0-preview.9",
     "@microsoft/teams.dev": "2.0.0-preview.9",
-    "@microsoft/teams.graph": "2.0.0-preview.9"
+    "@microsoft/teams.graph": "2.0.0-preview.9",
+    "@microsoft/teams.graph-endpoints": "2.0.0-preview.9"
   },
   "devDependencies": {
     "@microsoft/teams.config": "2.0.0-preview.9",

--- a/tests/graph/src/index.ts
+++ b/tests/graph/src/index.ts
@@ -1,14 +1,15 @@
 import { App } from '@microsoft/teams.apps';
 import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import * as endpoints from '@microsoft/teams.graph-endpoints';
 
 // :snippet-start: auth-config
-const app = new App({ 
+const app = new App({
   oauth: { // oauth configurations
     /**
      * The name of the auth connection to use.
      * It should be the same as the OAuth connection name defined in the Azure Bot configuration.
      */
-    defaultConnectionName: 'graph' 
+    defaultConnectionName: 'graph'
   },
   logger: new ConsoleLogger('@tests/auth', { level: 'debug' })
 });
@@ -28,17 +29,17 @@ app.on('message', async ({ log, signin, userGraph, isSignedIn }) => {
     await signin({
       // Customize the OAuth card text (only applies to OAuth flow, not SSO)
       oauthCardText: 'Sign in to your account',
-      signInButtonText: 'Sign in' 
+      signInButtonText: 'Sign in'
     }); // call signin for your auth connection...
     return;
   }
 
-  const me = await userGraph.me.get();
+  const me = await userGraph.call(endpoints.me.get);
   log.info(`user "${me.displayName}" already signed in!`);
 });
 
 app.event('signin', async ({ send, userGraph, token }) => {
-  const me = await userGraph.me.get();
+  const me = await userGraph.call(endpoints.me.get);
   await send(`user "${me.displayName}" signed in. Here's the token: ${JSON.stringify(token)}`);
 });
 // :snippet-end:

--- a/tests/graph/turbo.json
+++ b/tests/graph/turbo.json
@@ -11,7 +11,8 @@
         "@microsoft/teams.cards#build",
         "@microsoft/teams.common#build",
         "@microsoft/teams.dev#build",
-        "@microsoft/teams.graph#build"
+        "@microsoft/teams.graph#build",
+        "@microsoft/teams.graph-endpoints#build"
       ]
     }
   }

--- a/tests/tab/package.json
+++ b/tests/tab/package.json
@@ -26,6 +26,7 @@
     "@microsoft/teams.common": "2.0.0-preview.9",
     "@microsoft/teams.dev": "2.0.0-preview.9",
     "@microsoft/teams.graph": "2.0.0-preview.9",
+    "@microsoft/teams.graph-endpoints": "2.0.0-preview.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/tests/tab/src/Tab/App.css
+++ b/tests/tab/src/Tab/App.css
@@ -1,4 +1,43 @@
+body {
+  margin: 0px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
+}
+
+a {
+  color: white;
+}
+
+h1 {
+  font-size: 3rem;
+}
+
 .App {
   color: white;
+  background-color: #282c34;
+  display: flex;
+  flex-direction: column;
+  row-gap: 1rem;
+  justify-content: start;
+  align-items: center;
+  height: 100vh;
+  overflow: hidden auto;
+}
+
+.App > * {
+  max-width: calc(100% - 4rem);
+}
+
+.actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  column-gap: 1rem;
+}
+
+.result {
+  color: white;
   background-color: black;
+  padding: 0 1rem;
+  overflow: auto;
 }

--- a/tests/tab/src/Tab/App.tsx
+++ b/tests/tab/src/Tab/App.tsx
@@ -1,33 +1,107 @@
 import React from 'react';
 import * as client from '@microsoft/teams.client';
 import { ConsoleLogger } from '@microsoft/teams.common';
+import * as endpoints from '@microsoft/teams.graph-endpoints';
+import * as teamsJs from '@microsoft/teams-js';
 
 import './App.css';
 
+const clientId = import.meta.env.VITE_CLIENT_ID;
+
 export default function App() {
-  const [greeting, setGreeting] = React.useState('');
+  const [content, setContent] = React.useState('');
+  const [app, setApp] = React.useState<client.App | null>(null);
 
   React.useEffect(() => {
     (async () => {
-      const clientId = import.meta.env.VITE_CLIENT_ID;
-      const tenantId = import.meta.env.VITE_TENANT_ID;
+
+      // initialize the app and prompt for Graph scope consent, if not already granted
       const app = new client.App(clientId, {
-        tenantId,
         logger: new ConsoleLogger('@tests/tab', { level: 'debug' }),
+        msalOptions: {
+          prewarmScopes: ['User.Read', 'Presence.ReadWrite', 'Team.ReadBasic.All']
+        }
       });
 
       await app.start();
-
-      const result = await app.exec<string>('hello-world');
-      setGreeting(result);
+      app.log.info('app started');
+      setApp(app);
     })();
   }, []);
 
+  const showTeamsJsContext = React.useCallback(async () => {
+    if (!app) {
+      return;
+    }
+
+    const context = await teamsJs.app.getContext();
+    setContent(JSON.stringify(context, null, 2));
+  }, [app]);
+
+
+  const postChatMessage = React.useCallback(async () => {
+    if (!app) {
+      return;
+    }
+
+    // get the bot to post a message to the current chat, whichever that is
+    const { conversationId } = await app.exec<{ conversationId: string }>('post-to-chat', { message: 'Hello from the client!' });
+    setContent(`Message posted to conversation ${conversationId}`);
+  }, [app]);
+
+
+  const whoAmI = React.useCallback(async () => {
+    if (!app) {
+      return;
+    }
+
+    // get the current user from the Microsoft Graph
+    const me = await app.graph.call(endpoints.me.get);
+    setContent(JSON.stringify(me, null, 2));
+  }, [app]);
+
+
+  const togglePresentationMode = React.useCallback(async () => {
+    if (!app) {
+      return;
+    }
+
+    // get current presence from the Microsoft Graph
+    const { availability } = await app.graph.call(endpoints.me.presence.get);
+    const isAvailable = availability === 'Available';
+
+    // toggle between Dnd/Presenting and Available/Available
+    const newPresence = {
+      sessionId: clientId,
+      availability: isAvailable ? 'DoNotDisturb' : 'Available',
+      activity: isAvailable ? 'Presenting' : 'Available'
+    };
+    await app.graph.call(endpoints.me.presence.setPresence.create, newPresence);
+    setContent(`You're now ${newPresence.activity}`);
+
+  }, [app]);
+
   return (
     <div className="App">
-      <pre>
-        <code>{greeting}</code>
-      </pre>
+      <h1>👋 Welcome</h1>
+      <p>This test app lets you try out some of the features offered by Teams AI Library v2 for Teams Tab app developers.</p>
+
+      <div className="actions">
+        <button disabled={!app} onClick={showTeamsJsContext}>Show TeamsJs context</button>
+        <button disabled={!app} onClick={postChatMessage}>Post chat message</button>
+        <button disabled={!app} onClick={whoAmI}>Who am I?</button>
+        <button disabled={!app} onClick={togglePresentationMode}>Toggle presentation mode</button>
+      </div>
+
+      {content && (
+        <div className='result'>
+          <pre>
+            <code>{content}</code>
+          </pre>
+        </div>
+      )}
+
+      <p>For more information, please refer to the <a href='https://microsoft.github.io/teams-ai' rel='noopener noreferrer' target='_blank'>Teams AI documentation</a>.</p>
     </div>
   );
 }

--- a/tests/tab/src/index.ts
+++ b/tests/tab/src/index.ts
@@ -11,7 +11,7 @@ const app = new App({
 
 app.tab('test', path.resolve('dist/client'));
 
-app.function<{}, {message: string}>('post-to-chat', async ({ data, send, getCurrentConversationId }) => {
+app.function<{}, { message: string }>('post-to-chat', async ({ data, send, getCurrentConversationId }) => {
   // post to the current conversation; return the conversation ID to the caller
   await send(data.message);
   return {

--- a/tests/tab/src/index.ts
+++ b/tests/tab/src/index.ts
@@ -10,9 +10,18 @@ const app = new App({
 });
 
 app.tab('test', path.resolve('dist/client'));
-app.function('hello-world', async ({ log, data }) => {
-  log.info(data);
-  return 'Hello, world!';
+
+app.function<{}, {message: string}>('post-to-chat', async ({ data, send, getCurrentConversationId }) => {
+  // post to the current conversation; return the conversation ID to the caller
+  await send(data.message);
+  return {
+    conversationId: await getCurrentConversationId()
+  };
+});
+
+app.on('message', async ({ activity, reply }) => {
+  // simple echo bot
+  reply(`You said: ${activity.text}`);
 });
 
 (async () => {

--- a/tests/tab/turbo.json
+++ b/tests/tab/turbo.json
@@ -12,7 +12,8 @@
         "@microsoft/teams.common#build",
         "@microsoft/teams.client#build",
         "@microsoft/teams.dev#build",
-        "@microsoft/teams.graph#build"
+        "@microsoft/teams.graph#build",
+        "@microsoft/teams.graph-endpoints#build"
       ]
     }
   }


### PR DESCRIPTION
This PR updates the tab & graph tests to use the new graph calling pattern. It also makes some overall improvements to the tab test to better showcase some of the features of this library
 - pre-warming graph token consent
 - getting the teamsJs context
 - making a remote function call
 - having the remote function handler post a message to the current channel, and
 - a couple graph calls to fetch me & presence, and to set presence.

Tab test hosted in Teams:
<img width="1159" height="997" alt="image" src="https://github.com/user-attachments/assets/e33b7bb6-b85f-460d-9792-73a71507f728" />
