### PR TITLE
Fix runtime export error JS vs TS

### DIFF
--- a/packages/api/src/activities/index.ts
+++ b/packages/api/src/activities/index.ts
@@ -29,4 +29,5 @@ export * from './conversation';
 export * from './command';
 export * from './install-update';
 export * from './utils';
-export { IActivity, Activity as $Activity } from './activity';
+export { Activity as $Activity } from './activity';
+export type { IActivity } from './activity';


### PR DESCRIPTION
#minor 

Ran into a runtime error where because `IActivity` is typescript, it should not be put on the same export line as `Activity` (JS). This is a quick fix. 