### PR TITLE
 fix: route `app.graph` + `.ctx.graph` to sovereign endpoints via `cloud.graphScope`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@microsoft/teams.ai": "*",
         "@microsoft/teams.api": "*",
         "@microsoft/teams.apps": "*",
+        "@microsoft/teams.cards": "*",
         "@microsoft/teams.common": "*",
         "@microsoft/teams.dev": "*",
         "@microsoft/teams.openai": "*",
@@ -61,7 +62,7 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -99,7 +100,7 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -117,7 +118,7 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "dotenv": "^16.5.0",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -135,7 +136,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -154,7 +155,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -498,7 +499,7 @@
         "@types/node": "^22.5.4",
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -536,7 +537,7 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -555,7 +556,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -591,7 +592,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"

--- a/packages/apps/src/app.oauth.ts
+++ b/packages/apps/src/app.oauth.ts
@@ -38,7 +38,8 @@ export async function onTokenExchange<TPlugin extends IPlugin>(
     ctx.userGraph = new graph.Client(
       this.client.clone({
         token: token.token,
-      })
+      }),
+      this.graphBaseUrl
     );
 
     this.events.emit('signin', { ...ctx, token, isSignedIn: true });
@@ -87,7 +88,8 @@ export async function onVerifyState<TPlugin extends IPlugin>(
     ctx.userGraph = new graph.Client(
       this.client.clone({
         token: token.token,
-      })
+      }),
+      this.graphBaseUrl
     );
 
     this.events.emit('signin', { ...ctx, token, isSignedIn: true });

--- a/packages/apps/src/app.oauth.ts
+++ b/packages/apps/src/app.oauth.ts
@@ -39,7 +39,7 @@ export async function onTokenExchange<TPlugin extends IPlugin>(
       this.client.clone({
         token: token.token,
       }),
-      this.graphBaseUrl
+      { baseUrlRoot: this.graphBaseUrl }
     );
 
     this.events.emit('signin', { ...ctx, token, isSignedIn: true });
@@ -89,7 +89,7 @@ export async function onVerifyState<TPlugin extends IPlugin>(
       this.client.clone({
         token: token.token,
       }),
-      this.graphBaseUrl
+      { baseUrlRoot: this.graphBaseUrl }
     );
 
     this.events.emit('signin', { ...ctx, token, isSignedIn: true });

