### PR TITLE
Switch to named imports without subpaths

### DIFF
--- a/examples/botbuilder/src/index.ts
+++ b/examples/botbuilder/src/index.ts
@@ -2,7 +2,7 @@ import { TeamsActivityHandler } from 'botbuilder';
 
 import { App } from '@microsoft/teams.apps';
 import { BotBuilderPlugin } from '@microsoft/teams.botbuilder';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 export class ActivityHandler extends TeamsActivityHandler {

--- a/examples/echo/src/index.ts
+++ b/examples/echo/src/index.ts
@@ -1,6 +1,6 @@
 import { MessageActivity } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 import { MockReminderService } from './mock-reminder-service';

--- a/examples/graph/src/index.ts
+++ b/examples/graph/src/index.ts
@@ -1,5 +1,5 @@
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import * as endpoints from '@microsoft/teams.graph-endpoints';
 
 const app = new App({
@@ -10,7 +10,7 @@ const app = new App({
      */
     defaultConnectionName: 'graph'
   },
-  // Instead of setting in ConsoleLogger like below, you can also 
+  // Instead of setting in ConsoleLogger like below, you can also
   // set LOG_LEVEL=debug or LOG_LEVEL=trace env var for verbose SDK logging
   logger: new ConsoleLogger('@tests/auth', { level: 'debug' }),
     // This is an example of overriding the token URL for a specific region (e.g., Europe).

--- a/examples/lights/src/index.ts
+++ b/examples/lights/src/index.ts
@@ -2,8 +2,7 @@ import '@azure/openai/types';
 import { ChatPrompt, Message } from '@microsoft/teams.ai';
 import { MessageActivity } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
-import { LocalStorage } from '@microsoft/teams.common/storage';
+import { ConsoleLogger, LocalStorage } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 import { OpenAIChatModel } from '@microsoft/teams.openai';
 

--- a/examples/mcp-server/src/app.ts
+++ b/examples/mcp-server/src/app.ts
@@ -2,7 +2,7 @@ import express from 'express';
 
 import { AdaptiveCardActionMessageResponse } from '@microsoft/teams.api';
 import { App, ExpressAdapter } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 
 import { state } from './state';
 

--- a/examples/meetings/src/index.ts
+++ b/examples/meetings/src/index.ts
@@ -1,6 +1,6 @@
 import { App } from '@microsoft/teams.apps';
 import { AdaptiveCard, TextBlock, OpenUrlAction, ActionSet } from '@microsoft/teams.cards';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 
 const app = new App({
   logger: new ConsoleLogger('@examples/meetings', { level: 'debug' })

--- a/examples/message-extensions/src/index.ts
+++ b/examples/message-extensions/src/index.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { cardAttachment } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
 import { IAdaptiveCard } from '@microsoft/teams.cards';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 import {

--- a/examples/proactive-messaging/src/index.ts
+++ b/examples/proactive-messaging/src/index.ts
@@ -7,7 +7,7 @@
 
 import { App } from '@microsoft/teams.apps';
 import { ActionSet, AdaptiveCard, OpenUrlAction, TextBlock } from '@microsoft/teams.cards';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 
 async function sendProactiveMessage(app: App, conversationId: string, message: string) {
   console.log(`Sending proactive message to conversation: ${conversationId}`);

--- a/examples/reactions/src/index.ts
+++ b/examples/reactions/src/index.ts
@@ -1,6 +1,6 @@
 import { Client, MessageReactionActivity } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 
 const app = new App({
   logger: new ConsoleLogger('@examples/reactions', { level: 'debug' })

--- a/examples/tab/src/index.ts
+++ b/examples/tab/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 const app = new App({

--- a/examples/targeted-messages/src/index.ts
+++ b/examples/targeted-messages/src/index.ts
@@ -1,6 +1,6 @@
 import { MessageActivity } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 const app = new App({

--- a/examples/threading/src/index.ts
+++ b/examples/threading/src/index.ts
@@ -1,5 +1,5 @@
 import { App, toThreadedConversationId } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 const app = new App({

--- a/packages/api/src/clients/bot/index.ts
+++ b/packages/api/src/clients/bot/index.ts
@@ -1,4 +1,4 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import { Client, ClientOptions } from '@microsoft/teams.common';
 
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
 

--- a/packages/api/src/clients/bot/index.ts
+++ b/packages/api/src/clients/bot/index.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
 
@@ -14,16 +17,16 @@ export class BotClient {
     this.signIn.http = v;
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _clientSettings: Partial<ApiClientSettings>;
 
-  constructor(options?: Client | ClientOptions, clientSettings?: Partial<ApiClientSettings>) {
+  constructor(options?: HttpClient | HttpClientOptions, clientSettings?: Partial<ApiClientSettings>) {
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._clientSettings = mergeApiClientSettings(clientSettings);

--- a/packages/api/src/clients/bot/sign-in.spec.ts
+++ b/packages/api/src/clients/bot/sign-in.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { BotSignInClient } from './sign-in';
 

--- a/packages/api/src/clients/bot/sign-in.ts
+++ b/packages/api/src/clients/bot/sign-in.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import { Client, ClientOptions } from '@microsoft/teams.common';
 
 import { SignInUrlResponse } from '../../models';
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';

--- a/packages/api/src/clients/bot/sign-in.ts
+++ b/packages/api/src/clients/bot/sign-in.ts
@@ -1,6 +1,9 @@
 import qs from 'qs';
 
-import { Client, ClientOptions } from '@microsoft/teams.common';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { SignInUrlResponse } from '../../models';
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
@@ -31,16 +34,16 @@ export class BotSignInClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
   }

--- a/packages/api/src/clients/conversation/activity.spec.ts
+++ b/packages/api/src/clients/conversation/activity.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { ConversationActivityClient } from './activity';
 

--- a/packages/api/src/clients/conversation/activity.ts
+++ b/packages/api/src/clients/conversation/activity.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { Activity } from '../../activities';
 import { resolveAadObjectId, Resource, TeamsChannelAccount } from '../../models';
@@ -15,18 +18,18 @@ export class ConversationActivityClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);

--- a/packages/api/src/clients/conversation/activity.ts
+++ b/packages/api/src/clients/conversation/activity.ts
@@ -1,4 +1,4 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import { Client, ClientOptions } from '@microsoft/teams.common';
 
 import { Activity } from '../../activities';
 import { resolveAadObjectId, Resource, TeamsChannelAccount } from '../../models';

--- a/packages/api/src/clients/conversation/index.ts
+++ b/packages/api/src/clients/conversation/index.ts
@@ -1,6 +1,9 @@
 import qs from 'qs';
 
-import { Client, ClientOptions } from '@microsoft/teams.common';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { Account, Conversation, ConversationResource } from '../../models';
 
@@ -59,22 +62,22 @@ export class ConversationClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _activities: ConversationActivityClient;
   protected _members: ConversationMemberClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
-  
+
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
     this._activities = new ConversationActivityClient(serviceUrl, this.http, this._apiClientSettings);
     this._members = new ConversationMemberClient(serviceUrl, this.http, this._apiClientSettings);

--- a/packages/api/src/clients/conversation/index.ts
+++ b/packages/api/src/clients/conversation/index.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import { Client, ClientOptions } from '@microsoft/teams.common';
 
 import { Account, Conversation, ConversationResource } from '../../models';
 

--- a/packages/api/src/clients/conversation/member.ts
+++ b/packages/api/src/clients/conversation/member.ts
@@ -1,4 +1,4 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import { Client, ClientOptions } from '@microsoft/teams.common';
 
 import { PagedMembersResult, resolveAadObjectId, TeamsChannelAccount } from '../../models';
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';

--- a/packages/api/src/clients/conversation/member.ts
+++ b/packages/api/src/clients/conversation/member.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { PagedMembersResult, resolveAadObjectId, TeamsChannelAccount } from '../../models';
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
@@ -12,18 +15,18 @@ export class ConversationMemberClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
   }

--- a/packages/api/src/clients/conversation/members.spec.ts
+++ b/packages/api/src/clients/conversation/members.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { ConversationMemberClient } from './member';
 

--- a/packages/api/src/clients/index.ts
+++ b/packages/api/src/clients/index.ts
@@ -1,4 +1,7 @@
-import { Client as HttpClient, type ClientOptions as HttpClientOptions } from '@microsoft/teams.common';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { CloudEnvironment } from '../auth/cloud-environment';
 

--- a/packages/api/src/clients/index.ts
+++ b/packages/api/src/clients/index.ts
@@ -1,4 +1,4 @@
-import { Client as HttpClient, ClientOptions as HttpClientOptions } from '@microsoft/teams.common';
+import { Client as HttpClient, type ClientOptions as HttpClientOptions } from '@microsoft/teams.common';
 
 import { CloudEnvironment } from '../auth/cloud-environment';
 

--- a/packages/api/src/clients/index.ts
+++ b/packages/api/src/clients/index.ts
@@ -1,4 +1,4 @@
-import * as http from '@microsoft/teams.common/http';
+import { Client as HttpClient, ClientOptions as HttpClientOptions } from '@microsoft/teams.common';
 
 import { CloudEnvironment } from '../auth/cloud-environment';
 
@@ -35,18 +35,18 @@ export class Client {
     this.reactions.http = v;
     this._http = v;
   }
-  protected _http: http.Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: http.Client | http.ClientOptions, apiClientSettings?: Partial<ApiClientSettings>, cloud?: CloudEnvironment) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>, cloud?: CloudEnvironment) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new http.Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new http.Client({
+      this._http = new HttpClient({
         ...options,
         headers: {
           ...options?.headers,

--- a/packages/api/src/clients/meeting.spec.ts
+++ b/packages/api/src/clients/meeting.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { MeetingClient } from './meeting';
 

--- a/packages/api/src/clients/meeting.ts
+++ b/packages/api/src/clients/meeting.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import {
   MeetingInfo,
@@ -18,18 +21,18 @@ export class MeetingClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);

--- a/packages/api/src/clients/meeting.ts
+++ b/packages/api/src/clients/meeting.ts
@@ -1,4 +1,4 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import { Client, ClientOptions } from '@microsoft/teams.common';
 
 import {
   MeetingInfo,

--- a/packages/api/src/clients/reaction/reaction.spec.ts
+++ b/packages/api/src/clients/reaction/reaction.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { ReactionClient } from './reaction';
 

--- a/packages/api/src/clients/reaction/reaction.ts
+++ b/packages/api/src/clients/reaction/reaction.ts
@@ -1,4 +1,4 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import { Client, ClientOptions } from '@microsoft/teams.common';
 
 import { MessageReactionType } from '../../models/message/message-reaction';
 

--- a/packages/api/src/clients/reaction/reaction.ts
+++ b/packages/api/src/clients/reaction/reaction.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { MessageReactionType } from '../../models/message/message-reaction';
 
@@ -19,18 +22,18 @@ export class ReactionClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);

--- a/packages/api/src/clients/team.spec.ts
+++ b/packages/api/src/clients/team.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { TeamClient } from './team';
 

--- a/packages/api/src/clients/team.ts
+++ b/packages/api/src/clients/team.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { ChannelInfo, TeamDetails } from '../models';
 
@@ -13,18 +16,18 @@ export class TeamClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);

--- a/packages/api/src/clients/team.ts
+++ b/packages/api/src/clients/team.ts
@@ -1,4 +1,4 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import { Client, ClientOptions } from '@microsoft/teams.common';
 
 import { ChannelInfo, TeamDetails } from '../models';
 

--- a/packages/api/src/clients/user/index.ts
+++ b/packages/api/src/clients/user/index.ts
@@ -1,4 +1,4 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import { Client, ClientOptions } from '@microsoft/teams.common';
 
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
 

--- a/packages/api/src/clients/user/index.ts
+++ b/packages/api/src/clients/user/index.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
 
@@ -13,16 +16,16 @@ export class UserClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);

--- a/packages/api/src/clients/user/token.spec.ts
+++ b/packages/api/src/clients/user/token.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { UserTokenClient } from './token';
 
@@ -91,7 +91,7 @@ describe('UserTokenClient', () => {
     );
   });
 
-  
+
   it('should get AAD token in regional endpoint', async () => {
     const client = new UserTokenClient({}, { oauthUrl: 'https://europe.token.botframework.com' });
     const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});

--- a/packages/api/src/clients/user/token.ts
+++ b/packages/api/src/clients/user/token.ts
@@ -2,7 +2,7 @@ import qs from 'qs';
 
 import {
   Client as HttpClient,
-  type ClientOptions as HttpCLientOptions
+  type ClientOptions as HttpClientOptions
 } from '@microsoft/teams.common';
 
 import { ChannelID, TokenExchangeRequest, TokenResponse, TokenStatus } from '../../models';
@@ -59,7 +59,7 @@ export class UserTokenClient {
   protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(options?: HttpClient | HttpCLientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     if (!options) {
       this._http = new HttpClient();
     } else if ('request' in options) {

--- a/packages/api/src/clients/user/token.ts
+++ b/packages/api/src/clients/user/token.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import { Client, ClientOptions } from '@microsoft/teams.common';
 
 import { ChannelID, TokenExchangeRequest, TokenResponse, TokenStatus } from '../../models';
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';

--- a/packages/api/src/clients/user/token.ts
+++ b/packages/api/src/clients/user/token.ts
@@ -1,6 +1,9 @@
 import qs from 'qs';
 
-import { Client, ClientOptions } from '@microsoft/teams.common';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpCLientOptions
+} from '@microsoft/teams.common';
 
 import { ChannelID, TokenExchangeRequest, TokenResponse, TokenStatus } from '../../models';
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
@@ -53,16 +56,16 @@ export class UserTokenClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(options?: HttpClient | HttpCLientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);

--- a/packages/apps/src/activity-sender.spec.ts
+++ b/packages/apps/src/activity-sender.spec.ts
@@ -1,5 +1,5 @@
 import { ActivityParams, ConversationReference } from '@microsoft/teams.api';
-import  {Client as HttpClient  } from '@microsoft/teams.common';
+import  {Client as HttpClient } from '@microsoft/teams.common';
 
 import { ActivitySender } from './activity-sender';
 

--- a/packages/apps/src/activity-sender.spec.ts
+++ b/packages/apps/src/activity-sender.spec.ts
@@ -1,11 +1,11 @@
 import { ActivityParams, ConversationReference } from '@microsoft/teams.api';
-import * as $http from '@microsoft/teams.common/http';
+import  {Client as HttpClient  } from '@microsoft/teams.common';
 
 import { ActivitySender } from './activity-sender';
 
 describe('ActivitySender', () => {
   let sender: ActivitySender;
-  let mockHttpClient: $http.Client;
+  let mockHttpClient: HttpClient;
   let ref: ConversationReference;
 
   beforeEach(() => {

--- a/packages/apps/src/activity-sender.ts
+++ b/packages/apps/src/activity-sender.ts
@@ -1,6 +1,5 @@
 import { ActivityParams, Client, ConversationReference, SentActivity } from '@microsoft/teams.api';
-import * as $http from '@microsoft/teams.common/http';
-import { ILogger } from '@microsoft/teams.common/logging';
+import { Client as HttpClient, ILogger } from '@microsoft/teams.common';
 
 import { HttpStream } from './http/http-stream';
 import { IStreamer, IActivitySender } from './types';
@@ -11,7 +10,7 @@ import { IStreamer, IActivitySender } from './types';
  */
 export class ActivitySender implements IActivitySender {
   constructor(
-    private client: $http.Client,
+    private client: HttpClient,
     private logger: ILogger
   ) { }
 

--- a/packages/apps/src/api.ts
+++ b/packages/apps/src/api.ts
@@ -1,7 +1,2 @@
-import * as api from '@microsoft/teams.api';
-import * as graph from '@microsoft/teams.graph';
-
-export const ApiClient = api.Client;
-export type ApiClient = api.Client;
-export const GraphClient = graph.Client;
-export type GraphClient = graph.Client;
+export { Client as ApiClient } from '@microsoft/teams.api';
+export { Client as GraphClient } from '@microsoft/teams.graph';

--- a/packages/apps/src/app.oauth.ts
+++ b/packages/apps/src/app.oauth.ts
@@ -6,7 +6,7 @@ import {
   ISignInVerifyStateInvokeActivity,
   TokenExchangeInvokeResponse,
 } from '@microsoft/teams.api';
-import { Client as GraphClient} from '@microsoft/teams.graph';
+import { Client as GraphClient } from '@microsoft/teams.graph';
 
 import { App } from './app';
 import * as contexts from './contexts';

--- a/packages/apps/src/app.oauth.ts
+++ b/packages/apps/src/app.oauth.ts
@@ -6,7 +6,7 @@ import {
   ISignInVerifyStateInvokeActivity,
   TokenExchangeInvokeResponse,
 } from '@microsoft/teams.api';
-import * as graph from '@microsoft/teams.graph';
+import { Client as GraphClient} from '@microsoft/teams.graph';
 
 import { App } from './app';
 import * as contexts from './contexts';
@@ -35,7 +35,7 @@ export async function onTokenExchange<TPlugin extends IPlugin>(
       },
     });
 
-    ctx.userGraph = new graph.Client(
+    ctx.userGraph = new GraphClient(
       this.client.clone({
         token: token.token,
       }),
@@ -85,7 +85,7 @@ export async function onVerifyState<TPlugin extends IPlugin>(
       code: activity.value.state,
     });
 
-    ctx.userGraph = new graph.Client(
+    ctx.userGraph = new GraphClient(
       this.client.clone({
         token: token.token,
       }),

--- a/packages/apps/src/app.plugin.spec.ts
+++ b/packages/apps/src/app.plugin.spec.ts
@@ -1,4 +1,4 @@
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 
 import { ICoreActivity, IErrorEvent } from './events';
 import { createTestApp } from './test-utils';

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -15,7 +15,7 @@ import {
 } from '@microsoft/teams.api';
 import {
   Client as HttpClient,
-  ClientOptions as HttpClientOptions,
+  type ClientOptions as HttpClientOptions,
   ConsoleLogger,
   EventEmitter,
   ILogger,

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -13,10 +13,15 @@ import {
   toActivityParams,
   TokenCredentials,
 } from '@microsoft/teams.api';
-import { EventEmitter } from '@microsoft/teams.common/events';
-import * as http from '@microsoft/teams.common/http';
-import { ConsoleLogger, ILogger } from '@microsoft/teams.common/logging';
-import { IStorage, LocalStorage } from '@microsoft/teams.common/storage';
+import {
+  Client as HttpClient,
+  ClientOptions as HttpClientOptions,
+  ConsoleLogger,
+  EventEmitter,
+  ILogger,
+  IStorage,
+  LocalStorage
+} from '@microsoft/teams.common';
 
 import pkg from '../package.json';
 
@@ -103,7 +108,7 @@ export type AppOptions<TPlugin extends IPlugin> = {
   /**
    * http client or client options used to make api requests
    */
-  readonly client?: http.Client | http.ClientOptions | (() => http.Client);
+  readonly client?: HttpClient | HttpClientOptions | (() => HttpClient);
 
   /**
    * logger instance to use
@@ -192,7 +197,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
   readonly log: ILogger;
   readonly server: HttpServer;
   readonly http?: HttpPlugin;
-  readonly client: http.Client;
+  readonly client: HttpClient;
   readonly storage: IStorage;
   readonly entraTokenValidator?: middleware.JwtValidator;
   readonly tokenManager: TokenManager;
@@ -282,7 +287,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
     this.cloud = this.options.cloud ?? (cloudEnvName ? cloudFromName(cloudEnvName) : PUBLIC);
 
     if (!options.client) {
-      this.client = new http.Client({
+      this.client = new HttpClient({
         headers: {
           'User-Agent': this._userAgent,
         },
@@ -300,7 +305,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
         },
       });
     } else {
-      this.client = new http.Client({
+      this.client = new HttpClient({
         ...options.client,
         headers: {
           ...options.client.headers,

--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -8,8 +8,7 @@ import {
   TokenExchangeResource,
   TokenPostResource,
 } from '@microsoft/teams.api';
-import { ILogger } from '@microsoft/teams.common/logging';
-import { IStorage } from '@microsoft/teams.common/storage';
+import { ILogger, IStorage } from '@microsoft/teams.common';
 
 import { ApiClient, GraphClient } from '../api';
 

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -15,8 +15,7 @@ import {
   TokenPostResource,
   TypingActivity,
 } from '@microsoft/teams.api';
-import { ILogger } from '@microsoft/teams.common/logging';
-import { IStorage } from '@microsoft/teams.common/storage';
+import { ILogger, IStorage } from '@microsoft/teams.common';
 
 import { ApiClient, GraphClient } from '../api';
 import { IStreamer } from '../types';

--- a/packages/apps/src/middleware/strip-mentions-text.ts
+++ b/packages/apps/src/middleware/strip-mentions-text.ts
@@ -1,15 +1,19 @@
-import * as api from '@microsoft/teams.api';
+import {
+  Activity,
+  StripMentionsTextOptions,
+  stripMentionsText as apiStripMentionsText
+} from '@microsoft/teams.api';
 
 import { IActivityContext } from '../contexts';
 
-export function stripMentionsText(options?: api.StripMentionsTextOptions) {
-  return ({ activity, next }: IActivityContext<api.Activity, any>) => {
+export function stripMentionsText(options?: StripMentionsTextOptions) {
+  return ({ activity, next }: IActivityContext<Activity, any>) => {
     if (
       activity.type === 'message' ||
       activity.type === 'messageUpdate' ||
       activity.type === 'typing'
     ) {
-      activity.text = api.stripMentionsText(activity, options);
+      activity.text = apiStripMentionsText(activity, options);
     }
 
     return next();

--- a/packages/apps/src/middleware/strip-mentions-text.ts
+++ b/packages/apps/src/middleware/strip-mentions-text.ts
@@ -1,6 +1,6 @@
 import {
-  Activity,
-  StripMentionsTextOptions,
+  type Activity,
+  type StripMentionsTextOptions,
   stripMentionsText as apiStripMentionsText
 } from '@microsoft/teams.api';
 

--- a/packages/botbuilder/src/plugin.ts
+++ b/packages/botbuilder/src/plugin.ts
@@ -18,8 +18,7 @@ import {
   Plugin,
   manifest,
 } from '@microsoft/teams.apps';
-import { ILogger } from '@microsoft/teams.common';
-import * as $http from '@microsoft/teams.common/http';
+import { Client as HttpClient, ILogger } from '@microsoft/teams.common';
 
 import pkg from '../package.json';
 
@@ -37,7 +36,7 @@ export class BotBuilderPlugin implements IPlugin {
   declare readonly logger: ILogger;
 
   @Dependency()
-  declare readonly client: $http.Client;
+  declare readonly client: HttpClient;
 
   @HttpServer()
   declare readonly httpServer: IHttpServer;

--- a/packages/cli/templates/typescript/ai/src/index.ts
+++ b/packages/cli/templates/typescript/ai/src/index.ts
@@ -1,6 +1,6 @@
 import { App } from '@microsoft/teams.apps';
 import { ChatPrompt, Message } from '@microsoft/teams.ai';
-import { LocalStorage } from '@microsoft/teams.common/storage';
+import { LocalStorage } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 import { OpenAIChatModel } from '@microsoft/teams.openai';
 

--- a/packages/cli/templates/typescript/tab/src/index.ts
+++ b/packages/cli/templates/typescript/tab/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 const app = new App({

--- a/packages/client/src/app.spec.ts
+++ b/packages/client/src/app.spec.ts
@@ -67,9 +67,9 @@ jest.mock('@azure/msal-browser', () => {
   };
 });
 
-jest.mock('@microsoft/teams.common/http', () => {
+jest.mock('@microsoft/teams.common', () => {
   return {
-    ...jest.requireActual('@microsoft/teams.common/http'),
+    ...jest.requireActual('@microsoft/teams.common'),
     Client: jest.fn().mockImplementation(() => {
       return {
         post: httpClientPostMock,

--- a/packages/client/src/app.ts
+++ b/packages/client/src/app.ts
@@ -1,9 +1,13 @@
-import * as msal from '@azure/msal-browser';
+import {
+  createNestablePublicClientApplication,
+  Configuration,
+  IPublicClientApplication,
+  SilentRequest,
+} from '@azure/msal-browser';
 
-import * as teamsJs from '@microsoft/teams-js';
-import * as http from '@microsoft/teams.common/http';
-import { ILogger, ConsoleLogger } from '@microsoft/teams.common/logging';
-import * as graph from '@microsoft/teams.graph';
+import { app } from '@microsoft/teams-js';
+import { ConsoleLogger, Client as HttpClient, ILogger } from '@microsoft/teams.common';
+import  { Client as GraphClient }   from '@microsoft/teams.graph';
 
 import { buildGraphClient } from './graph-utils';
 import {
@@ -23,7 +27,7 @@ export type MsalOptions = (
        * This is useful if you want to use a custom MSAL instance or if you want to share the
        * same MSAL instance across multiple apps.
        */
-      readonly msalInstance?: msal.IPublicClientApplication;
+      readonly msalInstance?: IPublicClientApplication;
       readonly configuration?: never;
     }
   | {
@@ -31,7 +35,7 @@ export type MsalOptions = (
       /**
        * MSAL configuration to use when constructing an MSAL instance used
        * to make authenticated function calls to remote endpoints. */
-      readonly configuration?: msal.Configuration;
+      readonly configuration?: Configuration;
     }
 ) & {
   /**
@@ -85,7 +89,7 @@ type AppState =
   | {
       phase: 'started';
       startedAt: Date;
-      msalInstance: msal.IPublicClientApplication;
+      msalInstance: IPublicClientApplication;
     };
 
 /**
@@ -93,7 +97,7 @@ type AppState =
  */
 export type ExecOptions = (
   | {
-      readonly msalTokenRequest?: msal.SilentRequest;
+      readonly msalTokenRequest?: SilentRequest;
       readonly permission?: never;
     }
   | { readonly msalTokenRequest?: never; readonly permission?: string }
@@ -108,8 +112,8 @@ export type ExecOptions = (
  */
 export class App {
   readonly options: AppOptions;
-  readonly http: http.Client;
-  readonly graph: graph.Client;
+  readonly http: HttpClient;
+  readonly graph: GraphClient;
   readonly clientId: string;
   protected _state: AppState = { phase: 'stopped' };
 
@@ -141,7 +145,7 @@ export class App {
     this.clientId = clientId;
     this.options = options;
     this._log = options?.logger || new ConsoleLogger('@teams/client');
-    this.http = new http.Client({
+    this.http = new HttpClient({
       baseUrl: options?.remoteApiOptions?.baseUrl,
     });
     this.graph = buildGraphClient(() => this.appStateGuard(), this._log);
@@ -161,14 +165,14 @@ export class App {
     this._log.debug('app starting');
     this._state = { phase: 'starting' };
 
-    await teamsJs.app.initialize();
+    await app.initialize();
 
     let msalInstance = this.options.msalOptions?.msalInstance;
     if (!msalInstance) {
       const msalConfig =
         this.options.msalOptions?.configuration ??
         buildMsalConfig(this.clientId, this._log);
-      msalInstance = await msal.createNestablePublicClientApplication(
+      msalInstance = await createNestablePublicClientApplication(
         msalConfig
       );
     }
@@ -201,7 +205,7 @@ export class App {
     options?: ExecOptions
   ): Promise<T> {
     const { msalInstance } = this.appStateGuard();
-    const context = await teamsJs.app.getContext();
+    const context = await app.getContext();
 
     const remoteAppResource =
       this.options.remoteApiOptions?.remoteAppResource ??

--- a/packages/client/src/app.ts
+++ b/packages/client/src/app.ts
@@ -1,8 +1,8 @@
 import {
   createNestablePublicClientApplication,
-  Configuration,
-  IPublicClientApplication,
-  SilentRequest,
+  type Configuration,
+  type IPublicClientApplication,
+  type SilentRequest,
 } from '@azure/msal-browser';
 
 import { app } from '@microsoft/teams-js';

--- a/packages/client/src/app.ts
+++ b/packages/client/src/app.ts
@@ -7,7 +7,7 @@ import {
 
 import { app } from '@microsoft/teams-js';
 import { ConsoleLogger, Client as HttpClient, ILogger } from '@microsoft/teams.common';
-import  { Client as GraphClient }   from '@microsoft/teams.graph';
+import  { Client as GraphClient } from '@microsoft/teams.graph';
 
 import { buildGraphClient } from './graph-utils';
 import {

--- a/packages/client/src/app.ts
+++ b/packages/client/src/app.ts
@@ -7,7 +7,7 @@ import {
 
 import { app } from '@microsoft/teams-js';
 import { ConsoleLogger, Client as HttpClient, ILogger } from '@microsoft/teams.common';
-import  { Client as GraphClient } from '@microsoft/teams.graph';
+import { Client as GraphClient } from '@microsoft/teams.graph';
 
 import { buildGraphClient } from './graph-utils';
 import {

--- a/packages/client/src/graph-utils.spec.ts
+++ b/packages/client/src/graph-utils.spec.ts
@@ -2,9 +2,9 @@ const httpClientMock = jest.fn();
 
 import { buildGraphClient } from './graph-utils';
 
-jest.mock('@microsoft/teams.common/http', () => {
+jest.mock('@microsoft/teams.common', () => {
   return {
-    ...jest.requireActual('@microsoft/teams.common/http'),
+    ...jest.requireActual('@microsoft/teams.common'),
     Client: httpClientMock,
   };
 });

--- a/packages/client/src/graph-utils.ts
+++ b/packages/client/src/graph-utils.ts
@@ -1,4 +1,4 @@
-import { Client as HttpClient, ILogger, RequestContext } from '@microsoft/teams.common';
+import { Client as HttpClient, ILogger, type RequestContext } from '@microsoft/teams.common';
 import { Client as GraphClient } from '@microsoft/teams.graph';
 
 import { acquireMsalAccessToken } from './msal-utils';

--- a/packages/client/src/graph-utils.ts
+++ b/packages/client/src/graph-utils.ts
@@ -1,15 +1,14 @@
-import * as http from '@microsoft/teams.common/http';
-import { ILogger } from '@microsoft/teams.common/logging';
-import * as graph from '@microsoft/teams.graph';
+import { Client as HttpClient, ILogger, RequestContext } from '@microsoft/teams.common';
+import { Client as GraphClient } from '@microsoft/teams.graph';
 
 import { acquireMsalAccessToken } from './msal-utils';
 
 export function buildGraphClient(
   getMsalInstance: () => { msalInstance: Parameters<typeof acquireMsalAccessToken>[0] },
   logger: ILogger
-): graph.Client {
+): GraphClient {
   {
-    const graphRequestAccessTokenInterceptor = async (ctx: http.RequestContext) => {
+    const graphRequestAccessTokenInterceptor = async (ctx: RequestContext) => {
       const { msalInstance } = getMsalInstance();
 
       // The developer should already have made sure that the user has consented to the scope
@@ -24,8 +23,8 @@ export function buildGraphClient(
       return ctx.config;
     };
 
-    return new graph.Client(
-      new http.Client({
+    return new GraphClient(
+      new HttpClient({
         interceptors: [{ request: graphRequestAccessTokenInterceptor }],
       })
     );

--- a/packages/client/src/msal-utils.ts
+++ b/packages/client/src/msal-utils.ts
@@ -1,9 +1,9 @@
 import {
-  Configuration,
-  IPublicClientApplication,
+  type Configuration,
+  type IPublicClientApplication,
   InteractionRequiredAuthError,
   LogLevel,
-  SilentRequest,
+  type SilentRequest,
 } from '@azure/msal-browser';
 
 import { ILogger } from '@microsoft/teams.common';

--- a/packages/client/src/msal-utils.ts
+++ b/packages/client/src/msal-utils.ts
@@ -1,6 +1,12 @@
-import * as msal from '@azure/msal-browser';
+import {
+  Configuration,
+  IPublicClientApplication,
+  InteractionRequiredAuthError,
+  LogLevel,
+  SilentRequest,
+} from '@azure/msal-browser';
 
-import { ILogger } from '@microsoft/teams.common/logging';
+import { ILogger } from '@microsoft/teams.common';
 
 /**
  * Gets a silent request used to acquire an Entra access token for invoking remote functions on behalf of a user.
@@ -11,7 +17,7 @@ import { ILogger } from '@microsoft/teams.common/logging';
 export const getStandardExecSilentRequest = (
   resource: string,
   permission = 'access_as_user'
-): msal.SilentRequest => ({
+): SilentRequest => ({
   scopes: [`${resource}/${permission}`],
 });
 
@@ -22,7 +28,7 @@ export const getStandardExecSilentRequest = (
  * @returns A default MSAL configuration object suitable for creating a
  * @see{IPublicClientApplication} instance for a multi-tenant application.
  */
-export const buildMsalConfig = (clientId: string, logger: ILogger): msal.Configuration => {
+export const buildMsalConfig = (clientId: string, logger: ILogger): Configuration => {
   return {
     auth: {
       clientId,
@@ -35,16 +41,16 @@ export const buildMsalConfig = (clientId: string, logger: ILogger): msal.Configu
         piiLoggingEnabled: false,
         loggerCallback: (level, message) => {
           switch (level) {
-            case msal.LogLevel.Error:
+            case LogLevel.Error:
               logger.error(message);
               return;
-            case msal.LogLevel.Info:
+            case LogLevel.Info:
               logger.info(message);
               return;
-            case msal.LogLevel.Verbose:
+            case LogLevel.Verbose:
               logger.debug(message);
               return;
-            case msal.LogLevel.Warning:
+            case LogLevel.Warning:
               logger.warn(message);
               return;
             default:
@@ -66,8 +72,8 @@ export const buildMsalConfig = (clientId: string, logger: ILogger): msal.Configu
  * @returns A promise that resolves to the acquired access token.
  */
 export const acquireMsalAccessToken = async (
-  msalInstance: Pick<msal.IPublicClientApplication, 'acquireTokenSilent' | 'acquireTokenPopup'>,
-  request: msal.SilentRequest,
+  msalInstance: Pick<IPublicClientApplication, 'acquireTokenSilent' | 'acquireTokenPopup'>,
+  request: SilentRequest,
   logger: ILogger
 ): Promise<string> => {
   try {
@@ -76,7 +82,7 @@ export const acquireMsalAccessToken = async (
   } catch (ex) {
     // InteractionRequiredAuthError indicates that the user may not have consented to the requested
     // scope yet -- for this, we can fall back on acquireTokenPopup instead.
-    const tryAcquireTokenPopup = ex instanceof msal.InteractionRequiredAuthError;
+    const tryAcquireTokenPopup = ex instanceof InteractionRequiredAuthError;
     if (!tryAcquireTokenPopup) {
       logger.error('acquireTokenSilent failed', ex);
       throw ex;
@@ -103,7 +109,7 @@ export const acquireMsalAccessToken = async (
  * @returns A promise that resolves to a boolean indicating whether the user has consented to the scopes.
  */
 export const hasConsentForScopes = async (
-  msalInstance: Pick<msal.IPublicClientApplication, 'acquireTokenSilent'>,
+  msalInstance: Pick<IPublicClientApplication, 'acquireTokenSilent'>,
   scopes: string[],
   logger: ILogger
 ): Promise<boolean> => {
@@ -116,7 +122,7 @@ export const hasConsentForScopes = async (
   } catch (ex) {
     // InteractionRequiredAuthError indicates that the user has not consented to the requested scope yet.
     // This is not an error, but may be interesting when trouble shooting.
-    const acquireTokenPopupNeeded = ex instanceof msal.InteractionRequiredAuthError;
+    const acquireTokenPopupNeeded = ex instanceof InteractionRequiredAuthError;
     const logLevel = acquireTokenPopupNeeded ? 'debug' : 'error';
     logger.log(logLevel, 'hasConsentForScopes failed', ex);
     return false;

--- a/packages/dev/src/routes/context.ts
+++ b/packages/dev/src/routes/context.ts
@@ -1,5 +1,5 @@
 import { Activity, InvokeResponse, IToken } from '@microsoft/teams.api';
-import { ILogger } from '@microsoft/teams.common/logging';
+import { ILogger } from '@microsoft/teams.common';
 
 export type RouteContext = {
   readonly port: number;

--- a/packages/devtools/src/components/Logger/Logger.ts
+++ b/packages/devtools/src/components/Logger/Logger.ts
@@ -1,4 +1,4 @@
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 
 const Logger = new ConsoleLogger('@teams/devtools');
 

--- a/packages/graph/src/index.spec.ts
+++ b/packages/graph/src/index.spec.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from 'axios';
 
-import { Client as HttpClient} from '@microsoft/teams.common';
+import { Client as HttpClient } from '@microsoft/teams.common';
 
 import { Client, GraphError } from './index';
 

--- a/packages/graph/src/index.spec.ts
+++ b/packages/graph/src/index.spec.ts
@@ -1,19 +1,19 @@
 import { AxiosError } from 'axios';
 
-import * as http from '@microsoft/teams.common/http';
+import { Client as HttpClient} from '@microsoft/teams.common';
 
 import { Client, GraphError } from './index';
 
 import type { EndpointRequest } from './types';
 
 // Mock the http module
-jest.mock('@microsoft/teams.common/http', () => ({
+jest.mock('@microsoft/teams.common', () => ({
   Client: jest.fn(),
 }));
 
 describe('Client', () => {
-  let mockHttpClient: jest.Mocked<http.Client>;
-  let mockBetaHttpClient: jest.Mocked<http.Client>;
+  let mockHttpClient: jest.Mocked<HttpClient>;
+  let mockBetaHttpClient: jest.Mocked<HttpClient>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -41,7 +41,7 @@ describe('Client', () => {
     // Setup clone to return beta client
     mockHttpClient.clone.mockReturnValue(mockBetaHttpClient);
 
-    (http.Client as jest.MockedClass<typeof http.Client>).mockImplementation(
+    (HttpClient as jest.MockedClass<typeof HttpClient>).mockImplementation(
       () => mockHttpClient,
     );
   });
@@ -49,7 +49,7 @@ describe('Client', () => {
   describe('constructor', () => {
     it('should create client with default base URL', () => {
       new Client();
-      expect(http.Client).toHaveBeenCalledWith({
+      expect(HttpClient).toHaveBeenCalledWith({
         baseUrl: 'https://graph.microsoft.com/v1.0',
         headers: {
           'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ describe('Client', () => {
         baseUrlRoot: 'https://graph.microsoft.us',
       });
 
-      expect(http.Client).toHaveBeenCalledWith({
+      expect(HttpClient).toHaveBeenCalledWith({
         baseUrlRoot: 'https://graph.microsoft.us',
         baseUrl: 'https://graph.microsoft.us/v1.0',
         headers: {
@@ -81,7 +81,7 @@ describe('Client', () => {
         timeout: 10000,
       });
 
-      expect(http.Client).toHaveBeenCalledWith({
+      expect(HttpClient).toHaveBeenCalledWith({
         baseUrlRoot: 'https://graph.microsoft.de',
         timeout: 10000,
         baseUrl: 'https://graph.microsoft.de/v1.0',
@@ -130,7 +130,7 @@ describe('Client', () => {
     it('should honor graphOptions.baseUrlRoot when no options provided', () => {
       new Client(undefined, { baseUrlRoot: 'https://graph.microsoft.us' });
 
-      expect(http.Client).toHaveBeenCalledWith({
+      expect(HttpClient).toHaveBeenCalledWith({
         baseUrl: 'https://graph.microsoft.us/v1.0',
         headers: {
           'Content-Type': 'application/json',
@@ -145,7 +145,7 @@ describe('Client', () => {
         { baseUrlRoot: 'https://graph.microsoft.us' }
       );
 
-      expect(http.Client).toHaveBeenCalledWith({
+      expect(HttpClient).toHaveBeenCalledWith({
         baseUrlRoot: 'https://graph.microsoft.com',
         baseUrl: 'https://graph.microsoft.us/v1.0',
         headers: {

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,4 +1,7 @@
-import * as http from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { getInjectedUrl, getInjectedRequestConfig } from './utils/url';
 
@@ -45,7 +48,7 @@ export class GraphError extends Error {
 
 const defaultBaseUrlRoot = 'https://graph.microsoft.com';
 
-type Options = (http.Client | http.ClientOptions) & {
+type Options = (HttpClient | HttpClientOptions) & {
   /** Graph service root. By default, the global commercial URL "https://graph.microsoft.com" is used,
    * but certain tenants may wish to override this to direct Graph API calls to a different cloud instance.
    */
@@ -64,22 +67,22 @@ type GraphOptions = {
  */
 export class Client {
   protected baseUrlRoot;
-  protected _http: http.Client;
-  protected betaHttp?: http.Client;
+  protected _http: HttpClient;
+  protected betaHttp?: HttpClient;
 
   /**
    * The underlying HTTP client, pre-configured with Graph base URL and headers.
    * Use for raw Graph API requests not covered by endpoint functions.
    */
-  get http(): http.Client {
+  get http(): HttpClient {
     return this._http;
   }
 
   /**
    * Creates a Graph client.
    *
-   * @param options - The HTTP client to use; an existing {@link http.Client} will be cloned,
-   * or an {@link http.ClientOptions} bag will be used to build a new one.
+   * @param options - The HTTP client to use; an existing {@link HttpClient} will be cloned,
+   * or an {@link HttpClientOptions} bag will be used to build a new one.
    * HTTP-level settings like headers, interceptors, and timeouts belong here.
    * @param graphOptions - Graph-specific options. Takes precedence over `options.baseUrlRoot`
    * when both are set.
@@ -95,7 +98,7 @@ export class Client {
   constructor(options?: Options, graphOptions?: GraphOptions) {
     this.baseUrlRoot = graphOptions?.baseUrlRoot ?? options?.baseUrlRoot ?? defaultBaseUrlRoot;
     if (!options) {
-      this._http = new http.Client({
+      this._http = new HttpClient({
         baseUrl: `${this.baseUrlRoot}/v1.0`,
         headers: {
           'Content-Type': 'application/json',
@@ -111,7 +114,7 @@ export class Client {
         },
       });
     } else {
-      this._http = new http.Client({
+      this._http = new HttpClient({
         ...options,
         baseUrl: `${this.baseUrlRoot}/v1.0`,
         headers: {
@@ -192,7 +195,7 @@ export class Client {
     }
   }
 
-  private getHttpClient(schemaVersion: SchemaVersion): http.Client {
+  private getHttpClient(schemaVersion: SchemaVersion): HttpClient {
     if (schemaVersion === 'v1.0') {
       return this._http;
     }

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,6 +1,6 @@
 import {
   Client as HttpClient,
-  ClientOptions as HttpClientOptions
+  type ClientOptions as HttpClientOptions
 } from '@microsoft/teams.common';
 
 import { getInjectedUrl, getInjectedRequestConfig } from './utils/url';

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -1,4 +1,4 @@
-import * as http from '@microsoft/teams.common/http';
+import { type RequestConfig } from '@microsoft/teams.common';
 
 export type SchemaVersion = 'beta' | 'v1.0';
 
@@ -8,7 +8,7 @@ export type SchemaVersion = 'beta' | 'v1.0';
  */
 export type CallOptions = {
   /** HTTP request configuration */
-  requestConfig?: http.RequestConfig;
+  requestConfig?: RequestConfig;
 };
 
 export type ParamDefs = Partial<Record<'query' | 'header' | 'path', string[]>>;
@@ -20,6 +20,6 @@ export type EndpointRequest<TResponse> = {
   paramDefs?: ParamDefs;
   params?: Record<string, any>;
   body?: any;
-  config?: http.RequestConfig;
+  config?: RequestConfig;
   responseType?: TResponse;
 };

--- a/packages/graph/src/utils/url.ts
+++ b/packages/graph/src/utils/url.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 
-import * as http from '@microsoft/teams.common/http';
+import { type RequestConfig } from '@microsoft/teams.common';
 
 import { ParamDefs } from '../types';
 
@@ -25,8 +25,8 @@ export function getInjectedUrl(
 export function getInjectedRequestConfig(
   params: ParamDefs,
   data: Record<string, any>,
-  requestConfig?: http.RequestConfig,
-): http.RequestConfig | undefined {
+  requestConfig?: RequestConfig,
+): RequestConfig | undefined {
   const paramHeaders = (params.header ?? []).reduce<Record<string, any>>(
     (agg, param) => {
       if (data[param]) {

--- a/packages/openai/src/audio.ts
+++ b/packages/openai/src/audio.ts
@@ -3,7 +3,7 @@ import OpenAI, { toFile } from 'openai';
 import { Fetch } from 'openai/core.mjs';
 
 import { IAudioModel, TextToAudioParams, AudioToTextParams } from '@microsoft/teams.ai';
-import { ILogger, ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ILogger, ConsoleLogger } from '@microsoft/teams.common';
 
 export type OpenAIAudioPluginOptions = {
   readonly model: string;

--- a/packages/openai/src/chat.ts
+++ b/packages/openai/src/chat.ts
@@ -10,7 +10,7 @@ import {
   Message,
   ModelMessage,
 } from '@microsoft/teams.ai';
-import { ConsoleLogger, ILogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger, ILogger } from '@microsoft/teams.common';
 
 export type ChatCompletionCreateParams = Omit<
   OpenAI.ChatCompletionCreateParams,


### PR DESCRIPTION
While setting up some sample projects to repro & test a fix for bug 542, I realized that on older webpack I had to add babel configuration to work around subpath imports inside of the teams.ts libraries. I had to add the alias section here to my webpack.frontend.config.js just for a basic tab test app. Which is doable, but also unnecessary friction:
```
  resolve: {
    extensions: [".tsx", ".ts", ".js"],
    mainFields: ["main", "module", "browser"],
    alias: {
      "@microsoft/teams.common/http$": path.resolve(
        __dirname,
        "node_modules/@microsoft/teams.common/dist/http/index.js"
      ),
      "@microsoft/teams.common/logging$": path.resolve(
        __dirname,
        "node_modules/@microsoft/teams.common/dist/logging/index.js"
      ),
    },
  },
``` 

In addition, I noticed that we often use wildcard imports for readability, but on older bundlers this may impact tree shakability.

Let's clean up both of these and switch to named imports without subpaths. There are no code changes from this, just a bunch of routine imports & type alias changes.

How tested:
 - Built & packed the packages locally; npm installed them into my test project; verified that I could now remove the alias section
 - Build passes, linter passes, unit tests pass.
 - Verified that the diffs detected by Template Sync Verification are false positives, as they didn't have the same imports in the first place. skip-test-verification