### PR TITLE
fix(http-stream): resolve race condition in close() and streamType override in final message

### DIFF
--- a/packages/apps/src/http/http-stream.spec.ts
+++ b/packages/apps/src/http/http-stream.spec.ts
@@ -241,4 +241,54 @@ describe('HttpStream', () => {
     // Further emits throw
     expect(() => stream.emit('Should fail')).toThrow(StreamCancelledError);
   });
+
+  test('close sends final message with streamType final after update', async () => {
+    const stream = new HttpStream(client, ref, logger);
+    mockCreate();
+
+    stream.update('Thinking...');
+    stream.emit('first message');
+    stream.emit('last message');
+    stream.close();
+    await jest.runAllTimersAsync();
+
+    expect(client.conversations.activities().create).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: 'message',
+        text: 'first messagelast message',
+        channelData: expect.objectContaining({
+          streamType: 'final',
+        }),
+      })
+    );
+  });
+
+  test('close waits for flush to complete before sending final message', async () => {
+    mockCreate();
+
+    const stream = new HttpStream(client, ref, logger);
+
+    (stream as any)._flushing = true;
+    (stream as any).id = 'activity-1';
+    (stream as any).text = 'Response text';
+    (stream as any).index = 1;
+
+    const closePromise = stream.close();
+
+    await jest.advanceTimersByTimeAsync(100);
+
+    // Verify close() is still waiting
+    const callsBeforeFlush = client.conversations.activities().create.mock.calls.length;
+    expect(callsBeforeFlush).toBe(0);
+
+    // Simulate flush completing
+    (stream as any)._flushing = false;
+    await jest.runAllTimersAsync();
+
+    await closePromise;
+
+    // Now create() should have been called
+    const createCalls = client.conversations.activities().create.mock.calls.length;
+    expect(createCalls).toBe(1);
+  });
 });

--- a/packages/apps/src/http/http-stream.spec.ts
+++ b/packages/apps/src/http/http-stream.spec.ts
@@ -249,8 +249,9 @@ describe('HttpStream', () => {
     stream.update('Thinking...');
     stream.emit('first message');
     stream.emit('last message');
-    stream.close();
+    const closePromise = stream.close();
     await jest.runAllTimersAsync();
+    await closePromise;
 
     expect(client.conversations.activities().create).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/packages/apps/src/http/http-stream.ts
+++ b/packages/apps/src/http/http-stream.ts
@@ -124,7 +124,7 @@ export class HttpStream implements IStreamer {
     // Wait until all queued activities are flushed
     const start = Date.now();
 
-    while ((this.queue.length || !this.id) && !this._canceled) {
+    while ((this.queue.length || !this.id || this._flushing) && !this._canceled) {
       if (Date.now() - start > this._totalTimeout) {
         this._logger.warn('Timeout while waiting for id and queue to flush');
         return;
@@ -153,8 +153,8 @@ export class HttpStream implements IStreamer {
       .withId(this.id)
       .addAttachments(...this.attachments)
       .addEntities(...this.entities)
-      .addStreamFinal()
-      .withChannelData(this.channelData);
+      .withChannelData(this.channelData)
+      .addStreamFinal();
 
     const res = await promises.retry(() => this.send(activity), {
       logger: this._logger


### PR DESCRIPTION
Fixes #549 

## Summary
Fixes two bugs in HttpStream:

### Bug 1: streamType overwritten to informative in final message
close() calls .addStreamFinal().withChannelData(this.channelData). Since this.channelData contains streamType: informative from typing updates, it overwrites the final value.

### Bug 2: Race condition in close()
The while loop checks queue.length and this.id but not this._flushing. If flush() drained the queue but is still awaiting pushStreamChunk() calls, close() proceeds immediately.

### Fixes
1. Swap .withChannelData() and .addStreamFinal() order
2. Add || this._flushing to the while condition"