--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -45,10 +45,12 @@ export async function $process<TPlugin extends IPlugin>(
   const client = this.client.clone();
   const apiClient = new ApiClient(serviceUrl, this.client.clone({ token: () => this.getBotToken() }), this.options.apiClientSettings);
   const userGraph = new GraphClient(
-    client.clone({ token: () => userToken })
+    client.clone({ token: () => userToken }),
+    this.graphBaseUrl
   );
   const appGraph = new GraphClient(
-    client.clone({ token: () => this.getAppGraphToken(activity.conversation.tenantId ?? 'common') })
+    client.clone({ token: () => this.getAppGraphToken(activity.conversation.tenantId ?? 'common') }),
+    this.graphBaseUrl
   );
 
   const ref: ConversationReference = {

--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -46,11 +46,11 @@ export async function $process<TPlugin extends IPlugin>(
   const apiClient = new ApiClient(serviceUrl, this.client.clone({ token: () => this.getBotToken() }), this.options.apiClientSettings);
   const userGraph = new GraphClient(
     client.clone({ token: () => userToken }),
-    this.graphBaseUrl
+    { baseUrlRoot: this.graphBaseUrl }
   );
   const appGraph = new GraphClient(
     client.clone({ token: () => this.getAppGraphToken(activity.conversation.tenantId ?? 'common') }),
-    this.graphBaseUrl
+    { baseUrlRoot: this.graphBaseUrl }
   );
 
   const ref: ConversationReference = {

--- a/packages/apps/src/app.spec.ts
+++ b/packages/apps/src/app.spec.ts
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken';
 
-import { JsonWebToken } from '@microsoft/teams.api';
+import { CHINA, JsonWebToken, PUBLIC, US_GOV, US_GOV_DOD, withOverrides } from '@microsoft/teams.api';
 
 import { App } from './app';
 import { TestAdapter } from './test-utils';
@@ -409,6 +409,76 @@ describe('App', () => {
       await expect(
         unstartedApp.testReply('conv-id', { text: 'Hello' })
       ).rejects.toThrow('App has no credentials set up');
+    });
+  });
+
+  describe('sovereign cloud Graph routing', () => {
+    const newApp = (cloud?: any) =>
+      new App({
+        httpServerAdapter: new TestAdapter(),
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        tenantId: 'test-tenant-id',
+        cloud,
+      });
+
+    afterEach(async () => {
+      // individual tests await stop themselves
+    });
+
+    it('derives graphBaseUrl from PUBLIC cloud scope', async () => {
+      const app = newApp(PUBLIC);
+      try {
+        expect(app.graphBaseUrl).toBe('https://graph.microsoft.com');
+      } finally {
+        await app.stop();
+      }
+    });
+
+    it('derives graphBaseUrl from US_GOV cloud scope', async () => {
+      const app = newApp(US_GOV);
+      try {
+        expect(app.graphBaseUrl).toBe('https://graph.microsoft.us');
+      } finally {
+        await app.stop();
+      }
+    });
+
+    it('derives graphBaseUrl from US_GOV_DOD cloud scope', async () => {
+      const app = newApp(US_GOV_DOD);
+      try {
+        expect(app.graphBaseUrl).toBe('https://dod-graph.microsoft.us');
+      } finally {
+        await app.stop();
+      }
+    });
+
+    it('derives graphBaseUrl from CHINA cloud scope', async () => {
+      const app = newApp(CHINA);
+      try {
+        expect(app.graphBaseUrl).toBe('https://microsoftgraph.chinacloudapi.cn');
+      } finally {
+        await app.stop();
+      }
+    });
+
+    it('defaults to PUBLIC-derived graphBaseUrl when no cloud is specified', async () => {
+      const app = newApp();
+      try {
+        expect(app.graphBaseUrl).toBe('https://graph.microsoft.com');
+      } finally {
+        await app.stop();
+      }
+    });
+
+    it('leaves graphBaseUrl undefined when graphScope is not a URL', async () => {
+      const customCloud = withOverrides(PUBLIC, { graphScope: 'user.read' });
+      const app = newApp(customCloud);
+      try {
+        expect(app.graphBaseUrl).toBeUndefined();
+      } finally {
+        await app.stop();
+      }
     });
   });
 });

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -206,6 +206,14 @@ export class App<TPlugin extends IPlugin = IPlugin> {
   readonly tokenManager: TokenManager;
 
   /**
+   * Graph API base URL derived from the configured cloud's `graphScope`.
+   * Undefined when the scope isn't a URL — `GraphClient` then uses its public-cloud default.
+   * Shared across every `GraphClient` the app constructs (`app.graph`, `ctx.appGraph`, `ctx.userGraph`)
+   * so sovereign customers get consistent routing.
+   */
+  readonly graphBaseUrl?: string;
+
+  /**
    * the apps credentials
    */
   get credentials() {
@@ -318,11 +326,20 @@ export class App<TPlugin extends IPlugin = IPlugin> {
       this.cloud
     );
 
-    // Derive Graph API base URL from the cloud's graphScope
+    // Derive Graph API base URL from the cloud's graphScope (e.g. "https://graph.microsoft.us/.default"
+    // -> "https://graph.microsoft.us"). Falls back to the public Graph endpoint inside GraphClient if
+    // the scope isn't a URL (custom delegated scope, empty, etc.).
     const graphUrlMatch = /^(https?:\/\/[^/]+)/i.exec((this.cloud.graphScope ?? '').trim());
+    this.graphBaseUrl = graphUrlMatch?.[1];
+    if (!this.graphBaseUrl && this.cloud.graphScope) {
+      this.log.warn(
+        `graphScope "${this.cloud.graphScope}" is not a URL; Graph calls will route to the public cloud. ` +
+        'Set graphScope to an "https://<host>/.default" value to route to the correct Graph endpoint.'
+      );
+    }
     this.graph = new GraphClient(
       this.client.clone({ token: () => this.getAppGraphToken() }),
-      graphUrlMatch?.[1]
+      this.graphBaseUrl
     );
 
     // initialize TokenManager with credentials

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -339,7 +339,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
     }
     this.graph = new GraphClient(
       this.client.clone({ token: () => this.getAppGraphToken() }),
-      this.graphBaseUrl
+      { baseUrlRoot: this.graphBaseUrl }
     );
 
     // initialize TokenManager with credentials

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -318,8 +318,11 @@ export class App<TPlugin extends IPlugin = IPlugin> {
       this.cloud
     );
 
+    // Derive Graph API base URL from the cloud's graphScope
+    const graphUrlMatch = /^(https?:\/\/[^/]+)/i.exec((this.cloud.graphScope ?? '').trim());
     this.graph = new GraphClient(
-      this.client.clone({ token: () => this.getAppGraphToken() })
+      this.client.clone({ token: () => this.getAppGraphToken() }),
+      graphUrlMatch?.[1]
     );
 
     // initialize TokenManager with credentials

--- a/packages/graph/src/index.spec.ts
+++ b/packages/graph/src/index.spec.ts
@@ -109,6 +109,35 @@ describe('Client', () => {
         },
       });
     });
