### PR TITLE
ci: pin pipeline to Node 22 to match packageManager (npm 10)

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -57,9 +57,9 @@ extends:
             container: host
 
         - task: NodeTool@0
-          displayName: 'Use Node 24.x'
+          displayName: 'Use Node 22.x'
           inputs:
-            versionSpec: '24.x'
+            versionSpec: '22.x'
             checkLatest: true
           target:
             container: host


### PR DESCRIPTION
## Problem

The release pipeline fails on `npm ci` with errors like:

```
npm error Missing: turbo-windows-arm64@2.8.11 from lock file
npm error Missing: @esbuild/win32-arm64@0.25.12 from lock file
...
```

## Root cause

The pipeline's `NodeTool@0` task uses `versionSpec: '24.x'`, which provisions Node 24 + **npm 11**. However:

- This repo pins `"packageManager": "npm@10.8.1"` in `package.json`.
- npm 10 only records platform-specific optional dependencies for the **current** platform when generating `package-lock.json` (so a lockfile generated on macOS only contains Mac binaries for `@esbuild/*` and `turbo-*`).
- npm 11 requires **all** platform binaries to be present in the lockfile and treats missing ones as out-of-sync, failing `npm ci`.

Lockfile is valid under npm 10 — `npm ci` succeeds locally. The mismatch is purely between the pipeline's npm and the project's pinned npm.

## Fix

Pin the pipeline to Node 22 (LTS), which ships with npm 10, matching the `packageManager` field and every developer's local environment.

## Alternative considered

Bumping the project to npm 11 (update `packageManager`, regenerate lockfile under npm 11, force every dev to upgrade). Rejected as larger blast radius for an unblock-the-release fix.

## Follow-up

This same change needs to be cherry-picked to `release` to unblock the 2.0.10 publish.