### PR TITLE
fix: improve error message when app credentials are missing

### DIFF
--- a/packages/apps/src/app.spec.ts
+++ b/packages/apps/src/app.spec.ts
@@ -179,7 +179,7 @@ describe('App', () => {
 
       await expect(
         app.testSend('conversation-id', { text: 'Hello' })
-      ).rejects.toThrow('app not started');
+      ).rejects.toThrow('App has no credentials set up');
     });
   });
 

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -522,7 +522,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
    */
   async send(conversationId: string, activity: ActivityLike) {
     if (!this.id) {
-      throw new Error('app not started');
+      throw new Error('App has no credentials set up');
     }
 
     const params = toActivityParams(activity);


### PR DESCRIPTION
Updated the error message in `App.send()` when `this.id` is not set from "app not started" to "App has no credentials set up" for clarity. The error message was misleading and not very helpful to the user to debug.