### PR TITLE
Add tenantId to TeamDetails

### DIFF
--- a/e2e-instructions.md
+++ b/e2e-instructions.md
@@ -1,0 +1,9 @@
+# E2E Instructions
+
+## Environment
+- env: `e2e-test/.env`
+- devtunnel: `devtunnel host $DEVTUNNEL_NAME`
+
+## Bot Start
+- command: `DOTENV_CONFIG_PATH=../../e2e-test/.env npm run dev`
+- ready: `listening on port`

--- a/examples/echo/e2e.spec.md
+++ b/examples/echo/e2e.spec.md
@@ -1,0 +1,12 @@
+# Echo Bot E2E Tests
+
+## Tests
+
+- act: send "Hello there"
+  assert: bot replies with 'you said "Hello there"'
+
+- act: send "Testing 123"
+  assert: bot replies with 'you said "Testing 123"'
+
+- act: send "🎉"
+  assert: bot replies with 'you said "🎉"'

--- a/packages/api/src/models/team-details.ts
+++ b/packages/api/src/models/team-details.ts
@@ -35,4 +35,9 @@ export type TeamDetails = {
    * the team.
    */
   memberCount?: number;
+
+  /**
+   * @member {string} [tenantId] Azure Active Directory (AAD) tenant ID for the team.
+   */
+  tenantId?: string;
 };


### PR DESCRIPTION
- Adds `tenantId?: string` property to the `TeamDetails` type to expose the Azure AD tenant ID for a team

Checked in backend and it was being returned. Need this for a full picture of Team Details 