### PR TITLE
Add proactive threading support

### DIFF
--- a/examples/threading/README.md
+++ b/examples/threading/README.md
@@ -1,0 +1,34 @@
+# Example: Threading
+
+A bot that demonstrates reactive and proactive threading in Microsoft Teams channels.
+
+## Commands
+
+| Command | Behavior |
+|---------|----------|
+| `test reply` | `context.reply()` — reactive threaded reply with visual quote |
+| `test send` | `context.send()` — reactive send to same thread, no quote |
+| `test proactive` | `app.reply()` — proactive threaded reply |
+| `test manual` | `toThreadId()` + `app.send()` — advanced manual control (channels and 1:1 chats only) |
+| `help` | Shows available commands |
+
+## Notes
+
+- `test reply` and `test send` work in all scopes (1:1, group chat, channels)
+- `test proactive` works in all scopes — in channels it threads, in flat scopes it sends normally
+- `test manual` only works in channels and 1:1 chats since `toThreadId()` constructs a threaded conversation ID (group chats and meetings do not support threading)
+
+## Run
+
+```bash
+npm run dev
+```
+
+## Environment Variables
+
+Create a `.env` file:
+
+```
+CLIENT_ID=<your-azure-bot-app-id>
+CLIENT_SECRET=<your-azure-bot-app-secret>
+```

--- a/examples/threading/README.md
+++ b/examples/threading/README.md
@@ -9,14 +9,14 @@ A bot that demonstrates reactive and proactive threading in Microsoft Teams chan
 | `test reply` | `context.reply()` — reactive threaded reply with visual quote |
 | `test send` | `context.send()` — reactive send to same thread, no quote |
 | `test proactive` | `app.reply()` — proactive threaded reply |
-| `test manual` | `toThreadId()` + `app.send()` — advanced manual control (channels and 1:1 chats only) |
+| `test manual` | `toThreadedConversationId()` + `app.send()` — advanced manual control (channels and 1:1 chats only) |
 | `help` | Shows available commands |
 
 ## Notes
 
 - `test reply` and `test send` work in all scopes (1:1, group chat, channels)
 - `test proactive` works in all scopes — in channels it threads, in non-threading scopes it sends normally
-- `test manual` only works in channels and 1:1 chats since `toThreadId()` constructs a threaded conversation ID (group chats and meetings do not support threading)
+- `test manual` only works in channels and 1:1 chats since `toThreadedConversationId()` constructs a threaded conversation ID (group chats and meetings do not support threading)
 
 ## Run
 

--- a/examples/threading/README.md
+++ b/examples/threading/README.md
@@ -15,7 +15,7 @@ A bot that demonstrates reactive and proactive threading in Microsoft Teams chan
 ## Notes
 
 - `test reply` and `test send` work in all scopes (1:1, group chat, channels)
-- `test proactive` works in all scopes — in channels it threads, in flat scopes it sends normally
+- `test proactive` works in all scopes — in channels it threads, in non-threading scopes it sends normally
 - `test manual` only works in channels and 1:1 chats since `toThreadId()` constructs a threaded conversation ID (group chats and meetings do not support threading)
 
 ## Run

--- a/examples/threading/package.json
+++ b/examples/threading/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@examples/threading",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "tsx watch -r dotenv/config src/index.ts"
+  },
+  "dependencies": {
+    "@microsoft/teams.apps": "*",
+    "@microsoft/teams.dev": "*"
+  },
+  "devDependencies": {
+    "@microsoft/teams.config": "*",
+    "@types/node": "^22.5.4",
+    "dotenv": "^16.4.5",
+    "tsx": "^4.20.6",
+    "typescript": "^5.4.5"
+  }
+}

--- a/examples/threading/src/index.ts
+++ b/examples/threading/src/index.ts
@@ -1,4 +1,4 @@
-import { App, toThreadId } from '@microsoft/teams.apps';
+import { App, toThreadedConversationId } from '@microsoft/teams.apps';
 import { ConsoleLogger } from '@microsoft/teams.common/logging';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
