### PR TITLE
Tighten additionalAllowedDomains API contract

### DIFF
--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -146,9 +146,10 @@ export type AppOptions<TPlugin extends IPlugin> = {
   readonly skipAuth?: boolean;
 
   /**
-   * Additional allowed service URL hostnames beyond the built-in defaults.
-   * Use this if your bot receives activities from non-standard channels
-   * with service URLs outside the cloud environment's allowed hostnames.
+   * Additional service URL hostnames accepted beyond the cloud preset.
+   * Entries must be bare hostnames matched exactly (case-insensitive)
+   * wildcard patterns like `'*.example.com'`, URL suffixes, or full URLs are NOT supported.
+   * Pass `['*']` as the sole wildcard to accept any hostname (disables service-URL validation).
    * @example ['api.my-custom-channel.com']
    */
   readonly additionalAllowedDomains?: string[];

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -147,9 +147,10 @@ export type AppOptions<TPlugin extends IPlugin> = {
 
   /**
    * Additional service URL hostnames accepted beyond the cloud preset.
-   * Entries must be bare hostnames matched exactly (case-insensitive)
+   * Entries must be bare hostnames matched exactly (case-insensitive);
    * wildcard patterns like `'*.example.com'`, URL suffixes, or full URLs are NOT supported.
-   * Pass `['*']` as the sole wildcard to accept any hostname (disables service-URL validation).
+   * If `'*'` is present in the list, hostname allowlist validation is disabled,
+   * but service URLs are still parsed and must satisfy the existing scheme checks.
    * @example ['api.my-custom-channel.com']
    */
   readonly additionalAllowedDomains?: string[];

--- a/packages/apps/src/http/http-server.spec.ts
+++ b/packages/apps/src/http/http-server.spec.ts
@@ -1,5 +1,14 @@
+import { ServiceTokenValidator } from '../middleware/auth/service-token-validator';
+
 import { HttpMethod, IHttpServerAdapter, HttpRouteHandler } from './adapter';
 import { HttpServer } from './http-server';
+
+// Partial mock: replace ServiceTokenValidator with a spyable mock, but keep
+// isAllowedServiceUrl and other exports intact (http-server imports both).
+jest.mock('../middleware/auth/service-token-validator', () => ({
+  ...jest.requireActual('../middleware/auth/service-token-validator'),
+  ServiceTokenValidator: jest.fn(),
+}));
 
 class MockAdapter implements IHttpServerAdapter {
   routes: Array<{ method: HttpMethod; path: string; handler: HttpRouteHandler }> = [];
@@ -141,6 +150,71 @@ describe('HttpServer', () => {
 
       expect(result.status).toBe(401);
       expect(result.body).toEqual({ error: 'Missing authorization header' });
+    });
+  });
+
+  describe('additionalAllowedDomains plumbing', () => {
+    beforeEach(() => {
+      (ServiceTokenValidator as jest.Mock).mockClear();
+    });
+
+    it('should pass additionalAllowedDomains to ServiceTokenValidator at construction', async () => {
+      // Guard: verify the allowlist option travels from HttpServerOptions
+      //  all the way to the validator constructor.
+      const allowlist = ['canary.botapi.skype.com'];
+      const serverWithAllowlist = new HttpServer(adapter, {
+        skipAuth: false,
+        additionalAllowedDomains: allowlist,
+        messagingEndpoint: '/api/messages',
+      });
+
+      await serverWithAllowlist.initialize({
+        credentials: { clientId: 'test-app', tenantId: 'test-tenant' } as any,
+      });
+
+      expect(ServiceTokenValidator).toHaveBeenCalledWith(
+        'test-app',
+        'test-tenant',
+        undefined,
+        expect.anything(),
+        ['canary.botapi.skype.com'],
+        undefined,
+      );
+    });
+
+    it('should not construct ServiceTokenValidator when skipAuth=true', async () => {
+      const skipAuthServer = new HttpServer(adapter, {
+        skipAuth: true,
+        additionalAllowedDomains: ['canary.botapi.skype.com'],
+        messagingEndpoint: '/api/messages',
+      });
+
+      await skipAuthServer.initialize({
+        credentials: { clientId: 'test-app', tenantId: 'test-tenant' } as any,
+      });
+
+      expect(ServiceTokenValidator).not.toHaveBeenCalled();
+    });
+
+    it('should not share array reference with caller (defensive copy)', async () => {
+      // Guards against a future regression: if HttpServer stored the caller's array
+      // by reference, post-construction mutation would change validator behavior at runtime.
+      const callerList = ['first.example.com'];
+      const srv = new HttpServer(adapter, {
+        skipAuth: false,
+        additionalAllowedDomains: callerList,
+        messagingEndpoint: '/api/messages',
+      });
+
+      callerList.push('mutated.example.com');
+
+      await srv.initialize({
+        credentials: { clientId: 'test-app', tenantId: 'test-tenant' } as any,
+      });
+
+      // Validator received the list as it was at construction, not the mutated version.
+      const receivedList = (ServiceTokenValidator as jest.Mock).mock.calls[0][4];
+      expect(receivedList).toEqual(['first.example.com']);
     });
   });
 

--- a/packages/apps/src/http/http-server.ts
+++ b/packages/apps/src/http/http-server.ts
@@ -21,9 +21,10 @@ export type HttpServerOptions = {
   readonly skipAuth?: boolean;
   /**
    * Additional service URL hostnames accepted beyond the cloud preset.
-   * Entries must be bare hostnames matched exactly (case-insensitive)
+   * Entries must be bare hostnames matched exactly (case-insensitive);
    * wildcard patterns like `'*.example.com'`, URL suffixes, or full URLs are NOT supported.
-   * Pass `['*']` as the sole wildcard to accept any hostname (disables service-URL validation).
+   * If `'*'` is present anywhere in the list, hostname allowlist checks are disabled,
+   * but service URLs must still be valid URLs and use `https:` (except localhost).
    */
   readonly additionalAllowedDomains?: string[];
   readonly logger?: ILogger;

--- a/packages/apps/src/http/http-server.ts
+++ b/packages/apps/src/http/http-server.ts
@@ -19,6 +19,12 @@ type AuthResult =
 
 export type HttpServerOptions = {
   readonly skipAuth?: boolean;
+  /**
+   * Additional service URL hostnames accepted beyond the cloud preset.
+   * Entries must be bare hostnames matched exactly (case-insensitive)
+   * wildcard patterns like `'*.example.com'`, URL suffixes, or full URLs are NOT supported.
+   * Pass `['*']` as the sole wildcard to accept any hostname (disables service-URL validation).
+   */
   readonly additionalAllowedDomains?: string[];
   readonly logger?: ILogger;
   /**
@@ -75,7 +81,11 @@ export class HttpServer implements IHttpServer {
   constructor(adapter: IHttpServerAdapter, options: HttpServerOptions) {
     this._adapter = adapter;
     this.skipAuth = options.skipAuth ?? false;
-    this.additionalAllowedDomains = options.additionalAllowedDomains;
+    // Defensive copy so post-construction mutation of the caller's array
+    // does not change validator behavior at runtime.
+    this.additionalAllowedDomains = options.additionalAllowedDomains
+      ? [...options.additionalAllowedDomains]
+      : undefined;
     this.logger = options.logger ?? new ConsoleLogger('HttpServer');
     this._messagingEndpoint = options.messagingEndpoint;
   }

--- a/packages/apps/src/http/http-server.ts
+++ b/packages/apps/src/http/http-server.ts
@@ -84,9 +84,7 @@ export class HttpServer implements IHttpServer {
     this.skipAuth = options.skipAuth ?? false;
     // Defensive copy so post-construction mutation of the caller's array
     // does not change validator behavior at runtime.
-    this.additionalAllowedDomains = options.additionalAllowedDomains
-      ? [...options.additionalAllowedDomains]
-      : undefined;
+    this.additionalAllowedDomains = options.additionalAllowedDomains?.slice();
     this.logger = options.logger ?? new ConsoleLogger('HttpServer');
     this._messagingEndpoint = options.messagingEndpoint;
   }

--- a/packages/apps/src/middleware/auth/service-token-validator.spec.ts
+++ b/packages/apps/src/middleware/auth/service-token-validator.spec.ts
@@ -318,6 +318,62 @@ describe('ServiceTokenValidator', () => {
       expect(result.serviceUrl).toBe('https://any-domain.com/api');
     });
 
+    it('should defensively copy additionalAllowedDomains so caller mutation does not affect validator', async () => {
+      // Guards against a future regression: if the constructor stored the caller's array
+      // by reference, post-construction mutation would change validator behavior at runtime.
+      const callerList = ['api.custom-channel.com'];
+      const validator = new ServiceTokenValidator(
+        mockClientId, mockTenantId, undefined, undefined, callerList
+      );
+
+      callerList.push('evil.com');
+
+      const mockPayload = {
+        appid: mockClientId,
+        sub: 'bot-id',
+        serviceurl: 'https://evil.com'
+      };
+      mockValidateAccessToken.mockResolvedValue(mockPayload);
+
+      await expect(validator.check('Bearer test', { serviceUrl: 'https://evil.com' })).rejects.toThrow(
+        'is not from an allowed domain'
+      );
+    });
+
+    it('should handle undefined additionalAllowedDomains (construction + default rejection)', async () => {
+      const validator = new ServiceTokenValidator(
+        mockClientId, mockTenantId, undefined, undefined, undefined
+      );
+
+      const mockPayload = {
+        appid: mockClientId,
+        sub: 'bot-id',
+        serviceurl: 'https://not-in-defaults.example.com'
+      };
+      mockValidateAccessToken.mockResolvedValue(mockPayload);
+
+      await expect(
+        validator.check('Bearer test', { serviceUrl: 'https://not-in-defaults.example.com' })
+      ).rejects.toThrow('is not from an allowed domain');
+    });
+
+    it('should handle empty additionalAllowedDomains array as no additions', async () => {
+      const validator = new ServiceTokenValidator(
+        mockClientId, mockTenantId, undefined, undefined, []
+      );
+
+      const mockPayload = {
+        appid: mockClientId,
+        sub: 'bot-id',
+        serviceurl: 'https://unlisted.example.com'
+      };
+      mockValidateAccessToken.mockResolvedValue(mockPayload);
+
+      await expect(
+        validator.check('Bearer test', { serviceUrl: 'https://unlisted.example.com' })
+      ).rejects.toThrow('is not from an allowed domain');
+    });
+
     it('should accept US Government serviceUrl with US_GOV cloud', async () => {
       const { US_GOV } = await import('@microsoft/teams.api');
       const validator = new ServiceTokenValidator(

--- a/packages/apps/src/middleware/auth/service-token-validator.ts
+++ b/packages/apps/src/middleware/auth/service-token-validator.ts
@@ -56,6 +56,12 @@ export class ServiceTokenValidator {
   private additionalAllowedDomains?: string[];
   private cloud: CloudEnvironment;
 
+  /**
+   * @param additionalAllowedDomains Additional service URL hostnames accepted beyond the cloud preset.
+   *   Entries must be bare hostnames matched exactly (case-insensitive); wildcard patterns
+   *   like `'*.example.com'`, URL suffixes, or full URLs are NOT supported.
+   *   Pass `['*']` as the sole wildcard to accept any hostname.
+   */
   constructor(
     appId: string,
     tenantId?: string,
@@ -79,7 +85,11 @@ export class ServiceTokenValidator {
     }, logger);
 
     this.credentials = { clientId: appId, tenantId };
-    this.additionalAllowedDomains = additionalAllowedDomains;
+    // Defensive copy so post-construction mutation of the caller's array
+    // does not change validator behavior at runtime.
+    this.additionalAllowedDomains = additionalAllowedDomains
+      ? [...additionalAllowedDomains]
+      : undefined;
   }
 
   async check(authHeader: string, body: any): Promise<IToken> {

--- a/packages/apps/src/middleware/auth/service-token-validator.ts
+++ b/packages/apps/src/middleware/auth/service-token-validator.ts
@@ -87,9 +87,7 @@ export class ServiceTokenValidator {
     this.credentials = { clientId: appId, tenantId };
     // Defensive copy so post-construction mutation of the caller's array
     // does not change validator behavior at runtime.
-    this.additionalAllowedDomains = additionalAllowedDomains
-      ? [...additionalAllowedDomains]
-      : undefined;
+    this.additionalAllowedDomains = additionalAllowedDomains?.slice();
   }
 
   async check(authHeader: string, body: any): Promise<IToken> {


### PR DESCRIPTION
 Follow-up to the allowlist feature (shipped via #515). No runtime behavior change for correct callers. Adds hardening informed by review feedback on the sibling Python PR (microsoft/teams.py#404):

1. **Docstring clarity.** `App.additionalAllowedDomains`, `HttpServerOptions`, and `ServiceTokenValidator` constructor all document that entries must be bare hostnames matched exactly (case-insensitive); wildcard patterns like `*.example.com`, URL suffixes, and full URLs are NOT supported. `['*']` is the sole wildcard, used as a disable-validation sentinel.
2. **Defensive copy.** `HttpServer` and `ServiceTokenValidator` no longer store the caller's array by reference. A post-construction mutation of the caller's array would previously have changed validator behavior at runtime; now it is isolated.
3. **Tests** covering the class of bug Python shipped in #404: plumbing from `HttpServerOptions` through `HttpServer.initialize()` into the `ServiceTokenValidator` constructor.