### PR TITLE
[🐞fix] Change AttachmentLayout type to replace 'carousel' with correct value: 'grid'

### DIFF
--- a/packages/api/src/models/attachment/attachment-layout.ts
+++ b/packages/api/src/models/attachment/attachment-layout.ts
@@ -1,1 +1,1 @@
-export type AttachmentLayout = 'list' | 'carousel';
+export type AttachmentLayout = 'list' | 'grid';


### PR DESCRIPTION
Fixes the incorrect option `carousel` in type `AttachmentLayout`. If you use this, Teams doesn't render a response in a search-based message extension.

The [comment where this is used](https://github.com/microsoft/teams.ts/blob/main/packages/api/src/models/messaging-extension/messaging-extension-result.ts#L31) is correct, the implementation isn't.