### PR TITLE
Bump version to 2.0.9-preview

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.8-preview.{height}",
+  "version": "2.0.9-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release$"


### PR DESCRIPTION
## Summary
- Post-release version bump after v2.0.8 release
- Sets `version.json` to `2.0.9-preview.{height}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)