### PR TITLE
Update graph client to allow for different national clouds and route beta endpoint requests correctly

### DIFF
--- a/packages/graph/src/index.spec.ts
+++ b/packages/graph/src/index.spec.ts
@@ -21,14 +21,14 @@ jest.mock('./utils/url', () => ({
   }),
 }));
 
-describe('Client.call', () => {
-  let client: Client;
+describe('Client', () => {
   let mockHttpClient: jest.Mocked<http.Client>;
+  let mockBetaHttpClient: jest.Mocked<http.Client>;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // Create mock HTTP client
+    // Create mock HTTP client for v1.0
     mockHttpClient = {
       get: jest.fn(),
       post: jest.fn(),
@@ -38,53 +38,260 @@ describe('Client.call', () => {
       clone: jest.fn(),
     } as any;
 
+    // Create mock HTTP client for beta
+    mockBetaHttpClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+      patch: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+      clone: jest.fn(),
+    } as any;
+
+    // Setup clone to return beta client
+    mockHttpClient.clone.mockReturnValue(mockBetaHttpClient);
+
     (http.Client as jest.MockedClass<typeof http.Client>).mockImplementation(
       () => mockHttpClient,
     );
-
-    client = new Client();
   });
 
-  describe('GET requests', () => {
-    it('should make a GET request with correct URL', async () => {
-      const mockResponse = { data: { id: '123', name: 'Test User' } };
-      mockHttpClient.get.mockResolvedValue(mockResponse);
-
-      const mockEndpoint = jest.fn(
-        (): EndpointRequest<any> => ({
-          method: 'get',
-          path: '/users/{id}',
-          paramDefs: [{ name: 'id', in: 'path' }],
-          params: { id: '123' },
-        }),
-      );
-
-      const result = await client.call(mockEndpoint);
-
-      expect(mockHttpClient.get).toHaveBeenCalledWith('/users/123', undefined);
-      expect(result).toEqual({ id: '123', name: 'Test User' });
+  describe('constructor', () => {
+    it('should create client with default base URL', () => {
+      new Client();
+      
+      expect(http.Client).toHaveBeenCalledWith({
+        baseUrl: 'https://graph.microsoft.com/v1.0',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': expect.stringMatching(/^teams\.ts\[graph\]\/.+/),
+        },
+      });
     });
 
-    it('should make a GET request with request config', async () => {
-      const mockResponse = { data: { id: '123' } };
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+    it('should create client with custom national cloud base URL', () => {
+      new Client({ 
+        baseUrlRoot: 'https://graph.microsoft.us' 
+      });
+      
+      expect(http.Client).toHaveBeenCalledWith({
+        baseUrlRoot: 'https://graph.microsoft.us',
+        baseUrl: 'https://graph.microsoft.us/v1.0',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': expect.stringMatching(/^teams\.ts\[graph\]\/.+/),
+        },
+      });
+    });
 
-      const mockEndpoint = jest.fn(
-        (): EndpointRequest<any> => ({
-          method: 'get',
-          path: '/users',
-          paramDefs: [],
-        }),
-      );
+    it('should create client with custom options and preserve base URL root', () => {
+      const customHeaders = { 'Authorization': 'Bearer token123' };
+      new Client({ 
+        baseUrlRoot: 'https://graph.microsoft.de',
+        headers: customHeaders,
+        timeout: 10000 
+      });
+      
+      expect(http.Client).toHaveBeenCalledWith({
+        baseUrlRoot: 'https://graph.microsoft.de',
+        timeout: 10000,
+        baseUrl: 'https://graph.microsoft.de/v1.0',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': expect.stringMatching(/^teams\.ts\[graph\]\/.+/),
+          'Authorization': 'Bearer token123',
+        },
+      });
+    });
 
-      const requestConfig = { timeout: 5000 };
-      await client.call(mockEndpoint, { requestConfig });
-
-      expect(mockHttpClient.get).toHaveBeenCalledWith('/users', requestConfig);
+    it('should clone existing client with custom base URL root', () => {
+      const existingClient = { 
+        ...mockHttpClient, 
+        request: jest.fn(),
+        clone: jest.fn().mockReturnValue(mockHttpClient)
+      };
+      new Client(existingClient as any);
+      
+      expect(existingClient.clone).toHaveBeenCalledWith({
+        baseUrl: 'https://graph.microsoft.com/v1.0',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': expect.stringMatching(/^teams\.ts\[graph\]\/.+/),
+        },
+      });
     });
   });
 
-  describe('POST requests', () => {
+  describe('call method', () => {
+    let client: Client;
+
+    beforeEach(() => {
+      client = new Client();
+    });
+
+      describe('v1.0 endpoint requests', () => {
+      it('should make a GET request to v1.0 endpoint', async () => {
+        const mockResponse = { data: { id: '123', name: 'Test User' } };
+        mockHttpClient.get.mockResolvedValue(mockResponse);
+
+        const mockEndpoint = jest.fn(
+          (): EndpointRequest<any> => ({
+            ver: 'v1.0',
+            method: 'get',
+            path: '/users/{id}',
+            paramDefs: [{ name: 'id', in: 'path' }],
+            params: { id: '123' },
+          }),
+        );
+
+        const result = await client.call(mockEndpoint);
+
+        expect(mockHttpClient.get).toHaveBeenCalledWith('/users/123', undefined);
+        expect(mockBetaHttpClient.get).not.toHaveBeenCalled();
+        expect(result).toEqual({ id: '123', name: 'Test User' });
+      });
+
+      it('should make a GET request to v1.0 endpoint when no version specified', async () => {
+        const mockResponse = { data: { id: '123', name: 'Test User' } };
+        mockHttpClient.get.mockResolvedValue(mockResponse);
+
+        const mockEndpoint = jest.fn(
+          (): EndpointRequest<any> => ({
+            method: 'get',
+            path: '/users/{id}',
+            paramDefs: [{ name: 'id', in: 'path' }],
+            params: { id: '123' },
+          }),
+        );
+
+        const result = await client.call(mockEndpoint);
+
+        expect(mockHttpClient.get).toHaveBeenCalledWith('/users/123', undefined);
+        expect(mockBetaHttpClient.get).not.toHaveBeenCalled();
+        expect(result).toEqual({ id: '123', name: 'Test User' });
+      });
+    });
+
+    describe('beta endpoint requests', () => {
+      it('should make a GET request to beta endpoint', async () => {
+        const mockResponse = { data: { id: '123', name: 'Test User' } };
+        mockBetaHttpClient.get.mockResolvedValue(mockResponse);
+
+        const mockEndpoint = jest.fn(
+          (): EndpointRequest<any> => ({
+            ver: 'beta',
+            method: 'get',
+            path: '/users/{id}',
+            paramDefs: [{ name: 'id', in: 'path' }],
+            params: { id: '123' },
+          }),
+        );
+
+        const result = await client.call(mockEndpoint);
+
+        expect(mockHttpClient.clone).toHaveBeenCalledWith({
+          baseUrl: 'https://graph.microsoft.com/beta',
+        });
+        expect(mockBetaHttpClient.get).toHaveBeenCalledWith('/users/123', undefined);
+        expect(mockHttpClient.get).not.toHaveBeenCalled();
+        expect(result).toEqual({ id: '123', name: 'Test User' });
+      });
+
+      it('should reuse beta client for subsequent beta requests', async () => {
+        const mockResponse = { data: { id: '123' } };
+        mockBetaHttpClient.get.mockResolvedValue(mockResponse);
+
+        const mockEndpoint = jest.fn(
+          (): EndpointRequest<any> => ({
+            ver: 'beta',
+            method: 'get',
+            path: '/users/{id}',
+            paramDefs: [{ name: 'id', in: 'path' }],
+            params: { id: '123' },
+          }),
+        );
+
+        // Make two beta requests
+        await client.call(mockEndpoint);
+        await client.call(mockEndpoint);
+
+        // Clone should only be called once
+        expect(mockHttpClient.clone).toHaveBeenCalledTimes(1);
+        expect(mockBetaHttpClient.get).toHaveBeenCalledTimes(2);
+      });
+
+      it('should make a POST request to beta endpoint with custom base URL', async () => {
+        const customClient = new Client({ 
+          baseUrlRoot: 'https://graph.microsoft.us' 
+        });
+        const mockResponse = { data: { id: '456', name: 'New User' } };
+        mockBetaHttpClient.post.mockResolvedValue(mockResponse);
+
+        const mockEndpoint = jest.fn(
+          (data: any): EndpointRequest<any> => ({
+            ver: 'beta',
+            method: 'post',
+            path: '/users',
+            paramDefs: [],
+            body: data,
+          }),
+        );
+
+        const userData = { name: 'New User', email: 'test@example.com' };
+        const result = await customClient.call(mockEndpoint, userData);
+
+        expect(mockHttpClient.clone).toHaveBeenCalledWith({
+          baseUrl: 'https://graph.microsoft.us/beta',
+        });
+        expect(mockBetaHttpClient.post).toHaveBeenCalledWith(
+          '/users',
+          userData,
+          undefined,
+        );
+        expect(result).toEqual({ id: '456', name: 'New User' });
+      });
+    });
+
+    describe('GET requests', () => {
+      it('should make a GET request with correct URL', async () => {
+        const mockResponse = { data: { id: '123', name: 'Test User' } };
+        mockHttpClient.get.mockResolvedValue(mockResponse);
+
+        const mockEndpoint = jest.fn(
+          (): EndpointRequest<any> => ({
+            method: 'get',
+            path: '/users/{id}',
+            paramDefs: [{ name: 'id', in: 'path' }],
+            params: { id: '123' },
+          }),
+        );
+
+        const result = await client.call(mockEndpoint);
+
+        expect(mockHttpClient.get).toHaveBeenCalledWith('/users/123', undefined);
+        expect(result).toEqual({ id: '123', name: 'Test User' });
+      });
+
+      it('should make a GET request with request config', async () => {
+        const mockResponse = { data: { id: '123' } };
+        mockHttpClient.get.mockResolvedValue(mockResponse);
+
+        const mockEndpoint = jest.fn(
+          (): EndpointRequest<any> => ({
+            method: 'get',
+            path: '/users',
+            paramDefs: [],
+          }),
+        );
+
+        const requestConfig = { timeout: 5000 };
+        await client.call(mockEndpoint, { requestConfig });
+
+        expect(mockHttpClient.get).toHaveBeenCalledWith('/users', requestConfig);
+      });
+    });
+
+    describe('POST requests', () => {
     it('should make a POST request with body', async () => {
       const mockResponse = { data: { id: '456', name: 'New User' } };
       mockHttpClient.post.mockResolvedValue(mockResponse);
@@ -304,36 +511,37 @@ describe('Client.call', () => {
       expect(mockEndpoint).toHaveBeenCalledWith('123');
       expect(mockHttpClient.get).toHaveBeenCalledWith('/users/123', undefined);
     });
-  });
-
-  describe('Error handling', () => {
-    it('should throw error for unsupported HTTP method', async () => {
-      const mockEndpoint = jest.fn(
-        (): EndpointRequest<any> => ({
-          method: 'trace' as any,
-          path: '/users',
-          paramDefs: [],
-        }),
-      );
-
-      await expect(client.call(mockEndpoint)).rejects.toThrow(
-        'Unsupported HTTP method: trace',
-      );
     });
 
-    it('should propagate HTTP client errors', async () => {
-      const mockError = new Error('Network error');
-      mockHttpClient.get.mockRejectedValue(mockError);
+    describe('Error handling', () => {
+      it('should throw error for unsupported HTTP method', async () => {
+        const mockEndpoint = jest.fn(
+          (): EndpointRequest<any> => ({
+            method: 'trace' as any,
+            path: '/users',
+            paramDefs: [],
+          }),
+        );
 
-      const mockEndpoint = jest.fn(
-        (): EndpointRequest<any> => ({
-          method: 'get',
-          path: '/users',
-          paramDefs: [],
-        }),
-      );
+        await expect(client.call(mockEndpoint)).rejects.toThrow(
+          'Unsupported HTTP method: trace',
+        );
+      });
 
-      await expect(client.call(mockEndpoint)).rejects.toThrow('Network error');
+      it('should propagate HTTP client errors', async () => {
+        const mockError = new Error('Network error');
+        mockHttpClient.get.mockRejectedValue(mockError);
+
+        const mockEndpoint = jest.fn(
+          (): EndpointRequest<any> => ({
+            method: 'get',
+            path: '/users',
+            paramDefs: [],
+          }),
+        );
+
+        await expect(client.call(mockEndpoint)).rejects.toThrow('Network error');
+      });
     });
   });
 });

--- a/packages/graph/src/index.spec.ts
+++ b/packages/graph/src/index.spec.ts
@@ -9,18 +9,6 @@ jest.mock('@microsoft/teams.common/http', () => ({
   Client: jest.fn(),
 }));
 
-// Mock the utils/url module
-jest.mock('./utils/url', () => ({
-  getInjectedUrl: jest.fn((path, _paramDefs, params) => {
-    // Simple mock implementation that replaces {param} with values
-    let url = path;
-    for (const [key, value] of Object.entries(params)) {
-      url = url.replace(`{${key}}`, String(value));
-    }
-    return url;
-  }),
-}));
-
 describe('Client', () => {
   let mockHttpClient: jest.Mocked<http.Client>;
   let mockBetaHttpClient: jest.Mocked<http.Client>;
@@ -59,7 +47,6 @@ describe('Client', () => {
   describe('constructor', () => {
     it('should create client with default base URL', () => {
       new Client();
-      
       expect(http.Client).toHaveBeenCalledWith({
         baseUrl: 'https://graph.microsoft.com/v1.0',
         headers: {
@@ -70,10 +57,10 @@ describe('Client', () => {
     });
 
     it('should create client with custom national cloud base URL', () => {
-      new Client({ 
-        baseUrlRoot: 'https://graph.microsoft.us' 
+      new Client({
+        baseUrlRoot: 'https://graph.microsoft.us',
       });
-      
+
       expect(http.Client).toHaveBeenCalledWith({
         baseUrlRoot: 'https://graph.microsoft.us',
         baseUrl: 'https://graph.microsoft.us/v1.0',
@@ -85,13 +72,13 @@ describe('Client', () => {
     });
 
     it('should create client with custom options and preserve base URL root', () => {
-      const customHeaders = { 'Authorization': 'Bearer token123' };
-      new Client({ 
+      const customHeaders = { Authorization: 'Bearer token123' };
+      new Client({
         baseUrlRoot: 'https://graph.microsoft.de',
         headers: customHeaders,
-        timeout: 10000 
+        timeout: 10000,
       });
-      
+
       expect(http.Client).toHaveBeenCalledWith({
         baseUrlRoot: 'https://graph.microsoft.de',
         timeout: 10000,
@@ -99,19 +86,19 @@ describe('Client', () => {
         headers: {
           'Content-Type': 'application/json',
           'User-Agent': expect.stringMatching(/^teams\.ts\[graph\]\/.+/),
-          'Authorization': 'Bearer token123',
+          Authorization: 'Bearer token123',
         },
       });
     });
 
     it('should clone existing client with custom base URL root', () => {
-      const existingClient = { 
-        ...mockHttpClient, 
+      const existingClient = {
+        ...mockHttpClient,
         request: jest.fn(),
-        clone: jest.fn().mockReturnValue(mockHttpClient)
+        clone: jest.fn().mockReturnValue(mockHttpClient),
       };
       new Client(existingClient as any);
-      
+
       expect(existingClient.clone).toHaveBeenCalledWith({
         baseUrl: 'https://graph.microsoft.com/v1.0',
         headers: {
@@ -129,7 +116,7 @@ describe('Client', () => {
       client = new Client();
     });
 
-      describe('v1.0 endpoint requests', () => {
+    describe('v1.0 endpoint requests', () => {
       it('should make a GET request to v1.0 endpoint', async () => {
         const mockResponse = { data: { id: '123', name: 'Test User' } };
         mockHttpClient.get.mockResolvedValue(mockResponse);
@@ -146,7 +133,10 @@ describe('Client', () => {
 
         const result = await client.call(mockEndpoint);
 
-        expect(mockHttpClient.get).toHaveBeenCalledWith('/users/123', undefined);
+        expect(mockHttpClient.get).toHaveBeenCalledWith(
+          '/users/123',
+          undefined,
+        );
         expect(mockBetaHttpClient.get).not.toHaveBeenCalled();
         expect(result).toEqual({ id: '123', name: 'Test User' });
       });
@@ -166,7 +156,10 @@ describe('Client', () => {
 
         const result = await client.call(mockEndpoint);
 
-        expect(mockHttpClient.get).toHaveBeenCalledWith('/users/123', undefined);
+        expect(mockHttpClient.get).toHaveBeenCalledWith(
+          '/users/123',
+          undefined,
+        );
         expect(mockBetaHttpClient.get).not.toHaveBeenCalled();
         expect(result).toEqual({ id: '123', name: 'Test User' });
       });
@@ -192,7 +185,10 @@ describe('Client', () => {
         expect(mockHttpClient.clone).toHaveBeenCalledWith({
           baseUrl: 'https://graph.microsoft.com/beta',
         });
-        expect(mockBetaHttpClient.get).toHaveBeenCalledWith('/users/123', undefined);
+        expect(mockBetaHttpClient.get).toHaveBeenCalledWith(
+          '/users/123',
+          undefined,
+        );
         expect(mockHttpClient.get).not.toHaveBeenCalled();
         expect(result).toEqual({ id: '123', name: 'Test User' });
       });
@@ -221,8 +217,8 @@ describe('Client', () => {
       });
 
       it('should make a POST request to beta endpoint with custom base URL', async () => {
-        const customClient = new Client({ 
-          baseUrlRoot: 'https://graph.microsoft.us' 
+        const customClient = new Client({
+          baseUrlRoot: 'https://graph.microsoft.us',
         });
         const mockResponse = { data: { id: '456', name: 'New User' } };
         mockBetaHttpClient.post.mockResolvedValue(mockResponse);
@@ -268,7 +264,10 @@ describe('Client', () => {
 
         const result = await client.call(mockEndpoint);
 
-        expect(mockHttpClient.get).toHaveBeenCalledWith('/users/123', undefined);
+        expect(mockHttpClient.get).toHaveBeenCalledWith(
+          '/users/123',
+          undefined,
+        );
         expect(result).toEqual({ id: '123', name: 'Test User' });
       });
 
@@ -287,260 +286,690 @@ describe('Client', () => {
         const requestConfig = { timeout: 5000 };
         await client.call(mockEndpoint, { requestConfig });
 
-        expect(mockHttpClient.get).toHaveBeenCalledWith('/users', requestConfig);
+        expect(mockHttpClient.get).toHaveBeenCalledWith(
+          '/users',
+          requestConfig,
+        );
       });
     });
 
     describe('POST requests', () => {
-    it('should make a POST request with body', async () => {
-      const mockResponse = { data: { id: '456', name: 'New User' } };
-      mockHttpClient.post.mockResolvedValue(mockResponse);
-
-      const mockEndpoint = jest.fn(
-        (data: any): EndpointRequest<any> => ({
-          method: 'post',
-          path: '/users',
-          paramDefs: [],
-          body: data,
-        }),
-      );
-
-      const userData = { name: 'New User', email: 'test@example.com' };
-      const result = await client.call(mockEndpoint, userData);
-
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        '/users',
-        userData,
-        undefined,
-      );
-      expect(result).toEqual({ id: '456', name: 'New User' });
-    });
-
-    it('should make a POST request with body and request config', async () => {
-      const mockResponse = { data: { id: '456' } };
-      mockHttpClient.post.mockResolvedValue(mockResponse);
-
-      const mockEndpoint = jest.fn(
-        (data: any): EndpointRequest<any> => ({
-          method: 'post',
-          path: '/users',
-          paramDefs: [],
-          body: data,
-        }),
-      );
-
-      const userData = { name: 'New User' };
-      const requestConfig = { timeout: 10000 };
-
-      await client.call(mockEndpoint, userData, { requestConfig });
-
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        '/users',
-        userData,
-        requestConfig,
-      );
-    });
-  });
-
-  describe('PATCH requests', () => {
-    it('should make a PATCH request with body', async () => {
-      const mockResponse = { data: { id: '123', name: 'Updated User' } };
-      mockHttpClient.patch.mockResolvedValue(mockResponse);
-
-      const mockEndpoint = jest.fn(
-        (id: string, data: any): EndpointRequest<any> => ({
-          method: 'patch',
-          path: '/users/{id}',
-          paramDefs: [{ name: 'id', in: 'path' }],
-          params: { id },
-          body: data,
-        }),
-      );
-
-      const updateData = { name: 'Updated User' };
-      const result = await client.call(mockEndpoint, '123', updateData);
-
-      expect(mockHttpClient.patch).toHaveBeenCalledWith(
-        '/users/123',
-        updateData,
-        undefined,
-      );
-      expect(result).toEqual({ id: '123', name: 'Updated User' });
-    });
-  });
-
-  describe('PUT requests', () => {
-    it('should make a PUT request with body', async () => {
-      const mockResponse = { data: { id: '123', name: 'Replaced User' } };
-      mockHttpClient.put.mockResolvedValue(mockResponse);
-
-      const mockEndpoint = jest.fn(
-        (id: string, data: any): EndpointRequest<any> => ({
-          method: 'put',
-          path: '/users/{id}',
-          paramDefs: [{ name: 'id', in: 'path' }],
-          params: { id },
-          body: data,
-        }),
-      );
-
-      const replaceData = { name: 'Replaced User', email: 'new@example.com' };
-      const result = await client.call(mockEndpoint, '123', replaceData);
-
-      expect(mockHttpClient.put).toHaveBeenCalledWith(
-        '/users/123',
-        replaceData,
-        undefined,
-      );
-      expect(result).toEqual({ id: '123', name: 'Replaced User' });
-    });
-  });
-
-  describe('DELETE requests', () => {
-    it('should make a DELETE request', async () => {
-      const mockResponse = { data: null };
-      mockHttpClient.delete.mockResolvedValue(mockResponse);
-
-      const mockEndpoint = jest.fn(
-        (id: string): EndpointRequest<any> => ({
-          method: 'delete',
-          path: '/users/{id}',
-          paramDefs: [{ name: 'id', in: 'path' }],
-          params: { id },
-        }),
-      );
-
-      const result = await client.call(mockEndpoint, '123');
-
-      expect(mockHttpClient.delete).toHaveBeenCalledWith(
-        '/users/123',
-        undefined,
-      );
-      expect(result).toBeNull();
-    });
-
-    it('should make a DELETE request with request config', async () => {
-      const mockResponse = { data: null };
-      mockHttpClient.delete.mockResolvedValue(mockResponse);
-
-      const mockEndpoint = jest.fn(
-        (id: string): EndpointRequest<any> => ({
-          method: 'delete',
-          path: '/users/{id}',
-          paramDefs: [{ name: 'id', in: 'path' }],
-          params: { id },
-        }),
-      );
-
-      const requestConfig = { timeout: 3000 };
-      await client.call(mockEndpoint, '123', { requestConfig });
-
-      expect(mockHttpClient.delete).toHaveBeenCalledWith(
-        '/users/123',
-        requestConfig,
-      );
-    });
-  });
-
-  describe('Parameter handling', () => {
-    it('should correctly detect CallOptions when provided', async () => {
-      const mockResponse = { data: { id: '123' } };
-      mockHttpClient.get.mockResolvedValue(mockResponse);
-
-      const mockEndpoint = jest.fn(
-        (id: string): EndpointRequest<any> => ({
-          method: 'get',
-          path: '/users/{id}',
-          paramDefs: [{ name: 'id', in: 'path' }],
-          params: { id },
-        }),
-      );
-
-      const requestConfig = { timeout: 5000 };
-      await client.call(mockEndpoint, '123', { requestConfig });
-
-      expect(mockEndpoint).toHaveBeenCalledWith('123');
-      expect(mockHttpClient.get).toHaveBeenCalledWith(
-        '/users/123',
-        requestConfig,
-      );
-    });
-
-    it('should handle multiple function parameters with CallOptions', async () => {
-      const mockResponse = { data: { id: '123' } };
-      mockHttpClient.post.mockResolvedValue(mockResponse);
-
-      const mockEndpoint = jest.fn(
-        (id: string, data: any): EndpointRequest<any> => ({
-          method: 'post',
-          path: '/users/{id}/messages',
-          paramDefs: [{ name: 'id', in: 'path' }],
-          params: { id },
-          body: data,
-        }),
-      );
-
-      const messageData = { text: 'Hello' };
-      const requestConfig = { timeout: 2000 };
-
-      await client.call(mockEndpoint, '123', messageData, { requestConfig });
-
-      expect(mockEndpoint).toHaveBeenCalledWith('123', messageData);
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        '/users/123/messages',
-        messageData,
-        requestConfig,
-      );
-    });
-
-    it('should handle function calls without CallOptions', async () => {
-      const mockResponse = { data: { id: '123' } };
-      mockHttpClient.get.mockResolvedValue(mockResponse);
-
-      const mockEndpoint = jest.fn(
-        (id: string): EndpointRequest<any> => ({
-          method: 'get',
-          path: '/users/{id}',
-          paramDefs: [{ name: 'id', in: 'path' }],
-          params: { id },
-        }),
-      );
-
-      await client.call(mockEndpoint, '123');
-
-      expect(mockEndpoint).toHaveBeenCalledWith('123');
-      expect(mockHttpClient.get).toHaveBeenCalledWith('/users/123', undefined);
-    });
-    });
-
-    describe('Error handling', () => {
-      it('should throw error for unsupported HTTP method', async () => {
-        const mockEndpoint = jest.fn(
-          (): EndpointRequest<any> => ({
-            method: 'trace' as any,
-            path: '/users',
-            paramDefs: [],
-          }),
-        );
-
-        await expect(client.call(mockEndpoint)).rejects.toThrow(
-          'Unsupported HTTP method: trace',
-        );
+      beforeEach(() => {
+        client = new Client();
       });
 
-      it('should propagate HTTP client errors', async () => {
-        const mockError = new Error('Network error');
-        mockHttpClient.get.mockRejectedValue(mockError);
+      describe('v1.0 endpoint requests', () => {
+        it('should make a GET request to v1.0 endpoint', async () => {
+          const mockResponse = { data: { id: '123', name: 'Test User' } };
+          mockHttpClient.get.mockResolvedValue(mockResponse);
 
-        const mockEndpoint = jest.fn(
-          (): EndpointRequest<any> => ({
-            method: 'get',
-            path: '/users',
-            paramDefs: [],
-          }),
-        );
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              ver: 'v1.0',
+              method: 'get',
+              path: '/users/{id}',
+              paramDefs: [{ name: 'id', in: 'path' }],
+              params: { id: '123' },
+            }),
+          );
 
-        await expect(client.call(mockEndpoint)).rejects.toThrow('Network error');
+          const result = await client.call(mockEndpoint);
+
+          expect(mockHttpClient.get).toHaveBeenCalledWith(
+            '/users/123',
+            undefined,
+          );
+          expect(mockBetaHttpClient.get).not.toHaveBeenCalled();
+          expect(result).toEqual({ id: '123', name: 'Test User' });
+        });
+
+        it('should make a GET request to v1.0 endpoint when no version specified', async () => {
+          const mockResponse = { data: { id: '123', name: 'Test User' } };
+          mockHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              method: 'get',
+              path: '/users/{id}',
+              paramDefs: [{ name: 'id', in: 'path' }],
+              params: { id: '123' },
+            }),
+          );
+
+          const result = await client.call(mockEndpoint);
+
+          expect(mockHttpClient.get).toHaveBeenCalledWith(
+            '/users/123',
+            undefined,
+          );
+          expect(mockBetaHttpClient.get).not.toHaveBeenCalled();
+          expect(result).toEqual({ id: '123', name: 'Test User' });
+        });
+      });
+
+      describe('beta endpoint requests', () => {
+        it('should make a GET request to beta endpoint', async () => {
+          const mockResponse = { data: { id: '123', name: 'Test User' } };
+          mockBetaHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              ver: 'beta',
+              method: 'get',
+              path: '/users/{id}',
+              paramDefs: [{ name: 'id', in: 'path' }],
+              params: { id: '123' },
+            }),
+          );
+
+          const result = await client.call(mockEndpoint);
+
+          expect(mockHttpClient.clone).toHaveBeenCalledWith({
+            baseUrl: 'https://graph.microsoft.com/beta',
+          });
+          expect(mockBetaHttpClient.get).toHaveBeenCalledWith(
+            '/users/123',
+            undefined,
+          );
+          expect(mockHttpClient.get).not.toHaveBeenCalled();
+          expect(result).toEqual({ id: '123', name: 'Test User' });
+        });
+
+        it('should reuse beta client for subsequent beta requests', async () => {
+          const mockResponse = { data: { id: '123' } };
+          mockBetaHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              ver: 'beta',
+              method: 'get',
+              path: '/users/{id}',
+              paramDefs: [{ name: 'id', in: 'path' }],
+              params: { id: '123' },
+            }),
+          );
+
+          // Make two beta requests
+          await client.call(mockEndpoint);
+          await client.call(mockEndpoint);
+
+          // Clone should only be called once
+          expect(mockHttpClient.clone).toHaveBeenCalledTimes(1);
+          expect(mockBetaHttpClient.get).toHaveBeenCalledTimes(2);
+        });
+
+        it('should make a POST request to beta endpoint with custom base URL', async () => {
+          const customClient = new Client({
+            baseUrlRoot: 'https://graph.microsoft.us',
+          });
+          const mockResponse = { data: { id: '456', name: 'New User' } };
+          mockBetaHttpClient.post.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (data: any): EndpointRequest<any> => ({
+              ver: 'beta',
+              method: 'post',
+              path: '/users',
+              paramDefs: [],
+              body: data,
+            }),
+          );
+
+          const userData = { name: 'New User', email: 'test@example.com' };
+          const result = await customClient.call(mockEndpoint, userData);
+
+          expect(mockHttpClient.clone).toHaveBeenCalledWith({
+            baseUrl: 'https://graph.microsoft.us/beta',
+          });
+          expect(mockBetaHttpClient.post).toHaveBeenCalledWith(
+            '/users',
+            userData,
+            undefined,
+          );
+          expect(result).toEqual({ id: '456', name: 'New User' });
+        });
+      });
+
+      describe('GET requests', () => {
+        it('should make a GET request with correct URL', async () => {
+          const mockResponse = { data: { id: '123', name: 'Test User' } };
+          mockHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              method: 'get',
+              path: '/users/{id}',
+              paramDefs: [{ name: 'id', in: 'path' }],
+              params: { id: '123' },
+            }),
+          );
+
+          const result = await client.call(mockEndpoint);
+
+          expect(mockHttpClient.get).toHaveBeenCalledWith(
+            '/users/123',
+            undefined,
+          );
+          expect(result).toEqual({ id: '123', name: 'Test User' });
+        });
+
+        it('should make a GET request with request config', async () => {
+          const mockResponse = { data: { id: '123' } };
+          mockHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              method: 'get',
+              path: '/users',
+              paramDefs: [],
+            }),
+          );
+
+          const requestConfig = { timeout: 5000 };
+          await client.call(mockEndpoint, { requestConfig });
+
+          expect(mockHttpClient.get).toHaveBeenCalledWith(
+            '/users',
+            requestConfig,
+          );
+        });
+      });
+
+      describe('POST requests', () => {
+        it('should make a POST request with body', async () => {
+          const mockResponse = { data: { id: '456', name: 'New User' } };
+          mockHttpClient.post.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (data: any): EndpointRequest<any> => ({
+              method: 'post',
+              path: '/users',
+              paramDefs: [],
+              body: data,
+            }),
+          );
+
+          const userData = { name: 'New User', email: 'test@example.com' };
+          const result = await client.call(mockEndpoint, userData);
+
+          expect(mockHttpClient.post).toHaveBeenCalledWith(
+            '/users',
+            userData,
+            undefined,
+          );
+          expect(result).toEqual({ id: '456', name: 'New User' });
+        });
+
+        it('should make a POST request with body and request config', async () => {
+          const mockResponse = { data: { id: '456' } };
+          mockHttpClient.post.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (data: any): EndpointRequest<any> => ({
+              method: 'post',
+              path: '/users',
+              paramDefs: [],
+              body: data,
+            }),
+          );
+
+          const userData = { name: 'New User' };
+          const requestConfig = { timeout: 10000 };
+
+          await client.call(mockEndpoint, userData, { requestConfig });
+
+          expect(mockHttpClient.post).toHaveBeenCalledWith(
+            '/users',
+            userData,
+            requestConfig,
+          );
+        });
+      });
+
+      describe('PATCH requests', () => {
+        it('should make a PATCH request with body', async () => {
+          const mockResponse = { data: { id: '123', name: 'Updated User' } };
+          mockHttpClient.patch.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (id: string, data: any): EndpointRequest<any> => ({
+              method: 'patch',
+              path: '/users/{id}',
+              paramDefs: [{ name: 'id', in: 'path' }],
+              params: { id },
+              body: data,
+            }),
+          );
+
+          const updateData = { name: 'Updated User' };
+          const result = await client.call(mockEndpoint, '123', updateData);
+
+          expect(mockHttpClient.patch).toHaveBeenCalledWith(
+            '/users/123',
+            updateData,
+            undefined,
+          );
+          expect(result).toEqual({ id: '123', name: 'Updated User' });
+        });
+      });
+
+      describe('PUT requests', () => {
+        it('should make a PUT request with body', async () => {
+          const mockResponse = { data: { id: '123', name: 'Replaced User' } };
+          mockHttpClient.put.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (id: string, data: any): EndpointRequest<any> => ({
+              method: 'put',
+              path: '/users/{id}',
+              paramDefs: [{ name: 'id', in: 'path' }],
+              params: { id },
+              body: data,
+            }),
+          );
+
+          const replaceData = {
+            name: 'Replaced User',
+            email: 'new@example.com',
+          };
+          const result = await client.call(mockEndpoint, '123', replaceData);
+
+          expect(mockHttpClient.put).toHaveBeenCalledWith(
+            '/users/123',
+            replaceData,
+            undefined,
+          );
+          expect(result).toEqual({ id: '123', name: 'Replaced User' });
+        });
+      });
+
+      describe('DELETE requests', () => {
+        it('should make a DELETE request', async () => {
+          const mockResponse = { data: null };
+          mockHttpClient.delete.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (id: string): EndpointRequest<any> => ({
+              method: 'delete',
+              path: '/users/{id}',
+              paramDefs: [{ name: 'id', in: 'path' }],
+              params: { id },
+            }),
+          );
+
+          const result = await client.call(mockEndpoint, '123');
+
+          expect(mockHttpClient.delete).toHaveBeenCalledWith(
+            '/users/123',
+            undefined,
+          );
+          expect(result).toBeNull();
+        });
+
+        it('should make a DELETE request with request config', async () => {
+          const mockResponse = { data: null };
+          mockHttpClient.delete.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (id: string): EndpointRequest<any> => ({
+              method: 'delete',
+              path: '/users/{id}',
+              paramDefs: [{ name: 'id', in: 'path' }],
+              params: { id },
+            }),
+          );
+
+          const requestConfig = { timeout: 3000 };
+          await client.call(mockEndpoint, '123', { requestConfig });
+
+          expect(mockHttpClient.delete).toHaveBeenCalledWith(
+            '/users/123',
+            requestConfig,
+          );
+        });
+      });
+
+      describe('Parameter handling', () => {
+        it('should correctly detect CallOptions when provided', async () => {
+          const mockResponse = { data: { id: '123' } };
+          mockHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (id: string): EndpointRequest<any> => ({
+              method: 'get',
+              path: '/users/{id}',
+              paramDefs: [{ name: 'id', in: 'path' }],
+              params: { id },
+            }),
+          );
+
+          const requestConfig = { timeout: 5000 };
+          await client.call(mockEndpoint, '123', { requestConfig });
+
+          expect(mockEndpoint).toHaveBeenCalledWith('123');
+          expect(mockHttpClient.get).toHaveBeenCalledWith(
+            '/users/123',
+            requestConfig,
+          );
+        });
+
+        it('should handle multiple function parameters with CallOptions', async () => {
+          const mockResponse = { data: { id: '123' } };
+          mockHttpClient.post.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (id: string, data: any): EndpointRequest<any> => ({
+              method: 'post',
+              path: '/users/{id}/messages',
+              paramDefs: [{ name: 'id', in: 'path' }],
+              params: { id },
+              body: data,
+            }),
+          );
+
+          const messageData = { text: 'Hello' };
+          const requestConfig = { timeout: 2000 };
+
+          await client.call(mockEndpoint, '123', messageData, {
+            requestConfig,
+          });
+
+          expect(mockEndpoint).toHaveBeenCalledWith('123', messageData);
+          expect(mockHttpClient.post).toHaveBeenCalledWith(
+            '/users/123/messages',
+            messageData,
+            requestConfig,
+          );
+        });
+
+        it('should handle function calls without CallOptions', async () => {
+          const mockResponse = { data: { id: '123' } };
+          mockHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (id: string): EndpointRequest<any> => ({
+              method: 'get',
+              path: '/users/{id}',
+              paramDefs: [{ name: 'id', in: 'path' }],
+              params: { id },
+            }),
+          );
+
+          await client.call(mockEndpoint, '123');
+
+          expect(mockEndpoint).toHaveBeenCalledWith('123');
+          expect(mockHttpClient.get).toHaveBeenCalledWith(
+            '/users/123',
+            undefined,
+          );
+        });
+
+        it('should handle header parameters in v1.0 requests', async () => {
+          const mockResponse = { data: { value: [] } };
+          mockHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              method: 'get',
+              path: '/users',
+              paramDefs: [
+                { name: 'Authorization', in: 'header' },
+                { name: 'ConsistencyLevel', in: 'header' },
+              ],
+              params: {
+                Authorization: 'Bearer token123',
+                ConsistencyLevel: 'eventual',
+              },
+            }),
+          );
+
+          await client.call(mockEndpoint);
+
+          expect(mockHttpClient.get).toHaveBeenCalledWith('/users', {
+            headers: {
+              Authorization: 'Bearer token123',
+              ConsistencyLevel: 'eventual',
+            },
+          });
+        });
+
+        it('should handle header parameters in beta requests', async () => {
+          const mockResponse = { data: { value: [] } };
+          mockBetaHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              ver: 'beta',
+              method: 'get',
+              path: '/users',
+              paramDefs: [
+                { name: 'ConsistencyLevel', in: 'header' },
+                { name: 'count', in: 'query' },
+              ],
+              params: {
+                ConsistencyLevel: 'eventual',
+                count: true,
+              },
+            }),
+          );
+
+          await client.call(mockEndpoint);
+
+          expect(mockBetaHttpClient.get).toHaveBeenCalledWith(
+            '/users?count=true',
+            {
+              headers: {
+                ConsistencyLevel: 'eventual',
+              },
+            },
+          );
+        });
+
+        it('should handle mixed parameter types (path, query, header)', async () => {
+          const mockResponse = { data: { id: '123' } };
+          mockHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              method: 'get',
+              path: '/users/{userId}/messages',
+              paramDefs: [
+                { name: 'userId', in: 'path' },
+                { name: 'filter', in: 'query' },
+                { name: 'select', in: 'query' },
+                { name: 'Authorization', in: 'header' },
+                { name: 'If-Match', in: 'header' },
+              ],
+              params: {
+                userId: 'user-123',
+                filter: 'isRead eq false',
+                select: 'id,subject',
+                Authorization: 'Bearer token123',
+                'If-Match': '"etag-value"',
+              },
+            }),
+          );
+
+          await client.call(mockEndpoint);
+
+          expect(mockHttpClient.get).toHaveBeenCalledWith(
+            '/users/user-123/messages?filter=isRead%20eq%20false&select=id%2Csubject',
+            {
+              headers: {
+                Authorization: 'Bearer token123',
+                'If-Match': '"etag-value"',
+              },
+            },
+          );
+        });
+
+        it('should merge header parameters with existing request config', async () => {
+          const mockResponse = { data: { value: [] } };
+          mockHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              method: 'get',
+              path: '/users',
+              paramDefs: [
+                { name: 'Authorization', in: 'header' },
+                { name: 'ConsistencyLevel', in: 'header' },
+              ],
+              params: {
+                Authorization: 'Bearer token123',
+                ConsistencyLevel: 'eventual',
+              },
+            }),
+          );
+
+          const requestConfig = {
+            timeout: 10000,
+            headers: {
+              'Content-Type': 'application/json',
+              'User-Agent': 'MyApp/1.0',
+            },
+          };
+
+          await client.call(mockEndpoint, { requestConfig });
+
+          expect(mockHttpClient.get).toHaveBeenCalledWith('/users', {
+            timeout: 10000,
+            headers: {
+              'Content-Type': 'application/json',
+              'User-Agent': 'MyApp/1.0',
+              Authorization: 'Bearer token123',
+              ConsistencyLevel: 'eventual',
+            },
+          });
+        });
+
+        it('should handle POST request with header parameters and body', async () => {
+          const mockResponse = { data: { id: '123' } };
+          mockHttpClient.post.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (data: any): EndpointRequest<any> => ({
+              method: 'post',
+              path: '/users',
+              paramDefs: [
+                { name: 'Authorization', in: 'header' },
+                { name: 'ConsistencyLevel', in: 'header' },
+              ],
+              params: {
+                Authorization: 'Bearer token123',
+                ConsistencyLevel: 'eventual',
+              },
+              body: data,
+            }),
+          );
+
+          const userData = {
+            displayName: 'John Doe',
+            mail: 'john@contoso.com',
+          };
+          await client.call(mockEndpoint, userData);
+
+          expect(mockHttpClient.post).toHaveBeenCalledWith('/users', userData, {
+            headers: {
+              Authorization: 'Bearer token123',
+              ConsistencyLevel: 'eventual',
+            },
+          });
+        });
+
+        it('should handle header parameters with custom baseUrlRoot', async () => {
+          const customClient = new Client({
+            baseUrlRoot: 'https://graph.microsoft.us',
+          });
+          const mockResponse = { data: { value: [] } };
+          mockHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              method: 'get',
+              path: '/users/{id}',
+              paramDefs: [
+                { name: 'id', in: 'path' },
+                { name: 'Authorization', in: 'header' },
+              ],
+              params: {
+                id: 'user-123',
+                Authorization: 'Bearer token123',
+              },
+            }),
+          );
+
+          await customClient.call(mockEndpoint);
+
+          expect(mockHttpClient.get).toHaveBeenCalledWith('/users/user-123', {
+            headers: {
+              Authorization: 'Bearer token123',
+            },
+          });
+        });
+
+        it('should ignore header parameters with falsy values', async () => {
+          const mockResponse = { data: { value: [] } };
+          mockHttpClient.get.mockResolvedValue(mockResponse);
+
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              method: 'get',
+              path: '/users',
+              paramDefs: [
+                { name: 'Authorization', in: 'header' },
+                { name: 'ConsistencyLevel', in: 'header' },
+                { name: 'If-Match', in: 'header' },
+              ],
+              params: {
+                Authorization: 'Bearer token123',
+                ConsistencyLevel: null,
+                'If-Match': undefined,
+              },
+            }),
+          );
+
+          await client.call(mockEndpoint);
+
+          expect(mockHttpClient.get).toHaveBeenCalledWith('/users', {
+            headers: {
+              Authorization: 'Bearer token123',
+            },
+          });
+        });
+      });
+
+      describe('Error handling', () => {
+        it('should throw error for unsupported HTTP method', async () => {
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              method: 'trace' as any,
+              path: '/users',
+              paramDefs: [],
+            }),
+          );
+
+          await expect(client.call(mockEndpoint)).rejects.toThrow(
+            'Unsupported HTTP method: trace',
+          );
+        });
+
+        it('should propagate HTTP client errors', async () => {
+          const mockError = new Error('Network error');
+          mockHttpClient.get.mockRejectedValue(mockError);
+
+          const mockEndpoint = jest.fn(
+            (): EndpointRequest<any> => ({
+              method: 'get',
+              path: '/users',
+              paramDefs: [],
+            }),
+          );
+
+          await expect(client.call(mockEndpoint)).rejects.toThrow(
+            'Network error',
+          );
+        });
       });
     });
   });

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,13 +1,13 @@
 import * as http from '@microsoft/teams.common/http';
 
