### PR TITLE
Make Adaptive Cards version number required and set to 1.5

### DIFF
--- a/packages/cards/src/core.spec.ts
+++ b/packages/cards/src/core.spec.ts
@@ -1,0 +1,20 @@
+import { AdaptiveCard, TextBlock } from './core';
+
+describe('AdaptiveCard', () => {
+  it('should default version to 1.5', () => {
+    const card = new AdaptiveCard(new TextBlock('Hello'));
+    expect(card.version).toEqual('1.5');
+  });
+
+  it('should include version in serialized JSON', () => {
+    const card = new AdaptiveCard(new TextBlock('Hello'));
+    const json = JSON.stringify(card);
+    const parsed = JSON.parse(json);
+    expect(parsed.version).toEqual('1.5');
+  });
+
+  it('should allow overriding version', () => {
+    const card = new AdaptiveCard(new TextBlock('Hello')).withVersion('1.4');
+    expect(card.version).toEqual('1.4');
+  });
+});

--- a/packages/cards/src/core.ts
+++ b/packages/cards/src/core.ts
@@ -3044,8 +3044,9 @@ export class AdaptiveCard implements IAdaptiveCard {
   $schema?: string;
   /**
    * The Adaptive Card schema version the card is authored against.
+   * Defaults to `'1.5'`. The `version` field is required for Adaptive Cards to render on Teams mobile clients.
    */
-  version?: '1.0' | '1.1' | '1.2' | '1.3' | '1.4' | '1.5' | '1.6';
+  version: '1.0' | '1.1' | '1.2' | '1.3' | '1.4' | '1.5' | '1.6' = '1.5';
   /**
    * The text that should be displayed if the client is not able to render the card.
    */


### PR DESCRIPTION
It appears that mobile has a verification step on the Adaptive Cards version being set, despite desktop not having that check. This causes cards not to render if the card does not have a version. Setting a versions fixes rendering on mobile.