### PR TITLE
Remove supportsThreading guard from app.reply()

### DIFF
--- a/examples/threading/README.md
+++ b/examples/threading/README.md
@@ -9,14 +9,15 @@ A bot that demonstrates reactive and proactive threading in Microsoft Teams chan
 | `test reply` | `context.reply()` — reactive threaded reply with visual quote |
 | `test send` | `context.send()` — reactive send to same thread, no quote |
 | `test proactive` | `app.reply()` — proactive threaded reply |
-| `test manual` | `toThreadedConversationId()` + `app.send()` — advanced manual control (channels and 1:1 chats only) |
+| `test manual` | `toThreadedConversationId()` + `app.send()` — advanced manual control |
 | `help` | Shows available commands |
 
 ## Notes
 
 - `test reply` and `test send` work in all scopes (1:1, group chat, channels)
-- `test proactive` works in all scopes — in channels it threads, in non-threading scopes it sends normally
-- `test manual` only works in channels and 1:1 chats since `toThreadedConversationId()` constructs a threaded conversation ID (group chats and meetings do not support threading)
+- `test proactive` constructs a threaded conversation ID and sends to that thread
+- `test manual` does the same using `toThreadedConversationId()` + `app.send()` directly
+- `test proactive` and `test manual` will return a service error in meetings, which do not currently support threading
 
 ## Run
 