+
+    it('should clone existing client and route to sovereign base URL via positional baseUrlRoot', () => {
+      const existingClient = {
+        ...mockHttpClient,
+        request: jest.fn(),
+        clone: jest.fn().mockReturnValue(mockHttpClient),
+      };
+      new Client(existingClient as any, 'https://graph.microsoft.us');
+
+      expect(existingClient.clone).toHaveBeenCalledWith({
+        baseUrl: 'https://graph.microsoft.us/v1.0',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': expect.stringMatching(/^teams\.ts\[graph\]\/.+/),
+        },
+      });
+    });
+
+    it('should honor positional baseUrlRoot when no options provided', () => {
+      new Client(undefined, 'https://graph.microsoft.us');
+
+      expect(http.Client).toHaveBeenCalledWith({
+        baseUrl: 'https://graph.microsoft.us/v1.0',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': expect.stringMatching(/^teams\.ts\[graph\]\/.+/),
+        },
+      });
+    });
   });
 
   describe('call method', () => {

--- a/packages/graph/src/index.spec.ts
+++ b/packages/graph/src/index.spec.ts
@@ -138,6 +138,40 @@ describe('Client', () => {
         },
       });
     });
+
+    it('should prefer positional baseUrlRoot over options.baseUrlRoot', () => {
+      new Client(
+        { baseUrlRoot: 'https://graph.microsoft.com' },
+        'https://graph.microsoft.us'
+      );
+
+      expect(http.Client).toHaveBeenCalledWith({
+        baseUrlRoot: 'https://graph.microsoft.com',
+        baseUrl: 'https://graph.microsoft.us/v1.0',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': expect.stringMatching(/^teams\.ts\[graph\]\/.+/),
+        },
+      });
+    });
+
+    it('should honor options.baseUrlRoot when baseUrlRoot is attached to an existing client', () => {
+      const existingClient = {
+        ...mockHttpClient,
+        request: jest.fn(),
+        clone: jest.fn().mockReturnValue(mockHttpClient),
+        baseUrlRoot: 'https://graph.microsoft.us',
+      };
+      new Client(existingClient as any);
+
+      expect(existingClient.clone).toHaveBeenCalledWith({
+        baseUrl: 'https://graph.microsoft.us/v1.0',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': expect.stringMatching(/^teams\.ts\[graph\]\/.+/),
+        },
+      });
+    });
   });
 
   describe('call method', () => {

--- a/packages/graph/src/index.spec.ts
+++ b/packages/graph/src/index.spec.ts
@@ -110,13 +110,13 @@ describe('Client', () => {
       });
     });
 
