### PR TITLE
Add support for Targeted Messages"

### DIFF
--- a/packages/api/src/clients/conversation/activity.spec.ts
+++ b/packages/api/src/clients/conversation/activity.spec.ts
@@ -93,4 +93,76 @@ describe('ConversationActivityClient', () => {
     await client.getMembers('1', '2');
     expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2/members');
   });
+
+  describe('targeted messages', () => {
+    it('should create with query parameter when isTargeted is true', async () => {
+      const client = new ConversationActivityClient('');
+      const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+      await client.create('1', {
+        type: 'message',
+        text: 'hi',
+      }, true);
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities?isTargetedActivity=true', {
+        type: 'message',
+        text: 'hi',
+      });
+    });
+
+    it('should update with query parameter when isTargeted is true', async () => {
+      const client = new ConversationActivityClient('');
+      const spy = jest.spyOn(client.http, 'put').mockResolvedValueOnce({});
+
+      await client.update('1', '2', {
+        type: 'message',
+        text: 'hi',
+      }, true);
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2?isTargetedActivity=true', {
+        type: 'message',
+        text: 'hi',
+      });
+    });
+
+    it('should reply with query parameter when isTargeted is true', async () => {
+      const client = new ConversationActivityClient('');
+      const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+      await client.reply('1', '2', {
+        type: 'message',
+        text: 'hi',
+      }, true);
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2?isTargetedActivity=true', {
+        type: 'message',
+        text: 'hi',
+        replyToId: '2',
+      });
+    });
+
+    it('should delete with query parameter when isTargeted is true', async () => {
+      const client = new ConversationActivityClient('');
+      const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
+
+      await client.delete('1', '2', true);
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2?isTargetedActivity=true');
+    });
+
+    it('should not add query parameter when isTargeted is false', async () => {
+      const client = new ConversationActivityClient('');
+      const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+      await client.create('1', {
+        type: 'message',
+        text: 'hi',
+      }, false);
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities', {
+        type: 'message',
+        text: 'hi',
+      });
+    });
+  });
 });

--- a/packages/api/src/clients/conversation/activity.ts
+++ b/packages/api/src/clients/conversation/activity.ts
@@ -32,35 +32,44 @@ export class ConversationActivityClient {
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
   }
 
-  async create(conversationId: string, params: ActivityParams) {
-    const res = await this.http.post<Resource>(
-      `${this.serviceUrl}/v3/conversations/${conversationId}/activities`,
-      params
-    );
+  async create(conversationId: string, params: ActivityParams, isTargeted: boolean = false) {
+    let url = `${this.serviceUrl}/v3/conversations/${conversationId}/activities`;
+    if (isTargeted) {
+      url += '?isTargetedActivity=true';
+    }
+
+    const res = await this.http.post<Resource>(url, params);
     return res.data;
   }
 
-  async update(conversationId: string, id: string, params: ActivityParams) {
-    const res = await this.http.put<Resource>(
-      `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`,
-      params
-    );
+  async update(conversationId: string, id: string, params: ActivityParams, isTargeted: boolean = false) {
+    let url = `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`;
+    if (isTargeted) {
+      url += '?isTargetedActivity=true';
+    }
+
+    const res = await this.http.put<Resource>(url, params);
     return res.data;
   }
 
-  async reply(conversationId: string, id: string, params: ActivityParams) {
+  async reply(conversationId: string, id: string, params: ActivityParams, isTargeted: boolean = false) {
     params.replyToId = id;
-    const res = await this.http.post<Resource>(
-      `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`,
-      params
-    );
+    let url = `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`;
+    if (isTargeted) {
+      url += '?isTargetedActivity=true';
+    }
+
+    const res = await this.http.post<Resource>(url, params);
     return res.data;
   }
 
-  async delete(conversationId: string, id: string) {
-    const res = await this.http.delete<void>(
-      `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`
-    );
+  async delete(conversationId: string, id: string, isTargeted: boolean = false) {
+    let url = `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`;
+    if (isTargeted) {
+      url += '?isTargetedActivity=true';
+    }
+
+    const res = await this.http.delete<void>(url);
     return res.data;
   }
 

--- a/packages/api/src/clients/conversation/index.ts
+++ b/packages/api/src/clients/conversation/index.ts
@@ -67,12 +67,14 @@ export class ConversationClient {
 
   activities(conversationId: string) {
     return {
-      create: (params: ActivityParams) => this._activities.create(conversationId, params),
-      update: (id: string, params: ActivityParams) =>
-        this._activities.update(conversationId, id, params),
-      reply: (id: string, params: ActivityParams) =>
-        this._activities.reply(conversationId, id, params),
-      delete: (id: string) => this._activities.delete(conversationId, id),
+      create: (params: ActivityParams, isTargeted?: boolean) => 
+        this._activities.create(conversationId, params, isTargeted),
+      update: (id: string, params: ActivityParams, isTargeted?: boolean) =>
+        this._activities.update(conversationId, id, params, isTargeted),
+      reply: (id: string, params: ActivityParams, isTargeted?: boolean) =>
+        this._activities.reply(conversationId, id, params, isTargeted),
+      delete: (id: string, isTargeted?: boolean) => 
+        this._activities.delete(conversationId, id, isTargeted),
       members: (activityId: string) => this._activities.getMembers(conversationId, activityId),
     };
   }

--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -131,7 +131,8 @@ describe('ActivityContext', () => {
 </blockquote>\r\nWhat is up?`,
           type: 'message',
         }),
-        mockRef
+        mockRef,
+        undefined
       );
     });
 
@@ -152,7 +153,8 @@ describe('ActivityContext', () => {
 </blockquote>\r\nWhat is up?`,
           type: 'message',
         }),
-        mockRef
+        mockRef,
+        undefined
       );
     });
 
@@ -169,7 +171,8 @@ describe('ActivityContext', () => {
           text: 'What is up?',
           type: 'message',
         }),
-        mockRef
+        mockRef,
+        undefined
       );
     });
 
