### PR TITLE
chore(client): remove unused uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20655,8 +20655,7 @@
         "@azure/msal-browser": "^4.9.1",
         "@microsoft/teams.api": "*",
         "@microsoft/teams.common": "*",
-        "@microsoft/teams.graph": "*",
-        "uuid": "^11.0.5"
+        "@microsoft/teams.graph": "*"
       },
       "devDependencies": {
         "@microsoft/teams.config": "*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -40,8 +40,7 @@
     "@azure/msal-browser": "^4.9.1",
     "@microsoft/teams.api": "*",
     "@microsoft/teams.common": "*",
-    "@microsoft/teams.graph": "*",
-    "uuid": "^11.0.5"
+    "@microsoft/teams.graph": "*"
   },
   "peerDependencies": {
     "@microsoft/teams-js": "^2.35.0"


### PR DESCRIPTION

  - Removed `uuid` from `@microsoft/teams.client` dependencies — it's declared but never imported anywhere in
  `packages/client/`.
  - Resolves Dependabot alert for GHSA-w5hq-g745-h8pq in downstream consumers (e.g.
  [microsoft/teams.py#80](https://github.com/microsoft/teams.py/security/dependabot/80)).

  `uuid ^11.0.5` has been in `teams.client`'s `package.json` since the initial commit but is unused in source. Other packages
  that do use uuid (`packages/dev`, `external/a2a`) only call `v4`, which isn't affected by the advisory.