### PR TITLE
fix: add .mjs outExtension for ESM builds to fix Webpack 5 strict ESM…

### DIFF
--- a/packages/config/tsup.config.js
+++ b/packages/config/tsup.config.js
@@ -7,7 +7,12 @@ module.exports = {
   treeshake: true,
   splitting: true,
   clean: true,
-  outDir: 'dist',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts'],
-  format: ['cjs', 'esm'],
+  outDir: "dist",
+  entry: ["src/**/*.ts", "!src/**/*.spec.ts"],
+  format: ["cjs", "esm"],
+  esbuildOptions: (options, { format }) => {
+    if (format === "esm") {
+      options.outExtension = { ".js": ".mjs" };
+    }
+  },
 };


### PR DESCRIPTION
## Bug
When importing `@microsoft/teams.client` in a Webpack 5 / react-scripts 5 project,
the build fails with:

> Module not found: Error: Can't resolve './app' in dist/
> BREAKING CHANGE: The request './app' failed to resolve only because it was
> resolved as fully specified

## Root Cause
tsup is configured with `bundle: false` and `format: ['cjs', 'esm']`. When tsup
builds the ESM output without bundling, it copies each file individually and keeps
bare import specifiers like `'./app'` without file extensions.

Webpack 5 treats `.mjs` files as strict ES Modules and requires all import paths
to be fully specified with explicit extensions. Since `dist/index.mjs` references
`'./app'` instead of `'./app.mjs'`, Webpack 5 cannot resolve it and the build fails.

## Fix
Added `esbuildOptions` to the shared tsup config in `packages/config/tsup.config.js`:

```js
esbuildOptions: (options, { format }) => {
  if (format === 'esm') {
    options.outExtension = { '.js': '.mjs' };
  }
},
```

This tells esbuild to name ESM output files with `.mjs` extensions so that
import paths and file names match exactly, which is what Webpack 5 requires.

## Files Changed
- `packages/config/tsup.config.js`, added `esbuildOptions` for ESM builds

## Testing
- Import `@microsoft/teams.client` in a Webpack 5 react-scripts 5 project
- Run `react-scripts start`
- Verify build completes without extension resolution errors
- Verify `App` class is correctly importable and works at runtime

Closes #542