### PR TITLE
fix: support HTTPS servers and handle named pipe ports

### DIFF
--- a/packages/apps/src/http/express-adapter.spec.ts
+++ b/packages/apps/src/http/express-adapter.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import http from 'http';
+import https from 'https';
 
 import os from 'os';
 import path from 'path';
@@ -10,7 +11,7 @@ import supertest from 'supertest';
 import { ExpressAdapter } from './express-adapter';
 
 describe('ExpressAdapter', () => {
-  let server: http.Server;
+  let server: http.Server | https.Server;
   let adapter: ExpressAdapter;
 
   afterEach(() => {
@@ -194,6 +195,38 @@ describe('ExpressAdapter', () => {
         fs.unlinkSync(indexHtml);
         fs.rmdirSync(tmpDir);
       }
+    });
+  });
+
+  describe('HTTPS server support', () => {
+    it('should accept an https.Server and wire it up correctly', async () => {
+      // https.createServer() without certs creates a valid server object
+      // that is instanceof https.Server (but NOT instanceof http.Server)
+      const httpsServer = https.createServer({});
+
+      expect(httpsServer instanceof https.Server).toBe(true);
+      expect(httpsServer instanceof http.Server).toBe(false);
+
+      expect(() => {
+        adapter = new ExpressAdapter(httpsServer);
+      }).not.toThrow();
+
+      // Verify the adapter stored the server: stop() should reject with
+      // "Server is not running" (not "managed externally" which would mean
+      // the adapter didn't recognize the https.Server and created its own)
+      await expect(adapter.stop()).rejects.toThrow('Server is not running');
+    });
+
+    it('should register routes on https.Server', () => {
+      const httpsServer = https.createServer({});
+      adapter = new ExpressAdapter(httpsServer);
+
+      // Should not throw — routes register on the internal Express app
+      expect(() => {
+        adapter.registerRoute('POST', '/api/messages', async () => {
+          return { status: 200, body: { ok: true } };
+        });
+      }).not.toThrow();
     });
   });
 });

--- a/packages/apps/src/http/express-adapter.ts
+++ b/packages/apps/src/http/express-adapter.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import https from 'https';
 
 import cors from 'cors';
 import express from 'express';
@@ -27,12 +28,12 @@ export class ExpressAdapter implements IHttpServerAdapter {
   readonly use: express.Application['use'];
 
   protected express: express.Application;
-  protected server?: http.Server;
+  protected server?: http.Server | https.Server;
   protected logger: ILogger;
   protected onError?: (err: Error) => void;
 
-  constructor(serverOrApp?: http.Server | express.Application, options?: { logger?: ILogger; onError?: (err: Error) => void }) {
-    if (serverOrApp instanceof http.Server) {
+  constructor(serverOrApp?: http.Server | https.Server | express.Application, options?: { logger?: ILogger; onError?: (err: Error) => void }) {
+    if (serverOrApp instanceof http.Server || serverOrApp instanceof https.Server) {
       // The adapter handles all requests on this server. Use the adapter's
       // methods (get, post, use, etc.) to add routes. If you need your own
       // Express app, pass it in instead and manage the server yourself.

--- a/packages/dev/src/plugin.ts
+++ b/packages/dev/src/plugin.ts
@@ -103,8 +103,20 @@ export class DevtoolsPlugin {
   }
 
   onStart({ port }: IPluginStartEvent) {
-    const numericPort = this.options.customPort ?? (
-      typeof port === 'string' ? parseInt(port, 10) + 1 : port + 1);
+    let numericPort: number;
+    if (this.options.customPort) {
+      numericPort = this.options.customPort;
+    } else if (typeof port === 'number') {
+      numericPort = port + 1;
+    } else {
+      const parsed = parseInt(port, 10);
+      if (isNaN(parsed)) {
+        numericPort = 3979;
+        this.log.warn(`Port is a named pipe (${port}), using default devtools port ${numericPort}. Set customPort to override.`);
+      } else {
+        numericPort = parsed + 1;
+      }
+    }
 
     this.express.use(
       router({


### PR DESCRIPTION
## Summary

Fixes #511. Two bugs that affected HTTPS and Azure App Service deployments:

### 1. ExpressAdapter silently falls back to HTTP when given an HTTPS server

`ExpressAdapter` constructor uses `instanceof http.Server` to detect when a server is passed. However, `https.Server` extends `tls.Server` (not `http.Server`), so `https.createServer() instanceof http.Server` returns `false`. The adapter silently falls through to create its own `http.Server`, ignoring the user's HTTPS server entirely — **a silent HTTP downgrade with no error**.

**Fix:** Import `https` and check `serverOrApp instanceof http.Server || serverOrApp instanceof https.Server`. Widen the constructor parameter and `server` field types to `http.Server | https.Server`.

### 2. DevtoolsPlugin crashes on Azure App Service named pipe ports

On Azure App Service (IIS + iisnode), the `PORT` environment variable is a Windows named pipe path like `\.\pipe\507cb72a-...`. DevtoolsPlugin calls `parseInt(port, 10) + 1` to derive its port, which returns `NaN + 1 = NaN`, crashing the devtools HTTP server. Same root cause as #487 (fixed in #488 for `HttpServer.start()`, but missed in `DevtoolsPlugin.onStart()`).

**Fix:** Explicit branching — if port is a named pipe (non-numeric string), fall back to port 3979 with a warning suggesting `customPort` option.

## Test plan

- [x] 12/12 unit tests pass (10 existing + 2 new HTTPS tests)
- [x] New test: `https.createServer({} ) instanceof https.Server === true` and `instanceof http.Server === false` (documents root cause)
- [x] New test: `ExpressAdapter(httpsServer)` wires up correctly (stop rejects with "not running", not "managed externally")
- [x] New test: route registration works on https.Server
- [x] E2E: HTTPS server scenario — bot receives activities over HTTPS
- [x] E2E: Named pipe scenario — DevtoolsPlugin starts on fallback port with warning
- [x] E2E: HTTP regression — existing http.Server path unchanged

## Files changed

| File | Change |
|------|--------|
| `packages/apps/src/http/express-adapter.ts` | Accept `https.Server`, widen types |
| `packages/dev/src/plugin.ts` | Handle named pipe port with fallback |
| `packages/apps/src/http/express-adapter.spec.ts` | 2 new HTTPS server tests |

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>