### PR TITLE
fix: rm trailing comma in oauth template

### DIFF
--- a/packages/cli/templates/typescript/graph/package.json.hbs
+++ b/packages/cli/templates/typescript/graph/package.json.hbs
@@ -22,7 +22,7 @@
     "@microsoft/teams.common": "preview",
     "@microsoft/teams.dev": "preview",
     "@microsoft/teams.graph": "preview",
-    "@microsoft/teams.graph-endpoints": "preview",
+    "@microsoft/teams.graph-endpoints": "preview"
   },
   "devDependencies": {
     "@types/node": "^22.5.4",


### PR DESCRIPTION
skip-test-verification

This pull request makes a minor change to the `package.json.hbs` template for TypeScript graph projects, cleaning up the dependencies section by removing an unnecessary trailing comma.

- Removed an extra trailing comma from the `dependencies` list in `packages/cli/templates/typescript/graph/package.json.hbs` to ensure valid JSON syntax.