-import { getInjectedUrl } from './utils/url';
+import { getInjectedUrl, getInjectedRequestConfig } from './utils/url';
 
 import type { CallOptions, EndpointRequest, SchemaVersion } from './types';
 
 // Build-time constant injected by tsup
 declare const __PACKAGE_VERSION__: string;
 
-export { CallOptions, EndpointRequest } from './types';
+export { CallOptions, EndpointRequest, SchemaVersion } from './types';
 
 const defaultBaseUrlRoot = 'https://graph.microsoft.com';
 
@@ -92,20 +92,18 @@ export class Client {
 
     // Extract function arguments
     const funcArgs = hasOptions ? args.slice(0, -1) : args;
-
-    const requestConfig = hasOptions
-      ? (lastArg as CallOptions).requestConfig
-      : undefined;
+    const callOptions = hasOptions ? lastArg as CallOptions : undefined;
 
     const {
       ver = 'v1.0',
       method,
       path,
       paramDefs = [],
-      params,
+      params = {},
       body,
     } = func(...(funcArgs as any[]));
-    const url = getInjectedUrl(path, paramDefs, params || {});
+    const url = getInjectedUrl(path, paramDefs, params);
+    const requestConfig = getInjectedRequestConfig(paramDefs, params, callOptions?.requestConfig);
     const httpClient = this.getHttpClient(ver);
 
     switch (method) {

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -2,25 +2,36 @@ import * as http from '@microsoft/teams.common/http';
 
 import { getInjectedUrl } from './utils/url';
 
-import type { CallOptions, EndpointRequest } from './types';
+import type { CallOptions, EndpointRequest, SchemaVersion } from './types';
 
 // Build-time constant injected by tsup
 declare const __PACKAGE_VERSION__: string;
 
 export { CallOptions, EndpointRequest } from './types';
 
+const defaultBaseUrlRoot = 'https://graph.microsoft.com';
+
+type Options = (http.Client | http.ClientOptions) & {
+  /** Graph service root. By default, the global commercial URL "https://graph.microsoft.com" is used,
+   * but certain tenants may wish to override this to direct Graph API calls to a different cloud instance.
+   */
+  baseUrlRoot?: string;
+};
+
 /**
  * /
  * Provides an entry point for invoking Microsoft Graph APIs.
  */
 export class Client {
-  protected baseUrl = '/';
+  protected baseUrlRoot;
   protected http: http.Client;
+  protected betaHttp?: http.Client;
 
-  constructor(options?: http.Client | http.ClientOptions) {
+  constructor(options?: Options) {
+    this.baseUrlRoot = options?.baseUrlRoot ?? defaultBaseUrlRoot;
     if (!options) {
       this.http = new http.Client({
-        baseUrl: 'https://graph.microsoft.com/v1.0',
+        baseUrl: `${this.baseUrlRoot}/v1.0`,
         headers: {
           'Content-Type': 'application/json',
           'User-Agent': `teams.ts[graph]/${__PACKAGE_VERSION__}`,
@@ -28,7 +39,7 @@ export class Client {
       });
     } else if ('request' in options) {
       this.http = options.clone({
-        baseUrl: 'https://graph.microsoft.com/v1.0',
+        baseUrl: `${this.baseUrlRoot}/v1.0`,
         headers: {
           'Content-Type': 'application/json',
           'User-Agent': `teams.ts[graph]/${__PACKAGE_VERSION__}`,
@@ -37,7 +48,7 @@ export class Client {
     } else {
       this.http = new http.Client({
         ...options,
-        baseUrl: 'https://graph.microsoft.com/v1.0',
+        baseUrl: `${this.baseUrlRoot}/v1.0`,
         headers: {
           'Content-Type': 'application/json',
           'User-Agent': `teams.ts[graph]/${__PACKAGE_VERSION__}`,
@@ -87,6 +98,7 @@ export class Client {
       : undefined;
 
     const {
+      ver = 'v1.0',
       method,
       path,
       paramDefs = [],
@@ -94,17 +106,32 @@ export class Client {
       body,
     } = func(...(funcArgs as any[]));
     const url = getInjectedUrl(path, paramDefs, params || {});
+    const httpClient = this.getHttpClient(ver);
 
     switch (method) {
       case 'delete':
       case 'get':
-        return (await this.http[method](url, requestConfig)).data as R;
+        return (await httpClient[method](url, requestConfig)).data as R;
       case 'patch':
       case 'post':
       case 'put':
-        return (await this.http[method](url, body, requestConfig)).data as R;
+        return (await httpClient[method](url, body, requestConfig)).data as R;
       default:
         throw new Error(`Unsupported HTTP method: ${method}`);
     }
+  }
+
+  private getHttpClient(schemaVersion: SchemaVersion): http.Client {
+    if (schemaVersion === 'v1.0') {
+      return this.http;
+    }
+
+    this.betaHttp =
+      this.betaHttp ??
+      this.http.clone({
+        baseUrl: `${this.baseUrlRoot}/beta`,
+      });
+
+    return this.betaHttp;
   }
 }

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -1,6 +1,7 @@
 import * as http from '@microsoft/teams.common/http';
 
 export type SchemaVersion = 'beta' | 'v1.0';
+
 /**
  * Configuration options for the `call` method
  * @see {@link Client.call}

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -1,5 +1,6 @@
 import * as http from '@microsoft/teams.common/http';
 
+export type SchemaVersion = 'beta' | 'v1.0';
 /**
  * Configuration options for the `call` method
  * @see {@link Client.call}
@@ -10,7 +11,7 @@ export type CallOptions  = {
 };
 
 export type EndpointRequest<TResponse> = {
-  ver?: 'beta' | 'v1.0';
+  ver?: SchemaVersion;
   method: 'get' | 'post' | 'patch' | 'delete' | 'put';
   path: string;
   paramDefs?: Array<{ name: string; in: 'query' | 'header' | 'path' }>;

--- a/packages/graph/src/utils/url.ts
+++ b/packages/graph/src/utils/url.ts
@@ -1,5 +1,7 @@
 import qs from 'qs';
 
+import * as http from '@microsoft/teams.common/http';
+
 import { IParam } from './interfaces';
 
 export function getInjectedUrl(url: string, params: Array<IParam>, data: Record<string, any>) {
@@ -18,4 +20,23 @@ export function getInjectedUrl(url: string, params: Array<IParam>, data: Record<
   }
 
   return `${url}${qs.stringify(query, { addQueryPrefix: true, arrayFormat: 'comma' })}`;
+}
+
+export function getInjectedRequestConfig(
+  params: Array<IParam>,
+  data: Record<string, any>,
+  requestConfig?: http.RequestConfig
+): http.RequestConfig | undefined {
+
+  const paramHeaders = (params ?? []).reduce<Record<string, any>>((agg, param) => {
+    if (param.in === 'header' && data[param.name]) {
+      agg[param.name] = data[param.name];
+    }
+    return agg;
+   }, {});
+
+   return Object.keys(paramHeaders).length === 0 
+     ? requestConfig 
+    : {...requestConfig, headers: {...requestConfig?.headers, ...paramHeaders}};
+
 }


### PR DESCRIPTION
This PR has three changes to the graph client:

a) Adds a baseUrlRoot argument to let the graph client support different clouds. It still defaults to the public https://graph.microsoft.com, but can be overridden for special clouds.

b) In the call method, uses either /v1.0 or /beta baseUrl depending on the `ver` field in the endpoint request builder.

c) While testing, I realized that we never included the header parameters in the request. Query and path parameters - yes; header - no. This is a problem for instance for Graph APIs that rely on the `If-Match` header for optimistic concurrency -- e.g. [this one](https://learn.microsoft.com/en-us/graph/api/resources/planner-overview?view=graph-rest-1.0#planner-resource-versioning). The developer could work around that with the requestParams argument, but that's not nearly as convenient as just using the params - that are typed to support these headers anyway. Let's fix this too.

To test this, in a test app I call:
```
import * as endpoints from '@microsoft/teams.graph-endpoints';
import * as betaEndpoints from '@microsoft/teams.graph-endpoints-beta';
...
    const graph: Graph = app.graph;
    const betaMe = await graph.call(betaEndpoints.me.get);
    const v1Me = await graph.call(endpoints.me.get);
```

Network tab shows that the requests are routed correctly and both give the expected results.
<img width="1169" height="280" alt="image" src="https://github.com/user-attachments/assets/905fc436-feca-4999-b434-f2ef7dab1e66" />


To test the request header change, I called:
```
graph.call(endpoints.agreementAcceptances.del, { "agreementAcceptance-id": "bogus", "If-Match": "abc123" });
```
The network tab showed that the `If-Match` request header was not included before the change, but is included after the change.
