### PR TITLE
chore: bump version to 2.0.10-preview

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.9-preview.{height}",
+  "version": "2.0.10-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release$"


### PR DESCRIPTION
## Summary
- bumps `version.json` from `2.0.9-preview.{height}` to `2.0.10-preview.{height}`
- 2.0.9 was released from the release branch, so main needs to move to the next version

## Test plan
- CI passes
- verify `version.json` shows `2.0.10-preview.{height}`