### PR TITLE
Security hardening: remove eval() from MCP plugin

### DIFF
--- a/external/mcp/package.json
+++ b/external/mcp/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@microsoft/teams.ai": "*",
     "@microsoft/teams.common": "*",
-    "json-schema-to-zod": "^2.6.0",
     "zod": "^3.24.2"
   },
   "peerDependencies": {

--- a/external/mcp/src/json-schema-to-zod.spec.ts
+++ b/external/mcp/src/json-schema-to-zod.spec.ts
@@ -177,6 +177,17 @@ describe('jsonSchemaToZod', () => {
     it('throws on $ref (unsupported)', () => {
       expect(() => jsonSchemaToZod({ $ref: '#/defs/Foo' })).toThrow(/\$ref/);
     });
+
+    it('throws on enum values that are not string/number/boolean/null', () => {
+      expect(() => jsonSchemaToZod({ enum: [{ foo: 1 }] })).toThrow(/enum values must be/);
+      expect(() => jsonSchemaToZod({ enum: [[1, 2]] })).toThrow(/got array/);
+    });
+
+    it('throws a wrapped error for invalid regex patterns', () => {
+      expect(() => jsonSchemaToZod({ type: 'string', pattern: '[unterminated' })).toThrow(
+        /invalid string pattern/
+      );
+    });
   });
 
   describe('real-world ChatPrompt parameter schemas', () => {

--- a/external/mcp/src/json-schema-to-zod.spec.ts
+++ b/external/mcp/src/json-schema-to-zod.spec.ts
@@ -1,0 +1,211 @@
+import { z } from 'zod';
+
+import type { Schema } from '@microsoft/teams.ai';
+
+import { jsonSchemaToZod } from './json-schema-to-zod';
+
+describe('jsonSchemaToZod', () => {
+  describe('primitives', () => {
+    it('converts a string schema', () => {
+      const zod = jsonSchemaToZod({ type: 'string' });
+      expect(zod.safeParse('hello').success).toBe(true);
+      expect(zod.safeParse(42).success).toBe(false);
+    });
+
+    it('applies string constraints', () => {
+      const zod = jsonSchemaToZod({
+        type: 'string',
+        minLength: 2,
+        maxLength: 4,
+        pattern: '^[a-z]+$',
+      });
+      expect(zod.safeParse('ab').success).toBe(true);
+      expect(zod.safeParse('a').success).toBe(false);
+      expect(zod.safeParse('abcde').success).toBe(false);
+      expect(zod.safeParse('AB').success).toBe(false);
+    });
+
+    it('applies string format validators', () => {
+      expect(jsonSchemaToZod({ type: 'string', format: 'email' }).safeParse('a@b.co').success).toBe(true);
+      expect(jsonSchemaToZod({ type: 'string', format: 'email' }).safeParse('not-an-email').success).toBe(false);
+      expect(jsonSchemaToZod({ type: 'string', format: 'url' }).safeParse('https://ex.com').success).toBe(true);
+      expect(jsonSchemaToZod({ type: 'string', format: 'uri' }).safeParse('https://ex.com').success).toBe(true);
+      expect(jsonSchemaToZod({ type: 'string', format: 'uuid' }).safeParse('not-a-uuid').success).toBe(false);
+    });
+
+    it('ignores unknown string formats', () => {
+      const zod = jsonSchemaToZod({ type: 'string', format: 'something-custom' });
+      expect(zod.safeParse('anything').success).toBe(true);
+    });
+
+    it('converts number and integer schemas', () => {
+      expect(jsonSchemaToZod({ type: 'number' }).safeParse(1.5).success).toBe(true);
+      expect(jsonSchemaToZod({ type: 'integer' }).safeParse(1.5).success).toBe(false);
+      expect(jsonSchemaToZod({ type: 'integer' }).safeParse(2).success).toBe(true);
+    });
+
+    it('applies number min/max/multipleOf', () => {
+      const zod = jsonSchemaToZod({ type: 'number', min: 0, max: 10, multipleOf: 2 });
+      expect(zod.safeParse(4).success).toBe(true);
+      expect(zod.safeParse(-1).success).toBe(false);
+      expect(zod.safeParse(11).success).toBe(false);
+      expect(zod.safeParse(3).success).toBe(false);
+    });
+
+    it('converts boolean and null schemas', () => {
+      expect(jsonSchemaToZod({ type: 'boolean' }).safeParse(true).success).toBe(true);
+      expect(jsonSchemaToZod({ type: 'boolean' }).safeParse('true').success).toBe(false);
+      expect(jsonSchemaToZod({ type: 'null' }).safeParse(null).success).toBe(true);
+      expect(jsonSchemaToZod({ type: 'null' }).safeParse(undefined).success).toBe(false);
+    });
+
+    it('converts untyped (Any) schemas', () => {
+      const zod = jsonSchemaToZod({});
+      expect(zod.safeParse('anything').success).toBe(true);
+      expect(zod.safeParse({ whatever: 1 }).success).toBe(true);
+    });
+  });
+
+  describe('enum', () => {
+    it('converts a string enum', () => {
+      const zod = jsonSchemaToZod({ type: 'string', enum: ['a', 'b', 'c'] });
+      expect(zod.safeParse('a').success).toBe(true);
+      expect(zod.safeParse('d').success).toBe(false);
+    });
+
+    it('converts a mixed-type enum via union of literals', () => {
+      const zod = jsonSchemaToZod({ enum: [1, 'two', true] });
+      expect(zod.safeParse(1).success).toBe(true);
+      expect(zod.safeParse('two').success).toBe(true);
+      expect(zod.safeParse(true).success).toBe(true);
+      expect(zod.safeParse('three').success).toBe(false);
+    });
+
+    it('handles a single-value enum', () => {
+      const zod = jsonSchemaToZod({ enum: ['only'] });
+      expect(zod.safeParse('only').success).toBe(true);
+      expect(zod.safeParse('other').success).toBe(false);
+    });
+  });
+
+  describe('objects', () => {
+    it('converts an object with required array', () => {
+      const zod = jsonSchemaToZod({
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' },
+        },
+        required: ['name'],
+      });
+      expect(zod.safeParse({ name: 'x' }).success).toBe(true);
+      expect(zod.safeParse({ name: 'x', age: 3 }).success).toBe(true);
+      expect(zod.safeParse({ age: 3 }).success).toBe(false);
+    });
+
+    it('treats required: true as all-required', () => {
+      const zod = jsonSchemaToZod({
+        type: 'object',
+        properties: { a: { type: 'string' }, b: { type: 'string' } },
+        required: true,
+      });
+      expect(zod.safeParse({ a: 'x', b: 'y' }).success).toBe(true);
+      expect(zod.safeParse({ a: 'x' }).success).toBe(false);
+    });
+
+    it('treats required: false or missing as all-optional', () => {
+      const zodFalse = jsonSchemaToZod({
+        type: 'object',
+        properties: { a: { type: 'string' } },
+        required: false,
+      });
+      const zodMissing = jsonSchemaToZod({
+        type: 'object',
+        properties: { a: { type: 'string' } },
+      });
+      expect(zodFalse.safeParse({}).success).toBe(true);
+      expect(zodMissing.safeParse({}).success).toBe(true);
+    });
+
+    it('handles empty properties', () => {
+      const zod = jsonSchemaToZod({ type: 'object', properties: {} });
+      expect(zod.safeParse({}).success).toBe(true);
+    });
+
+    it('returns a ZodObject with accessible .shape', () => {
+      const zod = jsonSchemaToZod({
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        required: ['name'],
+      });
+      expect(zod).toBeInstanceOf(z.ZodObject);
+      expect((zod as z.AnyZodObject).shape.name).toBeDefined();
+    });
+  });
+
+  describe('arrays', () => {
+    it('converts an array with a single items schema', () => {
+      const zod = jsonSchemaToZod({ type: 'array', items: { type: 'string' } });
+      expect(zod.safeParse(['a', 'b']).success).toBe(true);
+      expect(zod.safeParse(['a', 1]).success).toBe(false);
+    });
+
+    it('converts an array with tuple items', () => {
+      const zod = jsonSchemaToZod({
+        type: 'array',
+        items: [{ type: 'string' }, { type: 'number' }],
+      });
+      expect(zod.safeParse(['x', 1]).success).toBe(true);
+      expect(zod.safeParse([1, 'x']).success).toBe(false);
+    });
+
+    it('handles an empty tuple', () => {
+      const zod = jsonSchemaToZod({ type: 'array', items: [] });
+      expect(zod.safeParse([]).success).toBe(true);
+      expect(zod.safeParse(['x']).success).toBe(false);
+    });
+  });
+
+  describe('descriptions', () => {
+    it('applies description to the resulting Zod schema', () => {
+      const zod = jsonSchemaToZod({ type: 'string', description: 'a greeting' });
+      expect(zod.description).toBe('a greeting');
+    });
+  });
+
+  describe('errors', () => {
+    it('throws on $ref (unsupported)', () => {
+      expect(() => jsonSchemaToZod({ $ref: '#/defs/Foo' })).toThrow(/\$ref/);
+    });
+  });
+
+  describe('real-world ChatPrompt parameter schemas', () => {
+    const pokemonSearch: Schema = {
+      type: 'object',
+      properties: { pokemonName: { type: 'string', description: 'the name of the pokemon' } },
+      required: ['pokemonName'],
+    };
+    const weatherSearch: Schema = {
+      type: 'object',
+      properties: { location: { type: 'string', description: 'the name of the location' } },
+      required: ['location'],
+    };
+    const structurify: Schema = {
+      type: 'object',
+      properties: { response: { type: 'string', description: 'The response to the user\'s message' } },
+      required: ['response'],
+    };
+    const noArgs: Schema = { type: 'object', properties: {} };
+
+    it.each([
+      ['pokemonSearch', pokemonSearch, { pokemonName: 'pikachu' }, true],
+      ['pokemonSearch missing required', pokemonSearch, {}, false],
+      ['weatherSearch', weatherSearch, { location: 'Seattle' }, true],
+      ['structurify', structurify, { response: 'hi' }, true],
+      ['noArgs accepts empty', noArgs, {}, true],
+    ])('%s parses as expected', (_name, schema, input, expected) => {
+      const zod = jsonSchemaToZod(schema);
+      expect(zod.safeParse(input).success).toBe(expected);
+    });
+  });
+});

--- a/external/mcp/src/json-schema-to-zod.ts
+++ b/external/mcp/src/json-schema-to-zod.ts
@@ -1,0 +1,133 @@
+import { z } from 'zod';
+
+import type {
+  AnySchema,
+  ArraySchema,
+  BooleanSchema,
+  NullSchema,
+  NumberSchema,
+  ObjectSchema,
+  Schema,
+  StringSchema,
+} from '@microsoft/teams.ai';
+
+/**
+ * Converts a {@link Schema} into an equivalent Zod schema by building the
+ * schema tree directly — no string generation, no dynamic code evaluation.
+ */
+export function jsonSchemaToZod(schema: Schema): z.ZodTypeAny {
+  if (schema.$ref) {
+    throw new Error(
+      `jsonSchemaToZod: $ref is not supported (got ${JSON.stringify(schema.$ref)})`
+    );
+  }
+
+  if (schema.enum && schema.enum.length > 0) {
+    return describe(buildEnum(schema.enum), schema);
+  }
+
+  switch (schema.type) {
+    case 'string':
+      return describe(buildString(schema), schema);
+    case 'number':
+      return describe(buildNumber(schema, false), schema);
+    case 'integer':
+      return describe(buildNumber(schema, true), schema);
+    case 'boolean':
+      return describe(buildBoolean(schema), schema);
+    case 'null':
+      return describe(buildNull(schema), schema);
+    case 'array':
+      return describe(buildArray(schema), schema);
+    case 'object':
+      return describe(buildObject(schema), schema);
+    case undefined:
+      return describe(buildAny(schema), schema);
+    default: {
+      const exhaustive: never = schema;
+      throw new Error(
+        `jsonSchemaToZod: unsupported schema type ${JSON.stringify((exhaustive as Schema).type)}`
+      );
+    }
+  }
+}
+
+function buildString(schema: StringSchema): z.ZodString {
+  let s = z.string();
+  if (schema.minLength !== undefined) s = s.min(schema.minLength);
+  if (schema.maxLength !== undefined) s = s.max(schema.maxLength);
+  if (schema.pattern) s = s.regex(new RegExp(schema.pattern));
+  if (schema.format) {
+    switch (schema.format) {
+      case 'email':
+        s = s.email();
+        break;
+      case 'uri':
+      case 'url':
+        s = s.url();
+        break;
+      case 'uuid':
+        s = s.uuid();
+        break;
+    }
+  }
+  return s;
+}
+
+function buildNumber(schema: NumberSchema, isInt: boolean): z.ZodNumber {
+  let n = isInt ? z.number().int() : z.number();
+  if (schema.min !== undefined) n = n.min(schema.min);
+  if (schema.max !== undefined) n = n.max(schema.max);
+  if (schema.multipleOf !== undefined) n = n.multipleOf(schema.multipleOf);
+  return n;
+}
+
+function buildBoolean(_schema: BooleanSchema): z.ZodBoolean {
+  return z.boolean();
+}
+
+function buildNull(_schema: NullSchema): z.ZodNull {
+  return z.null();
+}
+
+function buildAny(_schema: AnySchema): z.ZodTypeAny {
+  return z.any();
+}
+
+function buildObject(schema: ObjectSchema): z.ZodObject<z.ZodRawShape> {
+  const shape: z.ZodRawShape = {};
+  const properties = schema.properties ?? {};
+
+  const requiredAll = schema.required === true;
+  const requiredList = Array.isArray(schema.required) ? schema.required : [];
+
+  for (const [key, child] of Object.entries(properties)) {
+    const zodChild = jsonSchemaToZod(child);
+    const isRequired = requiredAll || requiredList.includes(key);
+    shape[key] = isRequired ? zodChild : zodChild.optional();
+  }
+
+  return z.object(shape);
+}
+
+function buildArray(schema: ArraySchema): z.ZodTypeAny {
+  if (Array.isArray(schema.items)) {
+    if (schema.items.length === 0) return z.tuple([]);
+    const tuple = schema.items.map(jsonSchemaToZod) as [z.ZodTypeAny, ...z.ZodTypeAny[]];
+    return z.tuple(tuple);
+  }
+  return z.array(jsonSchemaToZod(schema.items));
+}
+
+function buildEnum(values: readonly unknown[]): z.ZodTypeAny {
+  if (values.every((v): v is string => typeof v === 'string')) {
+    return z.enum(values as [string, ...string[]]);
+  }
+  const literals = values.map((v) => z.literal(v as z.Primitive));
+  if (literals.length === 1) return literals[0];
+  return z.union(literals as [z.ZodLiteral<z.Primitive>, z.ZodLiteral<z.Primitive>, ...z.ZodLiteral<z.Primitive>[]]);
+}
+
+function describe<T extends z.ZodTypeAny>(zodType: T, schema: Schema): T {
+  return schema.description ? (zodType.describe(schema.description) as T) : zodType;
+}

--- a/external/mcp/src/json-schema-to-zod.ts
+++ b/external/mcp/src/json-schema-to-zod.ts
@@ -56,7 +56,16 @@ function buildString(schema: StringSchema): z.ZodString {
   let s = z.string();
   if (schema.minLength !== undefined) s = s.min(schema.minLength);
   if (schema.maxLength !== undefined) s = s.max(schema.maxLength);
-  if (schema.pattern) s = s.regex(new RegExp(schema.pattern));
+  if (schema.pattern) {
+    try {
+      s = s.regex(new RegExp(schema.pattern));
+    } catch (error) {
+      throw new Error(
+        `jsonSchemaToZod: invalid string pattern ${JSON.stringify(schema.pattern)}`,
+        { cause: error }
+      );
+    }
+  }
   if (schema.format) {
     switch (schema.format) {
       case 'email':
@@ -123,6 +132,16 @@ function buildEnum(values: readonly unknown[]): z.ZodTypeAny {
   if (values.every((v): v is string => typeof v === 'string')) {
     return z.enum(values as [string, ...string[]]);
   }
+
+  for (const v of values) {
+    if (v !== null && typeof v !== 'string' && typeof v !== 'number' && typeof v !== 'boolean') {
+      const kind = Array.isArray(v) ? 'array' : typeof v;
+      throw new Error(
+        `jsonSchemaToZod: enum values must be string, number, boolean, or null (got ${kind})`
+      );
+    }
+  }
+
   const literals = values.map((v) => z.literal(v as z.Primitive));
   if (literals.length === 1) return literals[0];
   return z.union(literals as [z.ZodLiteral<z.Primitive>, z.ZodLiteral<z.Primitive>, ...z.ZodLiteral<z.Primitive>[]]);

--- a/external/mcp/src/plugin.ts
+++ b/external/mcp/src/plugin.ts
@@ -7,7 +7,6 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import express from 'express';
-import { jsonSchemaToZod } from 'json-schema-to-zod';
 import { z } from 'zod';
 
 import { IChatPrompt } from '@microsoft/teams.ai';
@@ -25,6 +24,7 @@ import { ILogger } from '@microsoft/teams.common';
 import pkg from '../package.json';
 
 import { IConnection } from './connection';
+import { jsonSchemaToZod } from './json-schema-to-zod';
 
 /**
  * MCP transport options for sse
@@ -150,13 +150,15 @@ export class McpPlugin implements IPlugin {
    */
   use(prompt: IChatPrompt) {
     for (const fn of prompt.functions) {
-      const schema: z.AnyZodObject = eval(
-        jsonSchemaToZod(fn.parameters, { module: 'cjs' }),
-      );
+      const zodSchema = jsonSchemaToZod(fn.parameters);
+      const shape =
+        zodSchema instanceof z.ZodObject
+          ? (zodSchema as z.AnyZodObject).shape
+          : {};
       this.server.tool(
         fn.name,
         fn.description,
-        schema.shape,
+        shape,
         this.onToolCall(fn.name, prompt)
       );
     }

--- a/external/mcp/src/plugin.ts
+++ b/external/mcp/src/plugin.ts
@@ -150,6 +150,12 @@ export class McpPlugin implements IPlugin {
    */
   use(prompt: IChatPrompt) {
     for (const fn of prompt.functions) {
+      if (fn.parameters.type !== undefined && fn.parameters.type !== 'object') {
+        throw new Error(
+          `McpPlugin.use: parameters for tool "${fn.name}" must be an object schema (got type "${fn.parameters.type}")`
+        );
+      }
+
       const zodSchema = jsonSchemaToZod(fn.parameters);
       const shape =
         zodSchema instanceof z.ZodObject

--- a/package-lock.json
+++ b/package-lock.json
@@ -687,7 +687,6 @@
       "dependencies": {
         "@microsoft/teams.ai": "*",
         "@microsoft/teams.common": "*",
-        "json-schema-to-zod": "^2.6.0",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -13739,13 +13738,6 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
-    "node_modules/json-schema-to-zod": {
-      "version": "2.7.0",
-      "license": "ISC",
-      "bin": {
-        "json-schema-to-zod": "dist/cjs/cli.js"
-      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",


### PR DESCRIPTION
## Summary

Removes `eval()` from `McpPlugin.use(prompt)` by replacing the external `json-schema-to-zod` library (which emits JavaScript source that must be evaluated) with a local converter that builds Zod schemas directly.

Addresses security finding RCE via `eval()` in MCP plugin. TypeScript-only; Python and C# MCP plugins are not affected.

## Approach

The MCP TypeScript SDK requires Zod schemas for `server.tool()` registration — we can't skip conversion the way the PY/C# SDKs do. Rather than hardening the `eval` call (e.g. scoping with `new Function`), we eliminate code generation entirely:

- New `external/mcp/src/json-schema-to-zod.ts` walks a `Schema` object and returns a live `z.ZodTypeAny`. No string emission, no `eval`, no `new Function`.
- `json-schema-to-zod` removed from `external/mcp/package.json` dependencies.
- `McpPlugin.use(prompt)` now calls the local converter and defensively checks `instanceof z.ZodObject` before accessing `.shape`.

Coverage scope is bounded by the `Schema` type in `@microsoft/teams.ai` (a closed, typed subset of JSON Schema). Constructs not expressible in that type — `anyOf`, `oneOf`, `allOf`, `const`, `patternProperties`, `not` — are not supported and not needed. `\$ref` is in the type but unused in practice; the converter throws a clear error if it appears.

Context and alternatives considered: `design/mcp-eval-removal-options.md`.

## Behavior change to be aware of

The prior `json-schema-to-zod` library silently ignored `min`, `max`, and `multipleOf` on `NumberSchema` (those are non-standard JSON Schema keywords; the spec uses `minimum`/`maximum`). The new converter honors them, matching the `Schema` type's stated contract.

Customers whose schemas already used these constraints will see:

- If the LLM produces an in-range value: no change.
- If the LLM produces an out-of-range value: the tool call now returns a structured `InvalidParams` error (e.g. *"Number must be less than or equal to 85"*) instead of silently passing invalid data to the handler. Modern MCP clients surface this error back to the LLM, which typically retries with a corrected value.

Example — a thermostat tool with `temperature: { type: 'number', min: 50, max: 85 }`:

- **Before:** LLM emits `95`, handler receives `95`, thermostat may or may not clamp.
- **After:** LLM emits `95`, MCP returns an `InvalidParams` error, LLM typically retries with `85`, handler runs with a valid value.

For the narrow case where a schema has typo'd bounds (e.g. `min: 10, max: 5`), every call will now fail — previously silently ignored.