### PR TITLE
Rename CUSTOM_VERSION variable to VersionNumber in publish pipeline

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -103,7 +103,7 @@ extends:
             # Get version from nbgv and set NpmTag
             $version = (npm run version:get --silent).Trim()
             Write-Host "Version from nbgv: $version"
-            Write-Host "##vso[task.setvariable variable=CUSTOM_VERSION]$version"
+            Write-Host "##vso[task.setvariable variable=VersionNumber]$version"
 
             # If version contains '-' it's a prerelease, use 'next' tag; otherwise 'latest'
             if ($version -match '-') {
@@ -116,12 +116,6 @@ extends:
           displayName: 'Stamp package versions (nbgv)'
           env:
             PublicRelease: 'true'
-
-        - task: onebranch.pipeline.version@1
-          displayName: 'Set pipeline version'
-          inputs:
-            system: 'Custom'
-            customVersion: '$(CUSTOM_VERSION)'
 
         - powershell: |
             New-Item -ItemType Directory -Force -Path ./out


### PR DESCRIPTION
This pull request makes a small update to the Azure DevOps pipeline configuration file `.azdo/publish.yml`. The main change is renaming the pipeline variable used to store the version number, and removing an unnecessary task related to setting the pipeline version.

- Pipeline variable update:
  * Changed the name of the variable set for the version number from `CUSTOM_VERSION` to `VersionNumber` to standardize variable naming.

- Pipeline task cleanup:
  * Removed the `onebranch.pipeline.version@1` task and its associated inputs, as it is no longer needed for setting the pipeline version.