### PR TITLE
remove python path in launch.json

### DIFF
--- a/packages/cli/configs/atk/basic/python/.vscode/launch.json
+++ b/packages/cli/configs/atk/basic/python/.vscode/launch.json
@@ -50,7 +50,6 @@
         "type": "debugpy",
         "request": "launch",
         "program": "${workspaceFolder}/src/main.py",
-        "python": "${workspaceFolder}/.venv/Scripts/python.exe",
         "console": "integratedTerminal"
     },
     {


### PR DESCRIPTION
VS Code's debugpy extension automatically detects the correct Python interpreter path based on the platform:
Windows: `.venv/Scripts/python.exe`
macOS/Linux: `.venv/bin/python`

https://code.visualstudio.com/docs/python/debugging#_troubleshooting