### PR TITLE
Improved endpoint function typing and readme

### DIFF
--- a/packages/graph-endpoints-beta/README.md
+++ b/packages/graph-endpoints-beta/README.md
@@ -1,25 +1,30 @@
 # Teams: Graph
 
 <p>
-    <a href="https://www.npmjs.com/package/@microsoft/teams.graphEndpointsBeta" target="_blank">
-        <img src="https://img.shields.io/npm/v/@microsoft/teams.graphEndpointsBeta/preview" />
+    <a href="https://www.npmjs.com/package/@microsoft/teams.graph-endpoints-beta" target="_blank">
+        <img src="https://img.shields.io/npm/v/@microsoft/teams.graph-endpoints-beta/preview" />
     </a>
-    <a href="https://www.npmjs.com/package/@microsoft/teams.graphEndpointsBeta?activeTab=code" target="_blank">
-        <img src="https://img.shields.io/bundlephobia/min/@microsoft/teams.graphEndpointsBeta" />
+    <a href="https://www.npmjs.com/package/@microsoft/teams.graph-endpoints-beta?activeTab=code" target="_blank">
+        <img src="https://img.shields.io/bundlephobia/min/@microsoft/teams.graph-endpoints-beta" />
     </a>
-    <a href="https://www.npmjs.com/package/@microsoft/teams.graphEndpointsBeta?activeTab=dependencies" target="_blank">
-        <img src="https://img.shields.io/librariesio/release/npm/@microsoft/teams.graphEndpointsBeta" />
+    <a href="https://www.npmjs.com/package/@microsoft/teams.graph-endpoints-beta?activeTab=dependencies" target="_blank">
+        <img src="https://img.shields.io/librariesio/release/npm/@microsoft/teams.graph-endpoints-beta" />
     </a>
-    <a href="https://www.npmjs.com/package/@microsoft/teams.graphEndpointsBeta" target="_blank">
-        <img src="https://img.shields.io/npm/dw/@microsoft/teams.graphEndpointsBeta" />
+    <a href="https://www.npmjs.com/package/@microsoft/teams.graph-endpoints-beta" target="_blank">
+        <img src="https://img.shields.io/npm/dw/@microsoft/teams.graph-endpoints-beta" />
     </a>
     <a href="https://microsoft.github.io/teams-ai" target="_blank">
         <img src="https://img.shields.io/badge/📖 docs-open-blue" />
     </a>
 </p>
 
-A collection of strongly typed request configuration builders for MSGraph beta endpoints, designed to be used
+A collection of strongly typed request configuration builders for Microsoft Graph preview endpoints, designed to be used
 together with <a href="https://www.npmjs.com/package/@microsoft/teams.graph" target="_blank">@microsoft/teams.graph</a>.
+
+Use this package if you need to call Microsoft Graph APIs that are still in preview. Note that these APIs are subject to
+change. We don't recommend that you use them in your production apps.
+
+To use APIs that are generally available, please refer to <a href="https://www.npmjs.com/package/@microsoft/teams.graph-endpoints" target="_blank">@microsoft/teams.graph-endpoints</a>.
 
 <a href="https://microsoft.github.io/teams-ai" target="_blank">
     <img src="https://img.shields.io/badge/📖 Getting Started-blue?style=for-the-badge" />
@@ -28,11 +33,13 @@ together with <a href="https://www.npmjs.com/package/@microsoft/teams.graph" tar
 ## Install
 
 ```bash
-$: npm install @microsoft/teams.graphEndpointsBeta
+$: npm install @microsoft/teams.graph-endpoints-beta
 ```
 
 ## Links
 
