### PR TITLE
feat: graceful stream cancellation on 403

### DIFF
--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -4,7 +4,7 @@ import { ApiClient, GraphClient } from './api';
 import { App } from './app';
 import { ActivityContext, IActivityContext } from './contexts';
 import { IActivityEvent } from './events';
-import { IPlugin } from './types';
+import { IPlugin, StreamCancelledError } from './types';
 
 /**
  * activity handler called when an inbound activity is received
@@ -170,8 +170,15 @@ export async function $process<TPlugin extends IPlugin>(
       response: res,
     });
   } catch (error: any) {
-    response = { status: 500 };
-    this.onError({ error, activity });
+    if (error instanceof StreamCancelledError) {
+      this.log.debug('Activity processing was cancelled (stream stopped)');
+      await context.stream.close();
+      response = { status: 200 };
+    } else {
+      response = { status: 500 };
+      this.onError({ error, activity });
+    }
+
     this.onActivityResponse({
       ...ref,
       activity,

--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -170,8 +170,8 @@ export async function $process<TPlugin extends IPlugin>(
       response: res,
     });
   } catch (error: any) {
-    if (error instanceof StreamCancelledError) {
-      this.log.debug('Activity processing was cancelled (stream stopped)');
+    if (error instanceof StreamCancelledError || error?.name === 'StreamCancelledError') {
+      this.log.debug('stream canceled, returning 200');
       await context.stream.close();
       response = { status: 200 };
     } else {

--- a/packages/apps/src/http/http-stream.spec.ts
+++ b/packages/apps/src/http/http-stream.spec.ts
@@ -1,3 +1,7 @@
+import { AxiosError } from 'axios';
+
+import { StreamCancelledError } from '../types';
+
 import { HttpStream } from './http-stream';
 
 describe('HttpStream', () => {
@@ -157,5 +161,84 @@ describe('HttpStream', () => {
     );
     const result = await res;
     expect(result).toBeUndefined();
+  });
+
+  test('stream canceled on 403', async () => {
+    const stream = new HttpStream(client, ref, logger);
+    const axiosError = new AxiosError('Forbidden', '403', undefined, undefined, {
+      status: 403,
+      data: {},
+      headers: {},
+      statusText: 'Forbidden',
+      config: {} as any,
+    });
+    client.conversations.activities().create.mockRejectedValue(axiosError);
+
+    stream.emit('Test message');
+    await jest.runAllTimersAsync();
+
+    expect(stream.canceled).toBe(true);
+  });
+
+  test('emit blocked after cancel', () => {
+    const stream = new HttpStream(client, ref, logger);
+    (stream as any)._canceled = true;
+
+    expect(() => stream.emit('Should fail')).toThrow(StreamCancelledError);
+  });
+
+  test('send blocked after cancel', async () => {
+    const stream = new HttpStream(client, ref, logger);
+    (stream as any)._canceled = true;
+
+    await expect((stream as any).send({ type: 'typing', text: 'test' })).rejects.toThrow(
+      StreamCancelledError
+    );
+  });
+
+  test('close returns undefined when canceled', async () => {
+    const stream = new HttpStream(client, ref, logger);
+    (stream as any)._canceled = true;
+    // Set index so we get past the "no content" early return
+    (stream as any).index = 1;
+
+    const result = await stream.close();
+    expect(result).toBeUndefined();
+    expect(logger.debug).toHaveBeenCalledWith('stream was cancelled, nothing to close');
+  });
+
+  test('stream canceled after successful message', async () => {
+    const stream = new HttpStream(client, ref, logger);
+    let callCount = 0;
+    const axiosError = new AxiosError('Forbidden', '403', undefined, undefined, {
+      status: 403,
+      data: {},
+      headers: {},
+      statusText: 'Forbidden',
+      config: {} as any,
+    });
+
+    client.conversations.activities().create.mockImplementation(async (_activity: any) => {
+      callCount++;
+      if (callCount === 1) {
+        return { _activity, id: 'activity-1' };
+      }
+      throw axiosError;
+    });
+
+    // First emit succeeds
+    stream.emit('First message');
+    await jest.runAllTimersAsync();
+    expect(stream.canceled).toBe(false);
+    expect(callCount).toBe(1);
+
+    // Second emit triggers 403
+    stream.emit('Second message');
+    await jest.runAllTimersAsync();
+    expect(stream.canceled).toBe(true);
+    expect(callCount).toBe(2);
+
+    // Further emits throw
+    expect(() => stream.emit('Should fail')).toThrow(StreamCancelledError);
   });
 });

--- a/packages/apps/src/http/http-stream.spec.ts
+++ b/packages/apps/src/http/http-stream.spec.ts
@@ -204,7 +204,7 @@ describe('HttpStream', () => {
 
     const result = await stream.close();
     expect(result).toBeUndefined();
-    expect(logger.debug).toHaveBeenCalledWith('stream was cancelled, nothing to close');
+    expect(logger.debug).toHaveBeenCalledWith('stream canceled, nothing to close');
   });
 
   test('stream canceled after successful message', async () => {

--- a/packages/apps/src/http/http-stream.ts
+++ b/packages/apps/src/http/http-stream.ts
@@ -13,7 +13,7 @@ import {
 } from '@microsoft/teams.api';
 import { ConsoleLogger, EventEmitter, ILogger } from '@microsoft/teams.common';
 
-import { IStreamer, IStreamerEvents } from '../types';
+import { IStreamer, IStreamerEvents, StreamCancelledError } from '../types';
 import { promises } from '../utils';
 
 /**
@@ -48,7 +48,16 @@ export class HttpStream implements IStreamer {
   private _timeout?: NodeJS.Timeout;
   private _logger: ILogger;
   private _flushing: boolean = false;
+  private _canceled: boolean = false;
   private readonly _totalTimeout = 30000; // 30 seconds
+
+  /**
+   * Whether the stream has been canceled.
+   * For example when the user pressed the Stop button or the 2-minute timeout has exceeded.
+   */
+  get canceled(): boolean {
+    return this._canceled;
+  }
 
   constructor(client: Client, ref: ConversationReference, logger?: ILogger) {
     this.client = client;
@@ -61,6 +70,9 @@ export class HttpStream implements IStreamer {
    * @param activity Activity object or string message.
    */
   emit(activity: Partial<IMessageActivity | ITypingActivity> | string) {
+    if (this._canceled) {
+      throw new StreamCancelledError('Stream has been cancelled.');
+    }
 
     if (typeof activity === 'string') {
       activity = {
@@ -104,16 +116,26 @@ export class HttpStream implements IStreamer {
       return this._result;
     }
 
+    if (this._canceled) {
+      this._logger.debug('stream was cancelled, nothing to close');
+      return;
+    }
+
     // Wait until all queued activities are flushed
     const start = Date.now();
 
-    while (this.queue.length || !this.id) {
+    while ((this.queue.length || !this.id) && !this._canceled) {
       if (Date.now() - start > this._totalTimeout) {
         this._logger.warn('Timeout while waiting for id and queue to flush');
         return;
       }
       this._logger.debug('waiting for id to be set or queue to be empty');
       await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    if (this._canceled) {
+      this._logger.debug('stream was cancelled, nothing to close');
+      return;
     }
 
     if (this.text === '' && !this.attachments.length) {
@@ -123,7 +145,7 @@ export class HttpStream implements IStreamer {
 
     // Build final message activity
     const activity = new MessageActivity(this.text)
-      .withId(this.id)
+      .withId(this.id!)
       .addAttachments(...this.attachments)
       .addEntities(...this.entities)
       .addStreamFinal()
@@ -217,7 +239,9 @@ export class HttpStream implements IStreamer {
         this._timeout = setTimeout(this.flush.bind(this), 500);
       }
     } catch (err) {
-      this._logger.error(err, 'flush failed');
+      if (!(err instanceof StreamCancelledError)) {
+        this._logger.error(err, 'flush failed');
+      }
     } finally {
       this._flushing = false;
     }
@@ -248,24 +272,37 @@ export class HttpStream implements IStreamer {
    * @param activity ActivityParams to send.
    */
   protected async send(activity: ActivityParams) {
+    if (this._canceled) {
+      throw new StreamCancelledError('Teams channel stopped the stream.');
+    }
+
     activity = {
       ...activity,
       from: this.ref.bot,
       conversation: this.ref.conversation,
     };
 
-    if (activity.id && !(activity.entities?.some((e) => e.type === 'streaminfo') || false)) {
+    try {
+      if (activity.id && !(activity.entities?.some((e) => e.type === 'streaminfo') || false)) {
+        const res = await this.client.conversations
+          .activities(this.ref.conversation.id)
+          .update(activity.id, activity);
+
+        return { ...activity, ...res };
+      }
+
       const res = await this.client.conversations
         .activities(this.ref.conversation.id)
-        .update(activity.id, activity);
+        .create(activity);
 
       return { ...activity, ...res };
+    } catch (err: any) {
+      if (err?.response?.status === 403) {
+        this._canceled = true;
+        this._logger.debug('Teams channel stopped the stream.');
+        throw new StreamCancelledError('Teams channel stopped the stream.');
+      }
+      throw err;
     }
-
-    const res = await this.client.conversations
-      .activities(this.ref.conversation.id)
-      .create(activity);
-
-    return { ...activity, ...res };
   }
 }

--- a/packages/apps/src/http/http-stream.ts
+++ b/packages/apps/src/http/http-stream.ts
@@ -138,6 +138,11 @@ export class HttpStream implements IStreamer {
       return;
     }
 
+    if (!this.id) {
+      this._logger.warn('no stream id set, cannot close stream');
+      return;
+    }
+
     if (this.text === '' && !this.attachments.length) {
       this._logger.warn('no text or attachments to send, cannot close stream');
       return;
@@ -145,7 +150,7 @@ export class HttpStream implements IStreamer {
 
     // Build final message activity
     const activity = new MessageActivity(this.text)
-      .withId(this.id!)
+      .withId(this.id)
       .addAttachments(...this.attachments)
       .addEntities(...this.entities)
       .addStreamFinal()

--- a/packages/apps/src/http/http-stream.ts
+++ b/packages/apps/src/http/http-stream.ts
@@ -71,7 +71,7 @@ export class HttpStream implements IStreamer {
    */
   emit(activity: Partial<IMessageActivity | ITypingActivity> | string) {
     if (this._canceled) {
-      throw new StreamCancelledError('Stream has been cancelled.');
+      throw new StreamCancelledError();
     }
 
     if (typeof activity === 'string') {
@@ -117,7 +117,7 @@ export class HttpStream implements IStreamer {
     }
 
     if (this._canceled) {
-      this._logger.debug('stream was cancelled, nothing to close');
+      this._logger.debug('stream canceled, nothing to close');
       return;
     }
 
@@ -134,7 +134,7 @@ export class HttpStream implements IStreamer {
     }
 
     if (this._canceled) {
-      this._logger.debug('stream was cancelled, nothing to close');
+      this._logger.debug('stream canceled, nothing to close');
       return;
     }
 
@@ -278,7 +278,7 @@ export class HttpStream implements IStreamer {
    */
   protected async send(activity: ActivityParams) {
     if (this._canceled) {
-      throw new StreamCancelledError('Teams channel stopped the stream.');
+      throw new StreamCancelledError();
     }
 
     activity = {
@@ -304,8 +304,8 @@ export class HttpStream implements IStreamer {
     } catch (err: any) {
       if (err?.response?.status === 403) {
         this._canceled = true;
-        this._logger.debug('Teams channel stopped the stream.');
-        throw new StreamCancelledError('Teams channel stopped the stream.');
+        this._logger.debug('stream canceled by Teams (403)');
+        throw new StreamCancelledError();
       }
       throw err;
     }

--- a/packages/apps/src/types/streamer.ts
+++ b/packages/apps/src/types/streamer.ts
@@ -2,6 +2,16 @@ import { IMessageActivity, ITypingActivity, SentActivity } from '@microsoft/team
 import { IEventEmitter } from '@microsoft/teams.common';
 
 /**
+ * Raised when a stream operation is attempted after the stream has been cancelled.
+ */
+export class StreamCancelledError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Stream has been cancelled.');
+    this.name = 'StreamCancelledError';
+  }
+}
+
+/**
  * the minimum events a streamer
  * should support
  */
@@ -22,6 +32,12 @@ export interface IStreamerEvents {
  */
 export interface IStreamer {
   readonly events: Omit<IEventEmitter<IStreamerEvents>, 'emit'>;
+
+  /**
+   * whether the stream has been canceled.
+   * For example when the user pressed the Stop button or the 2-minute timeout has exceeded.
+   */
+  readonly canceled: boolean;
 
   /**
    * emit an activity chunk

--- a/packages/apps/src/types/streamer.ts
+++ b/packages/apps/src/types/streamer.ts
@@ -2,11 +2,11 @@ import { IMessageActivity, ITypingActivity, SentActivity } from '@microsoft/team
 import { IEventEmitter } from '@microsoft/teams.common';
 
 /**
- * Raised when a stream operation is attempted after the stream has been cancelled.
+ * Raised when Teams cancels a stream (403) or when a stream operation is attempted after cancellation.
  */
 export class StreamCancelledError extends Error {
   constructor(message?: string) {
-    super(message ?? 'Stream has been cancelled.');
+    super(message ?? 'stream canceled');
     this.name = 'StreamCancelledError';
   }
 }

--- a/packages/apps/src/utils/promises/retry.ts
+++ b/packages/apps/src/utils/promises/retry.ts
@@ -1,5 +1,7 @@
 import { ILogger } from '@microsoft/teams.common';
 
+import { StreamCancelledError } from '../../types';
+
 export type RetryOptions = {
   /**
    * the max number of attempts
@@ -27,6 +29,10 @@ export async function retry<T = any>(factory: () => Promise<T>, options?: RetryO
   try {
     return await factory();
   } catch (err) {
+    if (err instanceof StreamCancelledError) {
+      throw err;
+    }
+
     if (max > 1) {
       log?.debug(`delaying ${delay}ms...`);
       await new Promise((resolve) => setTimeout(resolve, delay));

--- a/packages/apps/src/utils/promises/retry.ts
+++ b/packages/apps/src/utils/promises/retry.ts
@@ -29,7 +29,7 @@ export async function retry<T = any>(factory: () => Promise<T>, options?: RetryO
   try {
     return await factory();
   } catch (err) {
-    if (err instanceof StreamCancelledError) {
+    if (err instanceof StreamCancelledError || (err instanceof Error && err.name === 'StreamCancelledError')) {
       throw err;
     }
 


### PR DESCRIPTION
## Summary
- Detect when Teams stops a stream (user presses Stop or 2-min timeout) via 403 response and cancel immediately instead of silently retrying until timeout
- Add `StreamCancelledError` class and `canceled` property to `IStreamer` interface
- `HttpStream.send()` catches 403, sets `canceled` flag, and throws `StreamCancelledError`
- `emit()` and `close()` bail out immediately when canceled
- `retry()` skips retries for `StreamCancelledError` (no point retrying a permanent cancellation)
- `flush()` suppresses error log for expected cancellation
- `app.process` catches `StreamCancelledError` and returns 200 so Teams doesn't retry

Ports [teams.py#337](https://github.com/microsoft/teams.py/pull/337) to TypeScript.

To test, I ran a streaming bot, press Stop mid-stream — verify no held connection, verify future messages weren't impacted, verified that stream didn't restart b/c of a 500.