@@ -44,17 +44,17 @@ app.on('message', async ({ reply, send, activity, ref }) => {
   }
 
   // ============================================
-  // toThreadId() + app.send() — advanced manual control (channels only)
+  // toThreadedConversationId() + app.send() — advanced manual control (channels only)
   // ============================================
   if (text.includes('test manual')) {
-    // toThreadId() is only valid for conversations that support threading
+    // toThreadedConversationId() is only valid for conversations that support threading
     const base = conversationId.split(';')[0];
     if (!base.endsWith('@thread.tacv2') && !base.endsWith('@thread.skype') && !base.endsWith('@unq.gbl.spaces')) {
       await reply('This command doesn\'t support threading in this conversation type.');
       return;
     }
-    const threadId = toThreadId(conversationId, threadRootId);
-    await app.send(threadId, 'This was sent using toThreadId() + app.send() for manual control.');
+    const threadId = toThreadedConversationId(conversationId, threadRootId);
+    await app.send(threadId, 'This was sent using toThreadedConversationId() + app.send() for manual control.');
     return;
   }
 
@@ -68,19 +68,12 @@ app.on('message', async ({ reply, send, activity, ref }) => {
       '- `test reply` - context.reply() reactive threaded reply\n' +
       '- `test send` - context.send() to same thread without quoting\n' +
       '- `test proactive` - app.reply() proactive threaded reply\n' +
-      '- `test manual` - toThreadId() + app.send() for advanced control'
+      '- `test manual` - toThreadedConversationId() + app.send() for advanced control'
     );
     return;
   }
 
   await send('Say "help" for available commands.');
-});
-
-app.on('install.add', async ({ send }) => {
-  await send(
-    'Hi! I demonstrate threading.\n\n' +
-    'Say **help** to see available commands.'
-  );
 });
 
 app.start().catch(console.error);

--- a/examples/threading/src/index.ts
+++ b/examples/threading/src/index.ts
@@ -1,0 +1,86 @@
+import { App, toThreadId } from '@microsoft/teams.apps';
+import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { DevtoolsPlugin } from '@microsoft/teams.dev';
+
+const app = new App({
+  logger: new ConsoleLogger('@examples/threading', { level: 'debug' }),
+  plugins: [new DevtoolsPlugin()],
+});
+
+app.on('message', async ({ reply, send, activity, ref }) => {
+  await reply({ type: 'typing' });
+
+  const text = activity.text?.toLowerCase() || '';
+  const conversationId = ref.conversation.id;
+  const messageId = activity.id!;
+
+  // When inside a thread, conversationId contains ;messageid=<rootId>.
+  // Extract the root ID for threading; for top-level messages, use activity.id.
+  const threadParts = conversationId.split(';messageid=');
+  const threadRootId = threadParts.length > 1 ? threadParts[1] : messageId;
+
+  // ============================================
+  // context.reply() — reactive threaded reply
+  // ============================================
+  if (text.includes('test reply')) {
+    await reply('This is a threaded reply to your message.');
+    return;
+  }
+
+  // ============================================
+  // context.send() — reactive send to same thread
+  // ============================================
+  if (text.includes('test send')) {
+    await send('This is sent to the same thread, without quoting.');
+    return;
+  }
+
+  // ============================================
+  // app.reply() — proactive threaded reply
+  // ============================================
+  if (text.includes('test proactive')) {
+    await app.reply(conversationId, threadRootId, 'This is a proactive threaded reply using app.reply().');
+    return;
+  }
+
+  // ============================================
+  // toThreadId() + app.send() — advanced manual control (channels only)
+  // ============================================
+  if (text.includes('test manual')) {
+    // toThreadId() is only valid for conversations that support threading
+    const base = conversationId.split(';')[0];
+    if (!base.endsWith('@thread.tacv2') && !base.endsWith('@thread.skype') && !base.endsWith('@unq.gbl.spaces')) {
+      await reply('This command doesn\'t support threading in this conversation type.');
+      return;
+    }
+    const threadId = toThreadId(conversationId, threadRootId);
+    await app.send(threadId, 'This was sent using toThreadId() + app.send() for manual control.');
+    return;
+  }
+
+  // ============================================
+  // Help / Default
+  // ============================================
+  if (text.includes('help')) {
+    await reply(
+      '**Threading Test Bot**\n\n' +
+      '**Commands:**\n' +
+      '- `test reply` - context.reply() reactive threaded reply\n' +
+      '- `test send` - context.send() to same thread without quoting\n' +
+      '- `test proactive` - app.reply() proactive threaded reply\n' +
+      '- `test manual` - toThreadId() + app.send() for advanced control'
+    );
+    return;
+  }
+
+  await send('Say "help" for available commands.');
+});
+
+app.on('install.add', async ({ send }) => {
+  await send(
+    'Hi! I demonstrate threading.\n\n' +
+    'Say **help** to see available commands.'
+  );
+});
+
+app.start().catch(console.error);