@@ -186,7 +189,8 @@ describe('ActivityContext', () => {
           text: '',
           type: 'message',
         }),
-        mockRef
+        mockRef,
+        undefined
       );
     });
   });
@@ -203,7 +207,8 @@ describe('ActivityContext', () => {
           text: 'What is up?',
           type: 'message',
         }),
-        mockRef
+        mockRef,
+        undefined
       );
     });
   });
@@ -277,7 +282,8 @@ describe('ActivityContext', () => {
           inputHint: 'acceptingInput',
           recipient: { id: 'test-user', name: 'Test User', role: 'user' },
         }),
-        mockRef
+        mockRef,
+        undefined
       );
     });
 
@@ -314,7 +320,8 @@ describe('ActivityContext', () => {
       expect(mockApiClient.conversations.create).toHaveBeenCalled();
       expect(mockSender.send).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'message', text: 'Please Sign In...' }),
-        expect.any(Object)
+        expect.any(Object),
+        undefined
       );
     });
 

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -212,11 +212,11 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     }
   }
 
-  async send(activity: ActivityLike, conversationRef?: ConversationReference) {
-    return await this._plugin.send(toActivityParams(activity), conversationRef ?? this.ref);
+  async send(activity: ActivityLike, conversationRef?: ConversationReference, isTargeted?: boolean) {
+    return await this._plugin.send(toActivityParams(activity), conversationRef ?? this.ref, isTargeted);
   }
 
-  async reply(activity: ActivityLike) {
+  async reply(activity: ActivityLike, isTargeted?: boolean) {
     activity = toActivityParams(activity);
     activity.replyToId = this.activity.id;
 
@@ -228,7 +228,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
       }
     }
 
-    return this.send(activity);
+    return this.send(activity, this.ref, isTargeted);
   }
 
   async signin(options?: Partial<SignInOptions>) {

--- a/packages/apps/src/plugins/http/plugin.ts
+++ b/packages/apps/src/plugins/http/plugin.ts
@@ -148,7 +148,7 @@ export class HttpPlugin implements ISender {
     this._server.close();
   }
 
-  async send(activity: ActivityParams, ref: ConversationReference) {
+  async send(activity: ActivityParams, ref: ConversationReference, isTargeted: boolean = false) {
     const api = new Client(
       ref.serviceUrl,
       this.client.clone({
@@ -160,16 +160,18 @@ export class HttpPlugin implements ISender {
       ...activity,
       from: ref.bot,
       conversation: ref.conversation,
+      // Set recipient from ref.user if provided (for targeted messages)
+      ...(ref.user && { recipient: ref.user }),
     };
 
     if (activity.id) {
       const res = await api.conversations
         .activities(ref.conversation.id)
-        .update(activity.id, activity);
+        .update(activity.id, activity, isTargeted);
       return { ...activity, ...res };
     }
 
-    const res = await api.conversations.activities(ref.conversation.id).create(activity);
+    const res = await api.conversations.activities(ref.conversation.id).create(activity, isTargeted);
     return { ...activity, ...res };
   }
 

--- a/packages/apps/src/plugins/http/stream.ts
+++ b/packages/apps/src/plugins/http/stream.ts
@@ -246,25 +246,28 @@ export class HttpStream implements IStreamer {
   /**
    * Send or update a streaming activity
    * @param activity ActivityParams to send.
+   * @param isTargeted when true, sends the message privately to the specified recipient
    */
-  protected async send(activity: ActivityParams) {
+  protected async send(activity: ActivityParams, isTargeted: boolean = false) {
     activity = {
       ...activity,
       from: this.ref.bot,
       conversation: this.ref.conversation,
+      // Set recipient from ref.user if provided (for targeted messages)
+      ...(this.ref.user && { recipient: this.ref.user }),
     };
 
     if (activity.id && !(activity.entities?.some((e) => e.type === 'streaminfo') || false)) {
       const res = await this.client.conversations
         .activities(this.ref.conversation.id)
-        .update(activity.id, activity);
+        .update(activity.id, activity, isTargeted);
 
       return { ...activity, ...res };
     }
 
     const res = await this.client.conversations
       .activities(this.ref.conversation.id)
-      .create(activity);
+      .create(activity, isTargeted);
 
     return { ...activity, ...res };
   }

--- a/packages/apps/src/types/plugin/sender.ts
+++ b/packages/apps/src/types/plugin/sender.ts
@@ -11,8 +11,11 @@ export interface ISender<TCustomEvents extends {} = {}> extends IPlugin<TCustomE
   /**
    * called by the `App`
    * to send an activity
+   * @param activity the activity to send
+   * @param ref the conversation reference
+   * @param isTargeted when true, the message is sent privately to the recipient specified in activity.Recipient
    */
-  send(activity: ActivityParams, ref: ConversationReference): Promise<SentActivity>;
+  send(activity: ActivityParams, ref: ConversationReference, isTargeted?: boolean): Promise<SentActivity>;
 
   /**
    * called by the `App`


### PR DESCRIPTION
NOTE: This is reopening #427 because it needed some design work.
---
Add support for Targeted Messages
This PR introduces support for sending targeted messages - messages delivered privately to a specific recipient within a conversation.

Key Updates:

Added an isTargeted boolean parameter to the send, update, reply and delete APIs. When enabled, the message is sent privately to the Recipient.Id specified in the activity payload.

We append isTargetedActivity=true as a query parameter in API URLs when isTargeted is set, allowing backend services to correctly process these requests.