-    it('should clone existing client and route to sovereign base URL via positional baseUrlRoot', () => {
+    it('should clone existing client and route to sovereign base URL via graphOptions.baseUrlRoot', () => {
       const existingClient = {
         ...mockHttpClient,
         request: jest.fn(),
         clone: jest.fn().mockReturnValue(mockHttpClient),
       };
-      new Client(existingClient as any, 'https://graph.microsoft.us');
+      new Client(existingClient as any, { baseUrlRoot: 'https://graph.microsoft.us' });
 
       expect(existingClient.clone).toHaveBeenCalledWith({
         baseUrl: 'https://graph.microsoft.us/v1.0',
@@ -127,8 +127,8 @@ describe('Client', () => {
       });
     });
 
-    it('should honor positional baseUrlRoot when no options provided', () => {
-      new Client(undefined, 'https://graph.microsoft.us');
+    it('should honor graphOptions.baseUrlRoot when no options provided', () => {
+      new Client(undefined, { baseUrlRoot: 'https://graph.microsoft.us' });
 
       expect(http.Client).toHaveBeenCalledWith({
         baseUrl: 'https://graph.microsoft.us/v1.0',
@@ -139,10 +139,10 @@ describe('Client', () => {
       });
     });
 
-    it('should prefer positional baseUrlRoot over options.baseUrlRoot', () => {
+    it('should prefer graphOptions.baseUrlRoot over options.baseUrlRoot', () => {
       new Client(
         { baseUrlRoot: 'https://graph.microsoft.com' },
-        'https://graph.microsoft.us'
+        { baseUrlRoot: 'https://graph.microsoft.us' }
       );
 
       expect(http.Client).toHaveBeenCalledWith({

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -64,10 +64,13 @@ export class Client {
     return this._http;
   }
 
+  /**
+   * Creates a Graph client.
+   * Base URL resolution order: positional `baseUrlRoot` argument, then `options.baseUrlRoot`
+   * (read whether options is a `Client` instance or `ClientOptions`), then the public-cloud default.
+   */
   constructor(options?: Options, baseUrlRoot?: string) {
-    this.baseUrlRoot = baseUrlRoot
-      ?? (options && !('request' in options) ? options.baseUrlRoot : undefined)
-      ?? defaultBaseUrlRoot;
+    this.baseUrlRoot = baseUrlRoot ?? options?.baseUrlRoot ?? defaultBaseUrlRoot;
     if (!options) {
       this._http = new http.Client({
         baseUrl: `${this.baseUrlRoot}/v1.0`,

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -47,6 +47,12 @@ type Options = (http.Client | http.ClientOptions) & {
   baseUrlRoot?: string;
 };
 
+/** Graph-specific client options. */
+type GraphOptions = {
+  /** Graph service root override for routing Graph calls to sovereign cloud. */
+  baseUrlRoot?: string;
+};
+
 /**
  * /
  * Provides an entry point for invoking Microsoft Graph APIs.
@@ -66,11 +72,23 @@ export class Client {
 
   /**
    * Creates a Graph client.
-   * Base URL resolution order: positional `baseUrlRoot` argument, then `options.baseUrlRoot`
-   * (read whether options is a `Client` instance or `ClientOptions`), then the public-cloud default.
+   *
+   * @param options - The HTTP client to use; an existing {@link http.Client} will be cloned,
+   * or an {@link http.ClientOptions} bag will be used to build a new one.
+   * HTTP-level settings like headers, interceptors, and timeouts belong here.
+   * @param graphOptions - Graph-specific options. Takes precedence over `options.baseUrlRoot`
+   * when both are set.
+   *
+   * @example
+   * // Public cloud (default)
+   * new Client({ token });
+   *
+   * @example
+   * // Sovereign cloud (GCCH)
+   * new Client(httpClient, { baseUrlRoot: 'https://graph.microsoft.us' });
    */
-  constructor(options?: Options, baseUrlRoot?: string) {
-    this.baseUrlRoot = baseUrlRoot ?? options?.baseUrlRoot ?? defaultBaseUrlRoot;
+  constructor(options?: Options, graphOptions?: GraphOptions) {
+    this.baseUrlRoot = graphOptions?.baseUrlRoot ?? options?.baseUrlRoot ?? defaultBaseUrlRoot;
     if (!options) {
       this._http = new http.Client({
         baseUrl: `${this.baseUrlRoot}/v1.0`,

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -64,8 +64,10 @@ export class Client {
     return this._http;
   }
 
-  constructor(options?: Options) {
-    this.baseUrlRoot = options?.baseUrlRoot ?? defaultBaseUrlRoot;
+  constructor(options?: Options, baseUrlRoot?: string) {
+    this.baseUrlRoot = baseUrlRoot
+      ?? (options && !('request' in options) ? options.baseUrlRoot : undefined)
+      ?? defaultBaseUrlRoot;
     if (!options) {
       this._http = new http.Client({
         baseUrl: `${this.baseUrlRoot}/v1.0`,


### PR DESCRIPTION
- `app.graph` was routing all Microsoft Graph calls to the public-cloud endpoint (`https://graph.microsoft.com`) regardless of the sovereign cloud configured on the app. Sovereign customers (GCCH, DoD, China) would be unable to use
 - `app.graph` - calls would hit the wrong cloud and fail. This PR fixes that by deriving the Graph base URL from the cloud's `graphScope` and plumbing it through `GraphClient`.

  - Public cloud (default): `graphScope = "https://graph.microsoft.com/.default"` → derived base URL = `https://graph.microsoft.com` = previous hardcoded default. **Zero behavior change.**
  - Sovereign clouds: behavior changes from broken (silently public) to correct (per-cloud). This is the fix.