### PR TITLE
chore: bump version to 2.0.11-preview

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.10-preview.{height}",
+  "version": "2.0.11-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release$"


### PR DESCRIPTION
Bumps the patch version on main for the next preview release cycle following the 2.0.10 stable release. Per RELEASE.md step 4.