--- a/examples/threading/tsconfig.json
+++ b/examples/threading/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@microsoft/teams.config/tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -640,6 +640,21 @@
         "typescript": "^5.4.5"
       }
     },
+    "examples/threading": {
+      "name": "@examples/threading",
+      "version": "0.0.1",
+      "dependencies": {
+        "@microsoft/teams.apps": "*",
+        "@microsoft/teams.dev": "*"
+      },
+      "devDependencies": {
+        "@microsoft/teams.config": "*",
+        "@types/node": "^22.5.4",
+        "dotenv": "^16.4.5",
+        "tsx": "^4.20.6",
+        "typescript": "^5.4.5"
+      }
+    },
     "external/a2a": {
       "name": "@microsoft/teams.a2a",
       "version": "0.0.0",
@@ -2243,6 +2258,10 @@
     },
     "node_modules/@examples/targeted-messages": {
       "resolved": "examples/targeted-messages",
+      "link": true
+    },
+    "node_modules/@examples/threading": {
+      "resolved": "examples/threading",
       "link": true
     },
     "node_modules/@floating-ui/core": {

--- a/packages/apps/src/app.spec.ts
+++ b/packages/apps/src/app.spec.ts
@@ -19,6 +19,15 @@ class TestApp extends App {
     return this.send(conversationId, activity);
   }
 
+  public async testReply(conversationId: string, messageId: string, activity: any): Promise<any>;
+  public async testReply(conversationId: string, activity: any): Promise<any>;
+  public async testReply(conversationId: string, messageId: string | any, activity?: any) {
+    if (typeof messageId === 'string' && activity !== undefined) {
+      return this.reply(conversationId, messageId, activity);
+    }
+    return this.reply(conversationId, messageId);
+  }
+
   // Expose activitySender for mocking (it's protected, so we expose it publicly)
   public get testActivitySender() {
     return this.activitySender;
@@ -322,6 +331,76 @@ describe('App', () => {
         httpServerAdapter: new TestAdapter(),
       });
       expect(app3.api.serviceUrl).toBe('https://options.service.url/teams');
+    });
+  });
+
+  describe('reply', () => {
+    let app: TestApp;
+
+    beforeEach(async () => {
+      app = new TestApp({
+        httpServerAdapter: new TestAdapter(),
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        tenantId: 'test-tenant-id',
+      });
+      await app.start();
+    });
+
+    afterEach(async () => {
+      await app.stop();
+    });
+
+    it('should construct threaded ID when called with conversationId, messageId, and activity', async () => {
+      const mockSend = jest.fn().mockResolvedValue({ id: 'activity-id' });
+      jest.spyOn(app.testActivitySender, 'send').mockImplementation(mockSend);
+
+      await app.testReply('19:abc@thread.skype', '1680000000000', { text: 'Hello thread' });
+
+      expect(mockSend).toHaveBeenCalled();
+      const [, ref] = mockSend.mock.calls[0];
+      expect(ref.conversation.id).toBe('19:abc@thread.skype;messageid=1680000000000');
+    });
+
+    it('should pass conversationId as-is when called with two args', async () => {
+      const mockSend = jest.fn().mockResolvedValue({ id: 'activity-id' });
+      jest.spyOn(app.testActivitySender, 'send').mockImplementation(mockSend);
+
+      await app.testReply('19:abc@thread.skype', { text: 'Hello flat' });
+
+      expect(mockSend).toHaveBeenCalled();
+      const [, ref] = mockSend.mock.calls[0];
+      expect(ref.conversation.id).toBe('19:abc@thread.skype');
+    });
+
+    it('should pass pre-constructed threaded ID as-is when called with two args', async () => {
+      const mockSend = jest.fn().mockResolvedValue({ id: 'activity-id' });
+      jest.spyOn(app.testActivitySender, 'send').mockImplementation(mockSend);
+
+      await app.testReply('19:abc@thread.skype;messageid=123', { text: 'Hello' });
+
+      expect(mockSend).toHaveBeenCalled();
+      const [, ref] = mockSend.mock.calls[0];
+      expect(ref.conversation.id).toBe('19:abc@thread.skype;messageid=123');
+    });
+
+    it('should throw on invalid messageId in three-arg form', async () => {
+      await expect(
+        app.testReply('19:abc@thread.skype', 'not-a-number', { text: 'Hello' })
+      ).rejects.toThrow('Invalid messageId');
+    });
+
+    it('should throw when app is not started', async () => {
+      const unstartedApp = new TestApp({
+        httpServerAdapter: new TestAdapter(),
+      });
+      await unstartedApp.start();
+
+      await expect(
+        unstartedApp.testReply('conv-id', { text: 'Hello' })
+      ).rejects.toThrow('app not started');
+
+      await unstartedApp.stop();
     });
   });
 });

