### PR TITLE
hotfix: pin pipeline to Node 22 to unblock 2.0.10 release

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -57,9 +57,9 @@ extends:
             container: host
 
         - task: NodeTool@0
-          displayName: 'Use Node 24.x'
+          displayName: 'Use Node 22.x'
           inputs:
-            versionSpec: '24.x'
+            versionSpec: '22.x'
             checkLatest: true
           target:
             container: host


### PR DESCRIPTION
Cherry-pick of #559 onto `release` to unblock the 2.0.10 publish pipeline.

## Why

The publish pipeline fails on `npm ci` on Windows agents because Node 24 ships npm 11, which is stricter than the npm 10 pinned in `packageManager`. See #559 for full root-cause analysis.

## Change

Pins the `NodeTool@0` task in `.azdo/publish.yml` from `24.x` to `22.x` (npm 10). One-line fix, no lockfile or dependency changes.

## After merge

Re-trigger the [release pipeline](https://dev.azure.com/DomoreexpGithub/Github_Pipelines/_build?definitionId=52&_a=summary) on `release` with **Public** publish type to ship 2.0.10.