### PR TITLE
Extract threading suffixes to constant

### DIFF
--- a/packages/apps/src/utils/thread.ts
+++ b/packages/apps/src/utils/thread.ts
@@ -1,3 +1,8 @@
+// Conversation ID suffixes that support threading.
+// Channels use @thread.tacv2 or @thread.skype, 1:1 chats use @unq.gbl.spaces.
+// Group chats and meetings use @thread.v2 which does not support threading.
+const THREADING_SUFFIXES = ['@thread.tacv2', '@thread.skype', '@unq.gbl.spaces'] as const;
+
 /**
  * Constructs a threaded conversation ID by appending `;messageid={messageId}`
  * to the conversation ID. This is the format APX uses to route messages
@@ -23,10 +28,8 @@ export function toThreadedConversationId(conversationId: string, messageId: stri
   return `${baseId};messageid=${messageId}`;
 }
 
+// Check if a conversation ID represents a conversation that supports threading.
 export function supportsThreading(conversationId: string): boolean {
-  // Check if a conversation ID represents a conversation that supports threading.
-  // Channels use @thread.tacv2 or @thread.skype, 1:1 chats use @unq.gbl.spaces.
-  // Group chats and meetings use @thread.v2 which does not support threading.
   const base = conversationId.split(';')[0];
-  return base.endsWith('@thread.tacv2') || base.endsWith('@thread.skype') || base.endsWith('@unq.gbl.spaces');
+  return THREADING_SUFFIXES.some(suffix => base.endsWith(suffix));
 }


### PR DESCRIPTION
## Summary
- Extract `@thread.tacv2`, `@thread.skype`, `@unq.gbl.spaces` suffixes into a `THREADING_SUFFIXES` constant in `thread.ts`
- `supportsThreading()` now uses `THREADING_SUFFIXES.some()` instead of chained `endsWith()` calls
- Matches the pattern used in the Python SDK (per PR review feedback)

## Test plan
- [x] All 14 thread utility tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)