--- a/packages/apps/src/app.spec.ts
+++ b/packages/apps/src/app.spec.ts
@@ -384,6 +384,17 @@ describe('App', () => {
       expect(ref.conversation.id).toBe('19:abc@thread.skype;messageid=123');
     });
 
+    it('should pass conversationId as-is when conversation does not support threading (three-arg form)', async () => {
+      const mockSend = jest.fn().mockResolvedValue({ id: 'activity-id' });
+      jest.spyOn(app.testActivitySender, 'send').mockImplementation(mockSend);
+
+      await app.testReply('19:meeting_abc@thread.v2', '123', { text: 'Hello' });
+
+      expect(mockSend).toHaveBeenCalled();
+      const [, ref] = mockSend.mock.calls[0];
+      expect(ref.conversation.id).toBe('19:meeting_abc@thread.v2');
+    });
+
     it('should throw on invalid messageId in three-arg form', async () => {
       await expect(
         app.testReply('19:abc@thread.skype', 'not-a-number', { text: 'Hello' })
@@ -394,13 +405,10 @@ describe('App', () => {
       const unstartedApp = new TestApp({
         httpServerAdapter: new TestAdapter(),
       });
-      await unstartedApp.start();
 
       await expect(
         unstartedApp.testReply('conv-id', { text: 'Hello' })
       ).rejects.toThrow('app not started');
-
-      await unstartedApp.stop();
     });
   });
 });

--- a/packages/apps/src/app.spec.ts
+++ b/packages/apps/src/app.spec.ts
@@ -401,14 +401,14 @@ describe('App', () => {
       ).rejects.toThrow('Invalid messageId');
     });
 
-    it('should throw when app is not started', async () => {
+    it('should throw when app has no credentials', async () => {
       const unstartedApp = new TestApp({
         httpServerAdapter: new TestAdapter(),
       });
 
       await expect(
         unstartedApp.testReply('conv-id', { text: 'Hello' })
-      ).rejects.toThrow('app not started');
+      ).rejects.toThrow('App has no credentials set up');
     });
   });
 });

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -50,7 +50,7 @@ import { Router } from './router';
 import { TokenManager } from './token-manager';
 import { IPlugin, AppEvents } from './types';
 import { PluginAdditionalContext } from './types/app-routing';