+- [Microsoft Graph REST API beta endpoint reference](https://learn.microsoft.com/en-us/graph/api/overview?view=graph-rest-beta)
+
 ## Dependencies
 
--   none
+- None

--- a/packages/graph-endpoints/README.md
+++ b/packages/graph-endpoints/README.md
@@ -1,26 +1,27 @@
 # Teams: Graph
 
 <p>
-    <a href="https://www.npmjs.com/package/@microsoft/teams.graphEndpoints" target="_blank">
-        <img src="https://img.shields.io/npm/v/@microsoft/teams.graphEndpoints/preview" />
+    <a href="https://www.npmjs.com/package/@microsoft/teams.graph-endpoints" target="_blank">
+        <img src="https://img.shields.io/npm/v/@microsoft/teams.graph-endpoints/preview" />
     </a>
-    <a href="https://www.npmjs.com/package/@microsoft/teams.graphEndpoints?activeTab=code" target="_blank">
-        <img src="https://img.shields.io/bundlephobia/min/@microsoft/teams.graphEndpoints" />
+    <a href="https://www.npmjs.com/package/@microsoft/teams.graph-endpoints?activeTab=code" target="_blank">
+        <img src="https://img.shields.io/bundlephobia/min/@microsoft/teams.graph-endpoints" />
     </a>
-    <a href="https://www.npmjs.com/package/@microsoft/teams.graphEndpoints?activeTab=dependencies" target="_blank">
-        <img src="https://img.shields.io/librariesio/release/npm/@microsoft/teams.graphEndpoints" />
+    <a href="https://www.npmjs.com/package/@microsoft/teams.graph-endpoints?activeTab=dependencies" target="_blank">
+        <img src="https://img.shields.io/librariesio/release/npm/@microsoft/teams.graph-endpoints" />
     </a>
-    <a href="https://www.npmjs.com/package/@microsoft/teams.graphEndpoints" target="_blank">
-        <img src="https://img.shields.io/npm/dw/@microsoft/teams.graphEndpoints" />
+    <a href="https://www.npmjs.com/package/@microsoft/teams.graph-endpoints" target="_blank">
+        <img src="https://img.shields.io/npm/dw/@microsoft/teams.graph-endpoints" />
     </a>
     <a href="https://microsoft.github.io/teams-ai" target="_blank">
         <img src="https://img.shields.io/badge/📖 docs-open-blue" />
     </a>
 </p>
 
-A collection of strongly typed request configuration builders for MSGraph endpoints, designed to be used
+A collection of strongly typed request configuration builders for Microsoft Graph endpoints, designed to be used
 together with <a href="https://www.npmjs.com/package/@microsoft/teams.graph" target="_blank">@microsoft/teams.graph</a>.
 
+Use this package to call Microsoft Graph APIs that have reached general availability (GA), and have gone through a rigorous review-and-feedback process with customers to meet practical, production needs.
 
 <a href="https://microsoft.github.io/teams-ai" target="_blank">
     <img src="https://img.shields.io/badge/📖 Getting Started-blue?style=for-the-badge" />
@@ -29,11 +30,13 @@ together with <a href="https://www.npmjs.com/package/@microsoft/teams.graph" tar
 ## Install
 
 ```bash
-$: npm install @microsoft/teams.graphEndpoints
+$: npm install @microsoft/teams.graph-endpoints
 ```
 
 ## Links
 
+- [Microsoft Graph REST API v1.0 endpoint reference](https://learn.microsoft.com/en-us/graph/api/overview?view=graph-rest-1.0)
+
 ## Dependencies
 
-- axios
+- None

--- a/packages/graph-endpoints/src/me/appRoleAssignments.ts
+++ b/packages/graph-endpoints/src/me/appRoleAssignments.ts
@@ -104,14 +104,11 @@ export function update(
  *
  */
 export function create(
-  body: IEndpoints['POST /me/appRoleAssignments']['body'],
-  params?: IEndpoints['POST /me/appRoleAssignments']['parameters']
+  body: IEndpoints['POST /me/appRoleAssignments']['body']
 ): EndpointRequest<IEndpoints['POST /me/appRoleAssignments']['response']> {
   return {
     method: 'post',
     path: '/me/appRoleAssignments',
-    paramDefs: [],
-    params,
     body,
   };
 }

--- a/packages/graph-endpoints/src/me/removeAllDevicesFromManagement.ts
+++ b/packages/graph-endpoints/src/me/removeAllDevicesFromManagement.ts
@@ -12,15 +12,11 @@ export interface IEndpoints {
  *
  * Retire all devices from management for this user
  */
-export function create(
-  body: IEndpoints['POST /me/removeAllDevicesFromManagement']['body'],
-  params?: IEndpoints['POST /me/removeAllDevicesFromManagement']['parameters']
-): EndpointRequest<IEndpoints['POST /me/removeAllDevicesFromManagement']['response']> {
+export function create(): EndpointRequest<
+  IEndpoints['POST /me/removeAllDevicesFromManagement']['response']
+> {
   return {
     method: 'post',
     path: '/me/removeAllDevicesFromManagement',
-    paramDefs: [],
-    params,
-    body,
   };
 }

--- a/packages/graph-endpoints/src/me/reprocessLicenseAssignment.ts
+++ b/packages/graph-endpoints/src/me/reprocessLicenseAssignment.ts
@@ -9,15 +9,11 @@ export interface IEndpoints {
  *
  * Reprocess all group-based license assignments for the user. To learn more about group-based licensing, see What is group-based licensing in Microsoft Entra ID. Also see Identify and resolve license assignment problems for a group in Microsoft Entra ID for more details.
  */
-export function create(
-  body: IEndpoints['POST /me/reprocessLicenseAssignment']['body'],
-  params?: IEndpoints['POST /me/reprocessLicenseAssignment']['parameters']
-): EndpointRequest<IEndpoints['POST /me/reprocessLicenseAssignment']['response']> {
+export function create(): EndpointRequest<
+  IEndpoints['POST /me/reprocessLicenseAssignment']['response']
+> {
   return {
     method: 'post',
     path: '/me/reprocessLicenseAssignment',
-    paramDefs: [],
-    params,
-    body,
   };
 }

--- a/packages/graph-endpoints/src/me/retryServiceProvisioning.ts
+++ b/packages/graph-endpoints/src/me/retryServiceProvisioning.ts
@@ -9,15 +9,11 @@ export interface IEndpoints {
  *
  * Retry the provisioning of a user object in Microsoft Entra ID.
  */
-export function create(
-  body: IEndpoints['POST /me/retryServiceProvisioning']['body'],
-  params?: IEndpoints['POST /me/retryServiceProvisioning']['parameters']
-): EndpointRequest<IEndpoints['POST /me/retryServiceProvisioning']['response']> {
+export function create(): EndpointRequest<
+  IEndpoints['POST /me/retryServiceProvisioning']['response']
+> {
   return {
     method: 'post',
     path: '/me/retryServiceProvisioning',
-    paramDefs: [],
-    params,
-    body,
   };
 }

--- a/packages/graph-endpoints/src/me/sendMail.ts
+++ b/packages/graph-endpoints/src/me/sendMail.ts
@@ -10,14 +10,11 @@ export interface IEndpoints {
  * Send the message specified in the request body using either JSON or MIME format. When using JSON format, you can include a file attachment in the same sendMail action call. When using MIME format: This method saves the message in the Sent Items folder. Alternatively, create a draft message to send later. To learn more about the steps involved in the backend before a mail is delivered to recipients, see here.
  */
 export function create(
-  body: IEndpoints['POST /me/sendMail']['body'],
-  params?: IEndpoints['POST /me/sendMail']['parameters']
+  body: IEndpoints['POST /me/sendMail']['body']
 ): EndpointRequest<IEndpoints['POST /me/sendMail']['response']> {
   return {
     method: 'post',
     path: '/me/sendMail',
-    paramDefs: [],
-    params,
     body,
   };
 }

--- a/packages/graph-endpoints/src/types/common.ts
+++ b/packages/graph-endpoints/src/types/common.ts
@@ -4,7 +4,7 @@ import type { paths } from './types.ts';
 export type EndpointRequest<TResponse> = {
   method: 'get' | 'post' | 'patch' | 'delete' | 'put';
   path: string;
-  paramDefs: Array<{ name: string; in: 'query' | 'header' | 'path' }>;
+  paramDefs?: Array<{ name: string; in: 'query' | 'header' | 'path' }>;
   params?: Record<string, any>;
   body?: any;
   responseType?: TResponse; 

--- a/packages/graph-tools/src/endpoints.ts
+++ b/packages/graph-tools/src/endpoints.ts
@@ -62,6 +62,7 @@ interface IEndpoint {
   readonly parameters?: Array<OpenAPIV3.ParameterObject>;
   readonly description?: string;
   readonly deprecated?: boolean;
+  readonly hasRequestBody: boolean;
 }
 
 class Client {
@@ -205,6 +206,11 @@ class Client {
         name = name.slice(0, name.length - 1);
       }
 
+      if (method === 'delete') {
+        // 'delete' is a reserved word and can't be used as function name
+        name = 'del';
+      }
+
       this.endpoints[`${method.toUpperCase()} ${schema.url}`] = {
         method,
         name: this.getUniqueName(name),
@@ -212,6 +218,7 @@ class Client {
         parameters: params,
         description: def.description,
         deprecated: def.deprecated,
+        hasRequestBody: !!def.requestBody,
       };
     }
   }

--- a/packages/graph-tools/templates/client.ts.hbs
+++ b/packages/graph-tools/templates/client.ts.hbs
@@ -27,50 +27,13 @@ export interface IEndpoints {
   * @deprecated
   {{/if}}
   */
-{{#if (eq method "get")}}
 export function {{name}}(
-  params?: IEndpoints['{{@key}}']['parameters'], 
-  ) : EndpointRequest<IEndpoints['{{@key}}']['response']> {
-  return {
-    {{#if (eq ../apiVersion "beta")}}
-    ver: 'beta',
-    {{/if}}
-    method: 'get',
-    path: '{{url}}',
-    paramDefs: [
-      {{#if (notEmpty parameters)}}
-      {{#each parameters}}
-      { name: '{{name}}', in: '{{in}}' },
-      {{/each}}
-      {{/if}}
-    ],
-    params
-  };
-}
-{{else if (eq method "delete")}}
-export function del(
-  params?: IEndpoints['{{@key}}']['parameters'], 
-) : EndpointRequest<IEndpoints['{{@key}}']['response']> {
-  return {
-    {{#if (eq ../apiVersion "beta")}}
-    ver: 'beta',
-    {{/if}}
-    method: 'delete',
-    path: '{{url}}',
-    paramDefs: [
-      {{#if (notEmpty parameters)}}
-      {{#each parameters}}
-      { name: '{{name}}', in: '{{in}}' },
-      {{/each}}
-      {{/if}}
-    ],
-    params
-  };
-}
-{{else}}
-export function {{name}}(
+  {{#if hasRequestBody}}
   body: IEndpoints['{{@key}}']['body'],
+  {{/if}}
+  {{#if (notEmpty parameters)}}
   params?: IEndpoints['{{@key}}']['parameters'],
+  {{/if}}
 ) : EndpointRequest<IEndpoints['{{@key}}']['response']> {
   return {
     {{#if (eq ../apiVersion "beta")}}
@@ -78,17 +41,18 @@ export function {{name}}(
     {{/if}}
     method: '{{method}}',
     path: '{{url}}',
+    {{#if (notEmpty parameters)}}
     paramDefs: [
-      {{#if (notEmpty parameters)}}
       {{#each parameters}}
       { name: '{{name}}', in: '{{in}}' },
       {{/each}}
-      {{/if}}
     ],
     params,
+    {{/if}}
+    {{#if hasRequestBody}}
     body,
+    {{/if}}
   };
 }
-{{/if}}
 
 {{/each}}

--- a/packages/graph-tools/templates/common.ts.hbs
+++ b/packages/graph-tools/templates/common.ts.hbs
@@ -7,7 +7,7 @@ export type EndpointRequest<TResponse> = {
 {{/if}}
   method: 'get' | 'post' | 'patch' | 'delete' | 'put';
   path: string;
-  paramDefs: Array<{ name: string; in: 'query' | 'header' | 'path' }>;
+  paramDefs?: Array<{ name: string; in: 'query' | 'header' | 'path' }>;
   params?: Record<string, any>;
   body?: any;
   responseType?: TResponse; 

--- a/packages/graph/src/common.ts
+++ b/packages/graph/src/common.ts
@@ -16,7 +16,7 @@ export type EndpointRequest<TResponse> = {
   ver?: 'beta' | 'v1.0';
   method: 'get' | 'post' | 'patch' | 'delete' | 'put';
   path: string;
-  paramDefs: Array<{ name: string; in: 'query' | 'header' | 'path' }>;
+  paramDefs?: Array<{ name: string; in: 'query' | 'header' | 'path' }>;
   params?: Record<string, any>;
   body?: any;
   config?: http.RequestConfig;

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -9,6 +9,7 @@ import { ApplicationTemplatesClient } from './applicationTemplates';
 import { ApplicationsClient } from './applications';
 import { ChatsClient } from './chats';
 import { CommunicationsClient } from './communications';
+export { CallOptions, EndpointRequest } from './common';
 import { EmployeeExperienceClient } from './employeeExperience';
 import { MeClient } from './me';
 import { SitesClient } from './sites';
@@ -93,7 +94,7 @@ export class Client {
 
     const requestConfig = hasOptions ? (lastArg as CallOptions).requestConfig : undefined;
 
-    const { method, path, paramDefs, params, body } = func(...(funcArgs as any[]));
+    const { method, path, paramDefs = [], params, body } = func(...(funcArgs as any[]));
     const url = getInjectedUrl(path, paramDefs, params || {});
 
     switch (method) {


### PR DESCRIPTION
This PR improves the endpoint functions to not generate body & parameter arguments for APIs that don't need them. This reduces type clutter a little, and avoids generating impossible signatures.

For instance, `POST /me/reprocessLicenseAssignment` was generated with this effective signature:
`function create(body: never, params?: {} | undefined) : whatever`

This API doesn't take any body or params at all, so the types.ts `requestBody` type for this API is 'never'. Our code has assumed that all non-get, non-delete APIs will always require a body however, so we've been happily generating the `body` argument. The result is that `body: never` argument - which is problematic as there's nothing I can pass to satisfy it. 

The empty `params` type is not problematic as such, but it's a bit of clutter.

To make this PR reviewable, I only re-generated a handful of endpoints to show the difference before/after the changes. and keep the PR readable I'm planning to re-generate everything next week and that'll propagate the fixes.

Other minor things
 - paramDefs are made optional in the EndpointRequest type, to match params and reduce clutter
 - the EndpointRequest and CallOptions types are exported out of the Graph client, to make it easier to make custom endpoint functions.
 - the graph-endpoints and graph-endpoints-beta readmes are updated to correct links & instructions.

