### PR TITLE
Do not stream AI messages all the time

### DIFF
--- a/packages/ai/src/prompts/chat.ts
+++ b/packages/ai/src/prompts/chat.ts
@@ -243,7 +243,7 @@ export class ChatPrompt<
         messages,
         request: options.request,
         functions: fnMap,
-        onChunk: async (chunk) => {
+        onChunk: onChunk ? async (chunk) => {
           if (!chunk || !onChunk) return;
           buffer += chunk;
 
@@ -253,7 +253,7 @@ export class ChatPrompt<
           } catch (err) {
             return;
           }
-        },
+        } : undefined,
         autoFunctionCalling: options.autoFunctionCalling,
       }
     );


### PR DESCRIPTION
We were sending in onChunk all the time, so all AI messages were streamed. I this PR, we only send onChunk if it's actually provided.