-import { supportsThreading, toThreadId } from './utils/thread';
+import { supportsThreading, toThreadedConversationId } from './utils/thread';
 
 /**
  * App initialization options
@@ -520,7 +520,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
    * send an activity proactively to a conversation.
    *
    * Sends to the exact conversation ID provided. For channel threads,
-   * the conversation ID must include `;messageid=` - use {@link toThreadId}
+   * the conversation ID must include `;messageid=` - use {@link toThreadedConversationId}
    * to construct it, or use {@link reply} which handles this automatically.
    *
    * @param conversationId the conversation to send to
@@ -576,7 +576,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
   async reply(conversationId: string, messageId: string | ActivityLike, activity?: ActivityLike) {
     if (typeof messageId === 'string' && activity !== undefined) {
       const targetId = supportsThreading(conversationId)
-        ? toThreadId(conversationId, messageId)
+        ? toThreadedConversationId(conversationId, messageId)
         : conversationId;
       return this.send(targetId, activity);
     }

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -555,8 +555,8 @@ export class App<TPlugin extends IPlugin = IPlugin> {
    *
    * In channels, construct a threaded conversation ID from the
    * conversation ID and message ID, then send to that thread.
-   * In flat scopes (1:1, group chat, meetings), send as a
-   * normal message - the message ID is ignored.
+   * In scopes that do not support threading (group chat, meetings),
+   * send as a normal message - the message ID is ignored.
    *
    * @param conversationId the channel or conversation ID
    * @param messageId the thread root message ID

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -50,6 +50,7 @@ import { Router } from './router';
 import { TokenManager } from './token-manager';
 import { IPlugin, AppEvents } from './types';
 import { PluginAdditionalContext } from './types/app-routing';
+import { supportsThreading, toThreadId } from './utils/thread';
 
 /**
  * App initialization options
@@ -516,7 +517,12 @@ export class App<TPlugin extends IPlugin = IPlugin> {
   }
 
   /**
-   * send an activity proactively
+   * send an activity proactively to a conversation.
+   *
+   * Sends to the exact conversation ID provided. For channel threads,
+   * the conversation ID must include `;messageid=` - use {@link toThreadId}
+   * to construct it, or use {@link reply} which handles this automatically.
+   *
    * @param conversationId the conversation to send to
    * @param activity the activity to send
    */
@@ -537,12 +543,45 @@ export class App<TPlugin extends IPlugin = IPlugin> {
       },
       conversation: {
         id: conversationId,
-        conversationType: 'personal',
-      },
+      } as ConversationReference['conversation'],
     };
 
     const res = await this.activitySender.send(params, ref);
     return res;
+  }
+
+  /**
+   * send an activity proactively to a channel thread.
+   *
+   * In channels, construct a threaded conversation ID from the
+   * conversation ID and message ID, then send to that thread.
+   * In flat scopes (1:1, group chat, meetings), send as a
+   * normal message - the message ID is ignored.
+   *
+   * @param conversationId the channel or conversation ID
+   * @param messageId the thread root message ID
+   * @param activity the activity to send
+   */
+  async reply(conversationId: string, messageId: string, activity: ActivityLike): Promise<any>;
+  /**
+   * send an activity proactively to a conversation.
+   *
+   * Sends to the exact conversation ID provided - threaded if
+   * it contains `;messageid=`, flat otherwise.
+   *
+   * @param conversationId the conversation to send to
+   * @param activity the activity to send
+   */
+  async reply(conversationId: string, activity: ActivityLike): Promise<any>;
+  async reply(conversationId: string, messageId: string | ActivityLike, activity?: ActivityLike) {
+    if (typeof messageId === 'string' && activity !== undefined) {
+      const targetId = supportsThreading(conversationId)
+        ? toThreadId(conversationId, messageId)
+        : conversationId;
+      return this.send(targetId, activity);
+    }
+
+    return this.send(conversationId, messageId as ActivityLike);
   }
 
   /**

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -233,8 +233,8 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
   /**
    * send an activity in the current conversation without quoting.
    *
-   * In channels, sends to the current thread. In flat scopes (1:1,
-   * group chat, meetings), sends as a normal message.
+   * In channels, sends to the current thread. In scopes that do not
+   * support threading (group chat, meetings), sends as a normal message.
    * To send with a visual quote of the inbound message, use {@link reply}.
    *
    * @param activity the activity to send
@@ -259,7 +259,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
    * of the inbound message.
    *
    * In channels, sends to the current thread with a quoted reply.
-   * In flat scopes, sends with a quoted reply.
+   * In other scopes, sends with a quoted reply.
    * To send without quoting, use {@link send}.
    *
    * @param activity the activity to send

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -230,6 +230,16 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     }
   }
 
+  /**
+   * send an activity in the current conversation without quoting.
+   *
+   * In channels, sends to the current thread. In flat scopes (1:1,
+   * group chat, meetings), sends as a normal message.
+   * To send with a visual quote of the inbound message, use {@link reply}.
+   *
+   * @param activity the activity to send
+   * @param conversationRef optional conversation reference to send to a different conversation or thread
+   */
   async send(activity: ActivityLike, conversationRef?: ConversationReference) {
     const params = toActivityParams(activity);
 
@@ -244,6 +254,16 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     return await this.activitySender.send(params, conversationRef ?? this.ref);
   }
 