--- a/examples/threading/src/index.ts
+++ b/examples/threading/src/index.ts
@@ -47,12 +47,6 @@ app.on('message', async ({ reply, send, activity, ref }) => {
   // toThreadedConversationId() + app.send() — advanced manual control (channels only)
   // ============================================
   if (text.includes('test manual')) {
-    // toThreadedConversationId() is only valid for conversations that support threading
-    const base = conversationId.split(';')[0];
-    if (!base.endsWith('@thread.tacv2') && !base.endsWith('@thread.skype') && !base.endsWith('@unq.gbl.spaces')) {
-      await reply('This command doesn\'t support threading in this conversation type.');
-      return;
-    }
     const threadId = toThreadedConversationId(conversationId, threadRootId);
     await app.send(threadId, 'This was sent using toThreadedConversationId() + app.send() for manual control.');
     return;

--- a/packages/apps/src/app.spec.ts
+++ b/packages/apps/src/app.spec.ts
@@ -384,7 +384,7 @@ describe('App', () => {
       expect(ref.conversation.id).toBe('19:abc@thread.skype;messageid=123');
     });
 
-    it('should pass conversationId as-is when conversation does not support threading (three-arg form)', async () => {
+    it('should construct threaded ID for any conversation type (three-arg form)', async () => {
       const mockSend = jest.fn().mockResolvedValue({ id: 'activity-id' });
       jest.spyOn(app.testActivitySender, 'send').mockImplementation(mockSend);
 
@@ -392,7 +392,7 @@ describe('App', () => {
 
       expect(mockSend).toHaveBeenCalled();
       const [, ref] = mockSend.mock.calls[0];
-      expect(ref.conversation.id).toBe('19:meeting_abc@thread.v2');
+      expect(ref.conversation.id).toBe('19:meeting_abc@thread.v2;messageid=123');
     });
 
     it('should throw on invalid messageId in three-arg form', async () => {

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -50,7 +50,7 @@ import { Router } from './router';
 import { TokenManager } from './token-manager';
 import { IPlugin, AppEvents } from './types';
 import { PluginAdditionalContext } from './types/app-routing';
-import { supportsThreading, toThreadedConversationId } from './utils/thread';
+import { toThreadedConversationId } from './utils/thread';
 
 /**
  * App initialization options
@@ -551,14 +551,13 @@ export class App<TPlugin extends IPlugin = IPlugin> {
   }
 
   /**
-   * send an activity proactively to a channel thread.
+   * send an activity proactively as a threaded reply.
    *
-   * In channels, construct a threaded conversation ID from the
-   * conversation ID and message ID, then send to that thread.
-   * In scopes that do not support threading (group chat, meetings),
-   * send as a normal message - the message ID is ignored.
+   * Constructs a threaded conversation ID from the conversation ID
+   * and message ID via {@link toThreadedConversationId}, then sends
+   * to that thread.
    *
-   * @param conversationId the channel or conversation ID
+   * @param conversationId the conversation ID
    * @param messageId the thread root message ID
    * @param activity the activity to send
    */
@@ -575,10 +574,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
   async reply(conversationId: string, activity: ActivityLike): Promise<any>;
   async reply(conversationId: string, messageId: string | ActivityLike, activity?: ActivityLike) {
     if (typeof messageId === 'string' && activity !== undefined) {
-      const targetId = supportsThreading(conversationId)
-        ? toThreadedConversationId(conversationId, messageId)
-        : conversationId;
-      return this.send(targetId, activity);
+      return this.send(toThreadedConversationId(conversationId, messageId), activity);
     }
 
     return this.send(conversationId, messageId as ActivityLike);

--- a/packages/apps/src/utils/thread.spec.ts
+++ b/packages/apps/src/utils/thread.spec.ts
@@ -1,4 +1,4 @@
-import { toThreadedConversationId, supportsThreading } from './thread';
+import { toThreadedConversationId } from './thread';
 
 describe('toThreadedConversationId', () => {
   it('should construct a threaded conversation ID', () => {
@@ -53,28 +53,5 @@ describe('toThreadedConversationId', () => {
     expect(toThreadedConversationId('19:abc@thread.skype;messageid=111', '222')).toBe(
       '19:abc@thread.skype;messageid=222'
     );
-  });
-});
-
-describe('supportsThreading', () => {
-  it('should return true for @thread.tacv2 (channel)', () => {
-    expect(supportsThreading('19:abc@thread.tacv2')).toBe(true);
-  });
-
-  it('should return true for @thread.skype (classic channel)', () => {
-    expect(supportsThreading('19:abc@thread.skype')).toBe(true);
-  });
-
-  it('should return true for @unq.gbl.spaces (1:1 chat)', () => {
-    expect(supportsThreading('a]8:orgid:user-guid@unq.gbl.spaces')).toBe(true);
-  });
-
-  it('should return false for @thread.v2 (group chat / meeting)', () => {
-    expect(supportsThreading('19:meeting_abc@thread.v2')).toBe(false);
-  });
-
-  it('should check base ID when ;messageid= suffix is present', () => {
-    expect(supportsThreading('19:abc@thread.tacv2;messageid=123')).toBe(true);
-    expect(supportsThreading('19:meeting_abc@thread.v2;messageid=123')).toBe(false);
   });
 });

--- a/packages/apps/src/utils/thread.ts
+++ b/packages/apps/src/utils/thread.ts
@@ -1,8 +1,3 @@
-// Conversation ID suffixes that support threading.
-// Channels use @thread.tacv2 or @thread.skype, 1:1 chats use @unq.gbl.spaces.
-// Group chats and meetings use @thread.v2 which does not support threading.
-const THREADING_SUFFIXES = ['@thread.tacv2', '@thread.skype', '@unq.gbl.spaces'] as const;
-
 /**
  * Constructs a threaded conversation ID by appending `;messageid={messageId}`
  * to the conversation ID. This is the format APX uses to route messages
@@ -26,10 +21,4 @@ export function toThreadedConversationId(conversationId: string, messageId: stri
   // Strip any existing ;messageid= suffix (mirrors APX's NormalizeConversationId)
   const baseId = conversationId.split(';')[0];
   return `${baseId};messageid=${messageId}`;
-}
-
-// Check if a conversation ID represents a conversation that supports threading.
-export function supportsThreading(conversationId: string): boolean {
-  const base = conversationId.split(';')[0];
-  return THREADING_SUFFIXES.some(suffix => base.endsWith(suffix));
 }


### PR DESCRIPTION
## Summary
- Remove `supportsThreading()` guard from `app.reply()` 3-arg form -- always calls `toThreadedConversationId()` when messageId is provided
- Remove `supportsThreading()` function and `THREADING_SUFFIXES` constant (dead code)
- Remove `supportsThreading` tests
- Update `test manual` example to remove conversation type guard
- Threading support is now determined by the service, not the SDK

**Why:** Threading support is expanding (channels, 1:1, group chats). Maintaining an allowlist of conversation ID suffixes creates a maintenance burden and can block developers from using newly supported scopes until the SDK is updated.

## Test plan
- [x] Unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)