### PR TITLE
[bug] cli: remove unnecessary uv venv check

### DIFF
--- a/packages/cli/configs/atk/basic/python/.vscode/tasks.json
+++ b/packages/cli/configs/atk/basic/python/.vscode/tasks.json
@@ -71,7 +71,7 @@
     {
       "label": "setup-env",
       "type": "shell",
-      "command": "if (!(Test-Path -Path .venv -PathType Container)) { uv venv }; uv sync",
+      "command": "uv sync",
       "problemMatcher": [],
       "group": {
           "kind": "build",


### PR DESCRIPTION
Remove unneccessary .venv folder check that only works in powershell