+  /**
+   * send an activity in the current conversation with a visual quote
+   * of the inbound message.
+   *
+   * In channels, sends to the current thread with a quoted reply.
+   * In flat scopes, sends with a quoted reply.
+   * To send without quoting, use {@link send}.
+   *
+   * @param activity the activity to send
+   */
   async reply(activity: ActivityLike) {
     activity = toActivityParams(activity);
     activity.replyToId = this.activity.id;

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -10,4 +10,4 @@ export * as manifest from './manifest';
 export * from './http';
 
 // Threading utilities
-export { toThreadId } from './utils/thread';
+export { toThreadedConversationId } from './utils/thread';

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -8,3 +8,6 @@ export * as manifest from './manifest';
 
 // HTTP infrastructure - public API
 export * from './http';
+
+// Threading utilities
+export { toThreadId } from './utils/thread';

--- a/packages/apps/src/utils/index.ts
+++ b/packages/apps/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * as asserts from './asserts';
 export * as promises from './promises';
 export * as functionContext from './function-context';
+export { toThreadId } from './thread';

--- a/packages/apps/src/utils/index.ts
+++ b/packages/apps/src/utils/index.ts
@@ -1,4 +1,4 @@
 export * as asserts from './asserts';
 export * as promises from './promises';
 export * as functionContext from './function-context';
-export { toThreadId } from './thread';
+export { toThreadedConversationId } from './thread';

--- a/packages/apps/src/utils/thread.spec.ts
+++ b/packages/apps/src/utils/thread.spec.ts
@@ -1,56 +1,56 @@
-import { toThreadId, supportsThreading } from './thread';
+import { toThreadedConversationId, supportsThreading } from './thread';
 
-describe('toThreadId', () => {
+describe('toThreadedConversationId', () => {
   it('should construct a threaded conversation ID', () => {
-    expect(toThreadId('19:abc@thread.skype', '1680000000000')).toBe(
+    expect(toThreadedConversationId('19:abc@thread.skype', '1680000000000')).toBe(
       '19:abc@thread.skype;messageid=1680000000000'
     );
   });
 
   it('should work with different conversation ID formats', () => {
-    expect(toThreadId('19:meeting_abc@thread.v2', '999')).toBe(
+    expect(toThreadedConversationId('19:meeting_abc@thread.v2', '999')).toBe(
       '19:meeting_abc@thread.v2;messageid=999'
     );
   });
 
   it('should throw on empty conversationId', () => {
-    expect(() => toThreadId('', '123')).toThrow(
+    expect(() => toThreadedConversationId('', '123')).toThrow(
       'conversationId must be a non-empty string'
     );
   });
 
   it('should throw on empty messageId', () => {
-    expect(() => toThreadId('19:abc@thread.skype', '')).toThrow(
+    expect(() => toThreadedConversationId('19:abc@thread.skype', '')).toThrow(
       'Invalid messageId'
     );
   });
 
   it('should throw on zero messageId', () => {
-    expect(() => toThreadId('19:abc@thread.skype', '0')).toThrow(
+    expect(() => toThreadedConversationId('19:abc@thread.skype', '0')).toThrow(
       'Invalid messageId'
     );
   });
 
   it('should throw on non-numeric messageId', () => {
-    expect(() => toThreadId('19:abc@thread.skype', 'abc')).toThrow(
+    expect(() => toThreadedConversationId('19:abc@thread.skype', 'abc')).toThrow(
       'Invalid messageId'
     );
   });
 
   it('should throw on negative messageId', () => {
-    expect(() => toThreadId('19:abc@thread.skype', '-1')).toThrow(
+    expect(() => toThreadedConversationId('19:abc@thread.skype', '-1')).toThrow(
       'Invalid messageId'
     );
   });
 
   it('should throw on decimal messageId', () => {
-    expect(() => toThreadId('19:abc@thread.skype', '1.5')).toThrow(
+    expect(() => toThreadedConversationId('19:abc@thread.skype', '1.5')).toThrow(
       'Invalid messageId'
     );
   });
 
   it('should strip existing ;messageid= and replace with thread root', () => {
-    expect(toThreadId('19:abc@thread.skype;messageid=111', '222')).toBe(
+    expect(toThreadedConversationId('19:abc@thread.skype;messageid=111', '222')).toBe(
       '19:abc@thread.skype;messageid=222'
     );
   });

--- a/packages/apps/src/utils/thread.spec.ts
+++ b/packages/apps/src/utils/thread.spec.ts
@@ -1,0 +1,57 @@
+import { toThreadId } from './thread';
+
+describe('toThreadId', () => {
+  it('should construct a threaded conversation ID', () => {
+    expect(toThreadId('19:abc@thread.skype', '1680000000000')).toBe(
+      '19:abc@thread.skype;messageid=1680000000000'
+    );
+  });
+
+  it('should work with different conversation ID formats', () => {
+    expect(toThreadId('19:meeting_abc@thread.v2', '999')).toBe(
+      '19:meeting_abc@thread.v2;messageid=999'
+    );
+  });
+
+  it('should throw on empty conversationId', () => {
+    expect(() => toThreadId('', '123')).toThrow(
+      'conversationId must be a non-empty string'
+    );
+  });
+
+  it('should throw on empty messageId', () => {
+    expect(() => toThreadId('19:abc@thread.skype', '')).toThrow(
+      'Invalid messageId'
+    );
+  });
+
+  it('should throw on zero messageId', () => {
+    expect(() => toThreadId('19:abc@thread.skype', '0')).toThrow(
+      'Invalid messageId'
+    );
+  });
+
+  it('should throw on non-numeric messageId', () => {
+    expect(() => toThreadId('19:abc@thread.skype', 'abc')).toThrow(
+      'Invalid messageId'
+    );
+  });
+
+  it('should throw on negative messageId', () => {
+    expect(() => toThreadId('19:abc@thread.skype', '-1')).toThrow(
+      'Invalid messageId'
+    );
+  });
+
+  it('should throw on decimal messageId', () => {
+    expect(() => toThreadId('19:abc@thread.skype', '1.5')).toThrow(
+      'Invalid messageId'
+    );
+  });
+
+  it('should strip existing ;messageid= and replace with thread root', () => {
+    expect(toThreadId('19:abc@thread.skype;messageid=111', '222')).toBe(
+      '19:abc@thread.skype;messageid=222'
+    );
+  });
+});

--- a/packages/apps/src/utils/thread.spec.ts
+++ b/packages/apps/src/utils/thread.spec.ts
@@ -1,4 +1,4 @@
-import { toThreadId } from './thread';
+import { toThreadId, supportsThreading } from './thread';
 
 describe('toThreadId', () => {
   it('should construct a threaded conversation ID', () => {
@@ -53,5 +53,28 @@ describe('toThreadId', () => {
     expect(toThreadId('19:abc@thread.skype;messageid=111', '222')).toBe(
       '19:abc@thread.skype;messageid=222'
     );
+  });
+});
+
+describe('supportsThreading', () => {
+  it('should return true for @thread.tacv2 (channel)', () => {
+    expect(supportsThreading('19:abc@thread.tacv2')).toBe(true);
+  });
+
+  it('should return true for @thread.skype (classic channel)', () => {
+    expect(supportsThreading('19:abc@thread.skype')).toBe(true);
+  });
+
+  it('should return true for @unq.gbl.spaces (1:1 chat)', () => {
+    expect(supportsThreading('a]8:orgid:user-guid@unq.gbl.spaces')).toBe(true);
+  });
+
+  it('should return false for @thread.v2 (group chat / meeting)', () => {
+    expect(supportsThreading('19:meeting_abc@thread.v2')).toBe(false);
+  });
+
+  it('should check base ID when ;messageid= suffix is present', () => {
+    expect(supportsThreading('19:abc@thread.tacv2;messageid=123')).toBe(true);
+    expect(supportsThreading('19:meeting_abc@thread.v2;messageid=123')).toBe(false);
   });
 });

--- a/packages/apps/src/utils/thread.ts
+++ b/packages/apps/src/utils/thread.ts
@@ -1,0 +1,32 @@
+/**
+ * Constructs a threaded conversation ID by appending `;messageid={messageId}`
+ * to the conversation ID. This is the format APX uses to route messages
+ * to a specific thread.
+ *
+ * @param conversationId the conversation to thread into (e.g. `19:abc@thread.skype`)
+ * @param messageId the thread root message ID (must be a non-zero numeric string)
+ * @returns the threaded conversation ID (e.g. `19:abc@thread.skype;messageid=123`)
+ */
+export function toThreadId(conversationId: string, messageId: string): string {
+  if (!conversationId) {
+    throw new Error('conversationId must be a non-empty string');
+  }
+
+  if (!messageId || !/^\d+$/.test(messageId) || messageId === '0') {
+    throw new Error(
+      `Invalid messageId "${messageId}": must be a non-zero numeric value`
+    );
+  }
+
+  // Strip any existing ;messageid= suffix (mirrors APX's NormalizeConversationId)
+  const baseId = conversationId.split(';')[0];
+  return `${baseId};messageid=${messageId}`;
+}
+
+export function supportsThreading(conversationId: string): boolean {
+  // Check if a conversation ID represents a conversation that supports threading.
+  // Channels use @thread.tacv2 or @thread.skype, 1:1 chats use @unq.gbl.spaces.
+  // Group chats and meetings use @thread.v2 which does not support threading.
+  const base = conversationId.split(';')[0];
+  return base.endsWith('@thread.tacv2') || base.endsWith('@thread.skype') || base.endsWith('@unq.gbl.spaces');
+}

--- a/packages/apps/src/utils/thread.ts
+++ b/packages/apps/src/utils/thread.ts
@@ -7,7 +7,7 @@
  * @param messageId the thread root message ID (must be a non-zero numeric string)
  * @returns the threaded conversation ID (e.g. `19:abc@thread.skype;messageid=123`)
  */
-export function toThreadId(conversationId: string, messageId: string): string {
+export function toThreadedConversationId(conversationId: string, messageId: string): string {
   if (!conversationId) {
     throw new Error('conversationId must be a non-empty string');
   }


### PR DESCRIPTION
## Summary
- Add `app.reply(conversationId, messageId, activity)` for proactive thread sends — constructs threaded conversation ID via `toThreadedConversationId()` for channels and 1:1 chats that support threading
- Add `toThreadedConversationId()` helper exposed for advanced scenarios
- Add `supportsThreading()` internal guard (channels: `@thread.tacv2`/`@thread.skype`, 1:1: `@unq.gbl.spaces`)
- Update `context.send()` and `context.reply()` doc comments to clarify threading vs quoting behavior
- Add threading example bot with commands: `test reply`, `test send`, `test proactive`, `test manual`

## Test plan
- [x] Unit tests for `toThreadedConversationId()` (9 tests), `supportsThreading()` (5 tests), and `app.reply()` (6 tests)
- [x] E2E: All commands tested in 1:1 and channel (top-level + existing thread)
- [x] All tests passed, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)