### PR TITLE
feat: add action-based sub-route routing for dialogs and card actions

### DIFF
--- a/examples/cards/src/index.ts
+++ b/examples/cards/src/index.ts
@@ -1,5 +1,4 @@
 import {
-  AdaptiveCardActionErrorResponse,
   AdaptiveCardActionMessageResponse,
 } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
@@ -303,78 +302,55 @@ app.on('message', async ({ send, activity }) => {
   // await send(message);
 });
 
-app.on('card.action', async ({ activity, send }) => {
-  const data = activity.value?.action?.data;
-  if (!data?.action) {
-    return {
-      statusCode: 400,
-      type: 'application/vnd.microsoft.error',
-      value: {
-        code: 'BadRequest',
-        message: 'No action specified',
-        innerHttpError: {
-          statusCode: 400,
-          body: { error: 'No action specified' },
-        },
-      },
-    } satisfies AdaptiveCardActionErrorResponse;
-  }
+// Each card.action handler matches a specific action set by SubmitData
+const OK_RESPONSE: AdaptiveCardActionMessageResponse = {
+  statusCode: 200,
+  type: 'application/vnd.microsoft.activity.message',
+  value: 'Action processed successfully',
+};
 
-  console.debug('Received action data:', data);
+app.on('card.action.submit_basic', async ({ activity, send }) => {
+  const data = activity.value.action.data;
+  await send(`Notification preference set to: ${data.notify}`);
+  return OK_RESPONSE;
+});
 
-  switch (data.action) {
-    case 'submit_basic':
-      await send(`Notification preference set to: ${data.notify}`);
-      break;
+app.on('card.action.submit_form', async ({ activity, send }) => {
+  const data = activity.value.action.data;
+  await send(
+    `Form submitted!\nName: ${data.name}\nComments: ${data.comments}\nColor: ${data.color}`
+  );
+  return OK_RESPONSE;
+});
 
-    case 'submit_form':
-      await send(
-        `Form submitted!\nName: ${data.name}\nComments: ${data.comments}\nColor: ${data.color}`
-      );
-      break;
+app.on('card.action.create_task', async ({ activity, send }) => {
+  const data = activity.value.action.data;
+  await send(
+    `Task created!\nTitle: ${data.title}\nDescription: ${data.description}\nPriority: ${data.priority}\nDue Date: ${data.due_date}`
+  );
+  return OK_RESPONSE;
+});
 
-    case 'create_task':
-      await send(
-        `Task created!\nTitle: ${data.title}\nDescription: ${data.description}\nPriority: ${data.priority}\nDue Date: ${data.due_date}`
-      );
-      break;
+app.on('card.action.submit_feedback', async ({ activity, send }) => {
+  const data = activity.value.action.data;
+  await send(`Feedback received: ${data.feedback}`);
+  return OK_RESPONSE;
+});
 
-    case 'submit_feedback':
-      await send(`Feedback received: ${data.feedback}`);
-      break;
+app.on('card.action.purchase_item', async ({ activity, send }) => {
+  const data = activity.value.action.data;
+  await send(
+    `Purchase request received for game: ${data.choiceGameSingle}`
+  );
+  return OK_RESPONSE;
+});
 
-    case 'purchase_item':
-      await send(
-        `Purchase request received for game: ${data.choiceGameSingle}`
-      );
-      break;
-
-    case 'save_profile':
-      await send(
-        `Profile saved!\nName: ${data.name}\nEmail: ${data.email}\nSubscribed: ${data.subscribe}`
-      );
-      break;
-
-    default:
-      return {
-        statusCode: 400,
-        type: 'application/vnd.microsoft.error',
-        value: {
-          code: 'BadRequest',
-          message: 'Unknown action',
-          innerHttpError: {
-            statusCode: 400,
-            body: { error: 'Unknown action' },
-          },
-        },
-      } satisfies AdaptiveCardActionErrorResponse;
-  }
-
-  return {
-    statusCode: 200,
-    type: 'application/vnd.microsoft.activity.message',
-    value: 'Action processed successfully',
-  } satisfies AdaptiveCardActionMessageResponse;
+app.on('card.action.save_profile', async ({ activity, send }) => {
+  const data = activity.value.action.data;
+  await send(
+    `Profile saved!\nName: ${data.name}\nEmail: ${data.email}\nSubscribed: ${data.subscribe}`
+  );
+  return OK_RESPONSE;
 });
 
 app.start(process.env.PORT || 3978).catch(console.error);

--- a/examples/dialogs/README.md
+++ b/examples/dialogs/README.md
@@ -1,6 +1,13 @@
-# Sample: cards
+# Sample: dialogs
 
-a demo of dialogs in Teams
+A demo of dialogs (task modules) in Teams.
+
+## Features
+
+- **Sub-route routing** — Each dialog is handled by a targeted route (e.g., `dialog.open.simple_form`, `dialog.submit.webpage_dialog`) instead of a single catch-all handler with manual dispatch.
+- **Adaptive Card dialogs** — Simple form and multi-step form examples using Adaptive Cards with `Action.Submit`.
+- **Webpage dialogs** — Opens an HTML page hosted by the bot inside a Teams task module.
+- **Card action routing** — Adaptive Card `Action.Execute` actions routed via `card.action.{action}` sub-routes.
 
 ## Prerequisites
 

--- a/examples/dialogs/src/index.ts
+++ b/examples/dialogs/src/index.ts
@@ -9,6 +9,7 @@ import {
   IAdaptiveCard,
   OpenDialogData,
   SubmitAction,
+  SubmitData,
   TextInput,
 } from '@microsoft/teams.cards';
 import { ConsoleLogger } from '@microsoft/teams.common';
@@ -58,215 +59,150 @@ app.on('message', async ({ send }) => {
   await send(new MessageActivity('Enter this form').addCard('adaptive', card));
 });
 
-/**
-app.on('dialog.open', async ({ activity }) => {
-  const card: IAdaptiveCard = new AdaptiveCard()...
-
-  // Return an object with the task value that renders a card
-  return {
-    task: {
-      type: 'continue',
-      value: {
-        title: 'Title of Dialog',
-        card: cardAttachment('adaptive', card),
-      },
-    },
-  };
-}
-*/
-
 app.event('error', ({ error }) => {
   logger.error('Error', error);
 });
 
-app.on('dialog.open', async ({ activity, next }) => {
-  const dialogType = activity.value.data.dialog_id;
+// Each dialog.open handler matches a specific dialog_id set by OpenDialogData
+app.on('dialog.open.simple_form', async () => {
+  const dialogCard = new AdaptiveCard(
+    {
+      type: 'TextBlock',
+      text: 'This is a simple form',
+      size: 'Large',
+      weight: 'Bolder',
+    },
+    new TextInput()
+      .withLabel('Name')
+      .withIsRequired()
+      .withId('name')
+      .withPlaceholder('Enter your name')
+  ).withActions(
+    new SubmitAction()
+      .withTitle('Submit')
+      .withData(new SubmitData('simple_form'))
+  );
 
-  if (dialogType === 'simple_form') {
-    const dialogCard = new AdaptiveCard(
-      {
-        type: 'TextBlock',
-        text: 'This is a simple form',
-        size: 'Large',
-        weight: 'Bolder',
+  return {
+    task: {
+      type: 'continue',
+      value: {
+        title: 'Simple Form Dialog',
+        card: cardAttachment('adaptive', dialogCard),
       },
-      new TextInput()
-        .withLabel('Name')
-        .withIsRequired()
-        .withId('name')
-        .withPlaceholder('Enter your name')
-    )
-      // Inside the dialog, the card actions for submitting the card must be
-      // of type Action.Submit
-      .withActions(
-        new SubmitAction()
-          .withTitle('Submit')
-          .withData({ submissiondialogtype: 'simple_form' })
-      );
-
-    // Return an object with the task value that renders a card
-    return {
-      task: {
-        type: 'continue',
-        value: {
-          title: 'Simple Form Dialog',
-          card: cardAttachment('adaptive', dialogCard),
-        },
-      },
-    };
-  }
-
-  if (dialogType === 'webpage_dialog') {
-    return {
-      task: {
-        type: 'continue',
-        value: {
-          title: 'Webpage Dialog',
-          // Here we are using a webpage that is hosted in the same
-          // server as the agent. This server needs to be publicly accessible,
-          // needs to set up teams.js client library (https://www.npmjs.com/package/@microsoft/teams-js)
-          // and needs to be registered in the manifest.
-          url: `${process.env['BOT_ENDPOINT']}/tabs/dialog-form`,
-          width: 1000,
-          height: 800,
-        },
-      },
-    };
-  }
-  next();
+    },
+  };
 });
 
-app.on('dialog.open', async ({ activity, next }) => {
-  const dialogType = activity.value.data.dialog_id;
-
-  if (dialogType === 'multi_step_form') {
-    const dialogCard = new AdaptiveCard(
-      {
-        type: 'TextBlock',
-        text: 'This is a multi-step form',
-        size: 'Large',
-        weight: 'Bolder',
+app.on('dialog.open.webpage_dialog', async () => {
+  return {
+    task: {
+      type: 'continue',
+      value: {
+        title: 'Webpage Dialog',
+        // Here we are using a webpage that is hosted in the same
+        // server as the agent. This server needs to be publicly accessible,
+        // needs to set up teams.js client library (https://www.npmjs.com/package/@microsoft/teams-js)
+        // and needs to be registered in the manifest.
+        url: `${process.env['BOT_ENDPOINT']}/tabs/dialog-form`,
+        width: 1000,
+        height: 800,
       },
-      new TextInput()
-        .withLabel('Name')
-        .withIsRequired()
-        .withId('name')
-        .withPlaceholder('Enter your name')
-    )
-      // Inside the dialog, the card actions for submitting the card must be
-      // of type Action.Submit
-      .withActions(
-        new SubmitAction()
-          .withTitle('Submit')
-          .withData({ submissiondialogtype: 'webpage_dialog_step_1' })
-      );
-
-    // Return an object with the task value that renders a card
-    return {
-      task: {
-        type: 'continue',
-        value: {
-          title: 'Multi-step Form Dialog',
-          card: cardAttachment('adaptive', dialogCard),
-        },
-      },
-    };
-  }
-
-  next();
+    },
+  };
 });
 
-app.on('dialog.submit', async ({ activity, send, next }) => {
-  const dialogType = activity.value.data?.submissiondialogtype;
+app.on('dialog.open.multi_step_form', async () => {
+  const dialogCard = new AdaptiveCard(
+    {
+      type: 'TextBlock',
+      text: 'This is a multi-step form',
+      size: 'Large',
+      weight: 'Bolder',
+    },
+    new TextInput()
+      .withLabel('Name')
+      .withIsRequired()
+      .withId('name')
+      .withPlaceholder('Enter your name')
+  ).withActions(
+    new SubmitAction()
+      .withTitle('Submit')
+      .withData(new SubmitData('multi_step_1'))
+  );
 
-  if (dialogType === 'simple_form') {
-    // This is data from the form that was submitted
-    const name = activity.value.data.name;
-    await send(`Hi ${name}, thanks for submitting the form!`);
-    return {
-      task: {
-        type: 'message',
-        // This appears as a final message in the dialog
-        value: 'Form was submitted',
+  return {
+    task: {
+      type: 'continue',
+      value: {
+        title: 'Multi-step Form Dialog',
+        card: cardAttachment('adaptive', dialogCard),
       },
-    };
-  }
+    },
+  };
+});
 
-  next();
+// Each dialog.submit handler matches a specific action set by SubmitData
+app.on('dialog.submit.simple_form', async ({ activity, send }) => {
+  const name = activity.value.data.name;
+  await send(`Hi ${name}, thanks for submitting the form!`);
+  return {
+    task: {
+      type: 'message',
+      value: 'Form was submitted',
+    },
+  };
 });
 
 // The submission from a webpage happens via the microsoftTeams.tasks.submitTask(formData)
 // call.
-app.on('dialog.submit', async ({ activity, send, next }) => {
-  const dialogType = activity.value.data.submissiondialogtype;
-
-  if (dialogType === 'webpage_dialog') {
-    // This is data from the form that was submitted
-    const name = activity.value.data.name;
-    const email = activity.value.data.email;
-    await send(
-      `Hi ${name}, thanks for submitting the form! We got that your email is ${email}`
-    );
-    // You can also return a blank response
-    return {
-      status: 200,
-    };
-  }
-
-  next();
+app.on('dialog.submit.webpage_dialog', async ({ activity, send }) => {
+  const name = activity.value.data.name;
+  const email = activity.value.data.email;
+  await send(
+    `Hi ${name}, thanks for submitting the form! We got that your email is ${email}`
+  );
+  return { status: 200 };
 });
 
-app.on('dialog.submit', async ({ activity, send, next }) => {
-  const dialogType = activity.value.data.submissiondialogtype;
-
-  if (dialogType === 'webpage_dialog_step_1') {
-    // This is data from the form that was submitted
-    const name = activity.value.data.name;
-    const nextStepCard = new AdaptiveCard(
-      {
-        type: 'TextBlock',
-        text: 'Email',
-        size: 'Large',
-        weight: 'Bolder',
+app.on('dialog.submit.multi_step_1', async ({ activity }) => {
+  const name = activity.value.data.name;
+  const nextStepCard = new AdaptiveCard(
+    {
+      type: 'TextBlock',
+      text: 'Email',
+      size: 'Large',
+      weight: 'Bolder',
+    },
+    new TextInput()
+      .withLabel('Email')
+      .withIsRequired()
+      .withId('email')
+      .withPlaceholder('Enter your email')
+  ).withActions(
+    new SubmitAction()
+      .withTitle('Submit')
+      // Carry forward data from previous step
+      .withData(new SubmitData('multi_step_2', { name }))
+  );
+  return {
+    task: {
+      type: 'continue',
+      value: {
+        title: `Thanks ${name} - Get Email`,
+        card: cardAttachment('adaptive', nextStepCard),
       },
-      new TextInput()
-        .withLabel('Email')
-        .withIsRequired()
-        .withId('email')
-        .withPlaceholder('Enter your email')
-    ).withActions(
-      new SubmitAction().withTitle('Submit').withData({
-        // This same handler will get called, so we need to identify the step
-        // in the returned data
-        submissiondialogtype: 'webpage_dialog_step_2',
-        // Carry forward data from previous step
-        name,
-      })
-    );
-    return {
-      task: {
-        // This indicates that the dialog flow should continue
-        type: 'continue',
-        value: {
-          // Here we customize the title based on the previous response
-          title: `Thanks ${name} - Get Email`,
-          card: cardAttachment('adaptive', nextStepCard),
-        },
-      },
-    };
-  } else if (dialogType === 'webpage_dialog_step_2') {
-    const name = activity.value.data.name;
-    const email = activity.value.data.email;
-    await send(
-      `Hi ${name}, thanks for submitting the form! We got that your email is ${email}`
-    );
-    // You can also return a blank response
-    return {
-      status: 200,
-    };
-  }
+    },
+  };
+});
 
-  next();
+app.on('dialog.submit.multi_step_2', async ({ activity, send }) => {
+  const name = activity.value.data.name;
+  const email = activity.value.data.email;
+  await send(
+    `Hi ${name}, thanks for submitting the form! We got that your email is ${email}`
+  );
+  return { status: 200 };
 });
 
 app.start(process.env.PORT || 3978).catch(console.error);

--- a/examples/dialogs/src/views/customform/index.html
+++ b/examples/dialogs/src/views/customform/index.html
@@ -32,7 +32,7 @@
       let formData = {
         name: document.getElementById('name').value,
         email: document.getElementById('email').value,
-        submissiondialogtype: 'webpage_dialog'
+        action: 'webpage_dialog'
       };
       microsoftTeams.tasks.submitTask(formData);
     });

--- a/packages/apps/src/router/router.spec.ts
+++ b/packages/apps/src/router/router.spec.ts
@@ -255,6 +255,89 @@ describe('Router', () => {
       } as any)).toHaveLength(1);
     });
 
+    it('should select dialog open sub-routes by dialog_id', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('invoke', handler);
+      router.on('dialog.open', handler);
+      router.on('dialog.open.simple_form' as any, handler);
+
+      // Matches invoke + dialog.open + dialog.open.simple_form
+      expect(router.select({
+        type: 'invoke',
+        name: 'task/fetch',
+        value: { data: { dialog_id: 'simple_form' } }
+      } as any)).toHaveLength(3);
+
+      // Matches invoke + dialog.open but NOT dialog.open.simple_form
+      expect(router.select({
+        type: 'invoke',
+        name: 'task/fetch',
+        value: { data: { dialog_id: 'other_form' } }
+      } as any)).toHaveLength(2);
+
+      // Matches invoke + dialog.open (no data at all)
+      expect(router.select({
+        type: 'invoke',
+        name: 'task/fetch',
+        value: {}
+      } as any)).toHaveLength(2);
+    });
+
+    it('should select dialog submit sub-routes by action', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('invoke', handler);
+      router.on('dialog.submit', handler);
+      router.on('dialog.submit.submit_form' as any, handler);
+
+      // Matches invoke + dialog.submit + dialog.submit.submit_form
+      expect(router.select({
+        type: 'invoke',
+        name: 'task/submit',
+        value: { data: { action: 'submit_form' } }
+      } as any)).toHaveLength(3);
+
+      // Matches invoke + dialog.submit but NOT dialog.submit.submit_form
+      expect(router.select({
+        type: 'invoke',
+        name: 'task/submit',
+        value: { data: { action: 'other_action' } }
+      } as any)).toHaveLength(2);
+    });
+
+    it('should select card action sub-routes by action', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('invoke', handler);
+      router.on('card.action', handler);
+      router.on('card.action.save_profile' as any, handler);
+
+      // Matches invoke + card.action + card.action.save_profile
+      expect(router.select({
+        type: 'invoke',
+        name: 'adaptiveCard/action',
+        value: { action: { type: 'Action.Execute', data: { action: 'save_profile' } } }
+      } as any)).toHaveLength(3);
+
+      // Matches invoke + card.action but NOT card.action.save_profile
+      expect(router.select({
+        type: 'invoke',
+        name: 'adaptiveCard/action',
+        value: { action: { type: 'Action.Execute', data: { action: 'other_action' } } }
+      } as any)).toHaveLength(2);
+
+      // Does not match sub-route when no action field in data
+      expect(router.select({
+        type: 'invoke',
+        name: 'adaptiveCard/action',
+        value: { action: { type: 'Action.Execute', data: { name: 'test' } } }
+      } as any)).toHaveLength(2);
+    });
+
     it('should select message submit action routes', () => {
       const router = new Router();
       const handler = jest.fn();

--- a/packages/apps/src/router/router.spec.ts
+++ b/packages/apps/src/router/router.spec.ts
@@ -261,7 +261,7 @@ describe('Router', () => {
 
       router.on('invoke', handler);
       router.on('dialog.open', handler);
-      router.on('dialog.open.simple_form' as any, handler);
+      router.on('dialog.open.simple_form', handler);
 
       // Matches invoke + dialog.open + dialog.open.simple_form
       expect(router.select({
@@ -291,7 +291,7 @@ describe('Router', () => {
 
       router.on('invoke', handler);
       router.on('dialog.submit', handler);
-      router.on('dialog.submit.submit_form' as any, handler);
+      router.on('dialog.submit.submit_form', handler);
 
       // Matches invoke + dialog.submit + dialog.submit.submit_form
       expect(router.select({
@@ -314,7 +314,7 @@ describe('Router', () => {
 
       router.on('invoke', handler);
       router.on('card.action', handler);
-      router.on('card.action.save_profile' as any, handler);
+      router.on('card.action.save_profile', handler);
 
       // Matches invoke + card.action + card.action.save_profile
       expect(router.select({

--- a/packages/apps/src/router/router.ts
+++ b/packages/apps/src/router/router.ts
@@ -107,28 +107,16 @@ export class Router<TExtraCtx extends Record<string, any> = Record<string, any>>
             return event === `message.submit.${activity.value.actionName}`;
           }
 
-          // dialog.open.{dialogId} → matches value.data.dialog_id
-          if (activity.name === 'task/fetch') {
-            const prefix = 'dialog.open.';
-            if (typeof event === 'string' && (event as string).startsWith(prefix)) {
-              return activity.value?.data?.dialog_id === (event as string).slice(prefix.length);
-            }
+          if (activity.name === 'task/fetch' && activity.value?.data?.dialog_id) {
+            return event === `dialog.open.${activity.value.data.dialog_id}`;
           }
 
-          // dialog.submit.{action} → matches value.data.action
-          if (activity.name === 'task/submit') {
-            const prefix = 'dialog.submit.';
-            if (typeof event === 'string' && (event as string).startsWith(prefix)) {
-              return activity.value?.data?.action === (event as string).slice(prefix.length);
-            }
+          if (activity.name === 'task/submit' && activity.value?.data?.action) {
+            return event === `dialog.submit.${activity.value.data.action}`;
           }
 
-          // card.action.{action} → matches value.action.data.action
-          if (activity.name === 'adaptiveCard/action') {
-            const prefix = 'card.action.';
-            if (typeof event === 'string' && (event as string).startsWith(prefix)) {
-              return activity.value?.action?.data?.action === (event as string).slice(prefix.length);
-            }
+          if (activity.name === 'adaptiveCard/action' && activity.value?.action?.data?.action) {
+            return event === `card.action.${activity.value.action.data.action}`;
           }
         }
 

--- a/packages/apps/src/router/router.ts
+++ b/packages/apps/src/router/router.ts
@@ -106,6 +106,30 @@ export class Router<TExtraCtx extends Record<string, any> = Record<string, any>>
           if (activity.name === 'message/submitAction') {
             return event === `message.submit.${activity.value.actionName}`;
           }
+
+          // dialog.open.{dialogId} → matches value.data.dialog_id
+          if (activity.name === 'task/fetch') {
+            const prefix = 'dialog.open.';
+            if (typeof event === 'string' && (event as string).startsWith(prefix)) {
+              return activity.value?.data?.dialog_id === (event as string).slice(prefix.length);
+            }
+          }
+
+          // dialog.submit.{action} → matches value.data.action
+          if (activity.name === 'task/submit') {
+            const prefix = 'dialog.submit.';
+            if (typeof event === 'string' && (event as string).startsWith(prefix)) {
+              return activity.value?.data?.action === (event as string).slice(prefix.length);
+            }
+          }
+
+          // card.action.{action} → matches value.action.data.action
+          if (activity.name === 'adaptiveCard/action') {
+            const prefix = 'card.action.';
+            if (typeof event === 'string' && (event as string).startsWith(prefix)) {
+              return activity.value?.action?.data?.action === (event as string).slice(prefix.length);
+            }
+          }
         }
 
         // custom routes

--- a/packages/apps/src/routes/invoke/card-action.ts
+++ b/packages/apps/src/routes/invoke/card-action.ts
@@ -1,0 +1,11 @@
+import { IAdaptiveCardActionInvokeActivity, InvokeResponse } from '@microsoft/teams.api';
+
+import { IActivityContext } from '../../contexts';
+import { RouteHandler } from '../../types';
+
+export type CardActionSubRoutes<TExtraCtx extends Record<string, any> = Record<string, any>> = {
+  [K in `card.action.${string}`]?: RouteHandler<
+    IActivityContext<IAdaptiveCardActionInvokeActivity, TExtraCtx>,
+    InvokeResponse<'adaptiveCard/action'> | InvokeResponse<'adaptiveCard/action'>['body']
+  >;
+};

--- a/packages/apps/src/routes/invoke/dialog-open.ts
+++ b/packages/apps/src/routes/invoke/dialog-open.ts
@@ -1,0 +1,11 @@
+import { ITaskFetchInvokeActivity, InvokeResponse } from '@microsoft/teams.api';
+
+import { IActivityContext } from '../../contexts';
+import { RouteHandler } from '../../types';
+
+export type DialogOpenSubRoutes<TExtraCtx extends Record<string, any> = Record<string, any>> = {
+  [K in `dialog.open.${string}`]?: RouteHandler<
+    IActivityContext<ITaskFetchInvokeActivity, TExtraCtx>,
+    InvokeResponse<'task/fetch'> | InvokeResponse<'task/fetch'>['body']
+  >;
+};

--- a/packages/apps/src/routes/invoke/dialog-submit.ts
+++ b/packages/apps/src/routes/invoke/dialog-submit.ts
@@ -1,0 +1,11 @@
+import { ITaskSubmitInvokeActivity, InvokeResponse } from '@microsoft/teams.api';
+
+import { IActivityContext } from '../../contexts';
+import { RouteHandler } from '../../types';
+
+export type DialogSubmitSubRoutes<TExtraCtx extends Record<string, any> = Record<string, any>> = {
+  [K in `dialog.submit.${string}`]?: RouteHandler<
+    IActivityContext<ITaskSubmitInvokeActivity, TExtraCtx>,
+    InvokeResponse<'task/submit'> | InvokeResponse<'task/submit'>['body']
+  >;
+};

--- a/packages/apps/src/routes/invoke/index.ts
+++ b/packages/apps/src/routes/invoke/index.ts
@@ -3,6 +3,9 @@ import { InvokeActivity, InvokeResponse } from '@microsoft/teams.api';
 import { IActivityContext } from '../../contexts';
 import { RouteHandler } from '../../types';
 
+import { CardActionSubRoutes } from './card-action';
+import { DialogOpenSubRoutes } from './dialog-open';
+import { DialogSubmitSubRoutes } from './dialog-submit';
 import { FileConsentActivityRoutes } from './file-consent';
 import { MessageExtensionSubmitActivityRoutes } from './message-extension-submit';
 import { MessageSubmitActivityRoutes } from './message-submit';
@@ -14,7 +17,10 @@ export type InvokeActivityRoutes<TExtraCtx extends Record<string, any> = Record<
   >;
 } & FileConsentActivityRoutes &
   MessageExtensionSubmitActivityRoutes &
-  MessageSubmitActivityRoutes;
+  MessageSubmitActivityRoutes &
+  DialogOpenSubRoutes<TExtraCtx> &
+  DialogSubmitSubRoutes<TExtraCtx> &
+  CardActionSubRoutes<TExtraCtx>;
 
 type InvokeAliases = {
   'config/fetch': 'config.open';
@@ -68,6 +74,9 @@ export const INVOKE_ALIASES: InvokeAliases = {
   'adaptiveCard/action': 'card.action',
 };
 
+export * from './card-action';
+export * from './dialog-open';
+export * from './dialog-submit';
 export * from './file-consent';
 export * from './message-extension-submit';
 export * from './message-submit';


### PR DESCRIPTION
## Summary
- Add dot-separated sub-route routing for `dialog.open.{dialogId}`, `dialog.submit.{action}`, and `card.action.{action}`, matching the pattern used by `file.consent.accept` and `message.submit.feedback`
- Route selectors match against `value.data.dialog_id` (dialog open), `value.data.action` (dialog submit), and `value.action.data.action` (card action)
- Pairs with the existing `OpenDialogData` and `SubmitData` card utilities that set these reserved fields

## Usage
```ts
// Before: single catch-all handler with manual dispatch
app.on('dialog.open', (ctx) => {
  const dialogId = ctx.activity.value.data?.dialog_id;
  if (dialogId === 'simple_form') { ... }
});

// After: targeted handler per identifier
app.on('dialog.open.simple_form', (ctx) => { ... });
app.on('dialog.submit.submit_form', (ctx) => { ... });
app.on('card.action.save_profile', (ctx) => { ... });
```

## Test plan
- [x] New router tests verify sub-route selection for all three invoke types
- [x] Existing catch-all routes (`dialog.open`, `dialog.submit`, `card.action`) continue to work
- [x] Tested cards and dialogs examples and things work as usual. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)