### PR TITLE
fix(apps): add `userToken` to event callback context

### DIFF
--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -334,6 +334,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
       stream: this.stream,
       isSignedIn: this.isSignedIn,
       connectionName: this.connectionName,
+      userToken: this.userToken,
       next: this.next.bind(this),
       reply: this.reply.bind(this),
       send: this.send.bind(this),


### PR DESCRIPTION
The attribute `userToken` in the event callback context was always undefined, even if `issignedin` was true.