### PR TITLE
[Bug]: Cannot import @microsoft/teams.client into webpack 5 javascript react project: Module has no exports.

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -8,6 +8,7 @@
   "files": [
     "eslint.config.js",
     "jest.config.js",
+    "rewrite-esm-imports.js",
     "tsup.config.js"
   ],
   "publishConfig": {

--- a/packages/config/rewrite-esm-imports.js
+++ b/packages/config/rewrite-esm-imports.js
@@ -1,23 +1,49 @@
-const fs = require('node:fs');
-const path = require('node:path');
+const fs = require("node:fs");
+const path = require("node:path");
+
+const KNOWN_RUNTIME_EXTENSIONS = new Set([
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".json",
+  ".node",
+  ".wasm",
+]);
+
+function hasKnownRuntimeExtension(specifier) {
+  const bareSpecifier = specifier.split(/[?#]/, 1)[0];
+  const lastSegment = bareSpecifier.slice(bareSpecifier.lastIndexOf("/") + 1);
+
+  if (!lastSegment || lastSegment === "." || lastSegment === "..") {
+    return false;
+  }
+
+  const dotIndex = lastSegment.lastIndexOf(".");
+  if (dotIndex <= 0) {
+    return false;
+  }
+
+  const ext = lastSegment.slice(dotIndex).toLowerCase();
+  return KNOWN_RUNTIME_EXTENSIONS.has(ext);
+}
 
 function rewriteRelativeMjsSpecifier(specifier, sourceFilePath) {
-  // Skip if specifier already has a file extension (.js, .mjs, .json, etc.)
-  if (path.posix.extname(specifier)) {
+  // Skip if specifier already has a known runtime extension.
+  if (hasKnownRuntimeExtension(specifier)) {
     return specifier;
   }
 
   const sourceDir = path.dirname(sourceFilePath);
   const resolvedBase = path.resolve(sourceDir, specifier);
   const resolvedFile = `${resolvedBase}.mjs`;
-  const resolvedIndex = path.join(resolvedBase, 'index.mjs');
+  const resolvedIndex = path.join(resolvedBase, "index.mjs");
 
   if (fs.existsSync(resolvedFile)) {
     return `${specifier}.mjs`;
   }
 
   if (fs.existsSync(resolvedIndex)) {
-    const cleanSpecifier = specifier.endsWith('/')
+    const cleanSpecifier = specifier.endsWith("/")
       ? specifier.slice(0, -1)
       : specifier;
     return `${cleanSpecifier}/index.mjs`;
@@ -50,14 +76,14 @@ function rewriteMjsImportsInDist(distDir) {
         continue;
       }
 
-      if (!entry.isFile() || !entry.name.endsWith('.mjs')) {
+      if (!entry.isFile() || !entry.name.endsWith(".mjs")) {
         continue;
       }
 
-      const source = fs.readFileSync(fullPath, 'utf8');
+      const source = fs.readFileSync(fullPath, "utf8");
       const rewritten = rewriteMjsSpecifiers(source, fullPath);
       if (rewritten !== source) {
-        fs.writeFileSync(fullPath, rewritten, 'utf8');
+        fs.writeFileSync(fullPath, rewritten, "utf8");
       }
     }
   };

--- a/packages/config/rewrite-esm-imports.js
+++ b/packages/config/rewrite-esm-imports.js
@@ -1,0 +1,70 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function rewriteRelativeMjsSpecifier(specifier, sourceFilePath) {
+  // Skip if specifier already has a file extension (.js, .mjs, .json, etc.)
+  if (path.posix.extname(specifier)) {
+    return specifier;
+  }
+
+  const sourceDir = path.dirname(sourceFilePath);
+  const resolvedBase = path.resolve(sourceDir, specifier);
+  const resolvedFile = `${resolvedBase}.mjs`;
+  const resolvedIndex = path.join(resolvedBase, 'index.mjs');
+
+  if (fs.existsSync(resolvedFile)) {
+    return `${specifier}.mjs`;
+  }
+
+  if (fs.existsSync(resolvedIndex)) {
+    const cleanSpecifier = specifier.endsWith('/')
+      ? specifier.slice(0, -1)
+      : specifier;
+    return `${cleanSpecifier}/index.mjs`;
+  }
+
+  return specifier;
+}
+
+function rewriteMjsSpecifiers(content, sourceFilePath) {
+  const rewrite = (_, prefix, specifier, suffix) => {
+    return `${prefix}${rewriteRelativeMjsSpecifier(specifier, sourceFilePath)}${suffix}`;
+  };
+
+  return content
+    .replace(/(from\s+['"])(\.{1,2}\/[^'"\n]+)(['"])/g, rewrite)
+    .replace(/(import\s+['"])(\.{1,2}\/[^'"\n]+)(['"])/g, rewrite)
+    .replace(/(import\(\s*['"])(\.{1,2}\/[^'"\n]+)(['"]\s*\))/g, rewrite);
+}
+
+function rewriteMjsImportsInDist(distDir) {
+  if (!fs.existsSync(distDir)) {
+    return;
+  }
+
+  const visit = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath);
+        continue;
+      }
+
+      if (!entry.isFile() || !entry.name.endsWith('.mjs')) {
+        continue;
+      }
+
+      const source = fs.readFileSync(fullPath, 'utf8');
+      const rewritten = rewriteMjsSpecifiers(source, fullPath);
+      if (rewritten !== source) {
+        fs.writeFileSync(fullPath, rewritten, 'utf8');
+      }
+    }
+  };
+
+  visit(distDir);
+}
+
+module.exports = {
+  rewriteMjsImportsInDist,
+};

--- a/packages/config/tsup.config.js
+++ b/packages/config/tsup.config.js
@@ -1,5 +1,7 @@
-const path = require('node:path');
-const { rewriteMjsImportsInDist } = require('./rewrite-esm-imports');
+const path = require("node:path");
+const { rewriteMjsImportsInDist } = require("./rewrite-esm-imports");
+
+const OUT_DIR = "dist";
 
 /** @type {import('tsup').Options} */
 module.exports = {
@@ -10,10 +12,10 @@ module.exports = {
   treeshake: true,
   splitting: true,
   clean: true,
-  outDir: 'dist',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts'],
-  format: ['cjs', 'esm'],
+  outDir: OUT_DIR,
+  entry: ["src/**/*.ts", "!src/**/*.spec.ts"],
+  format: ["cjs", "esm"],
   async onSuccess() {
-    rewriteMjsImportsInDist(path.join(process.cwd(), 'dist'));
+    rewriteMjsImportsInDist(path.join(process.cwd(), OUT_DIR));
   },
 };

--- a/packages/config/tsup.config.js
+++ b/packages/config/tsup.config.js
@@ -1,3 +1,6 @@
+const path = require('node:path');
+const { rewriteMjsImportsInDist } = require('./rewrite-esm-imports');
+
 /** @type {import('tsup').Options} */
 module.exports = {
   dts: true,
@@ -10,4 +13,7 @@ module.exports = {
   outDir: 'dist',
   entry: ['src/**/*.ts', '!src/**/*.spec.ts'],
   format: ['cjs', 'esm'],
+  async onSuccess() {
+    rewriteMjsImportsInDist(path.join(process.cwd(), 'dist'));
+  },
 };


### PR DESCRIPTION
This PR addresses [bug 542](https://github.com/microsoft/teams.ts/issues/542). by adding an onSuccess handler to the tsup.config.js to rewrite .mjs import paths to be compliant with the ESM specification.

Webpack 5 strictly requires that ESM code follows specification and includes a file extension on import paths. Other bundlers - Webpack 4, RSPack, Vite/Rollup - are more forgiving, but benefit from code following specification.

Tsup that we're using in these libraries doesn't automatically produce compliant import statements, but we can take care of that with an onSuccess handler to call a script and update the import paths. This was already done for the graph-endpoints package that doesn't use tsup at all, and makes sense to do for the tsupped code also.

Before the change in this PR, a React app using these libraries and relying on Webpack 5 would fail during build with e.g.:

```
building with released bits, webpack 5:
WARNING in ./src/Tab/App.tsx 35:28-41
export 'ConsoleLogger' (imported as 'ConsoleLogger') was not found in '@microsoft/teams.common' (module has no exports)
 @ ./src/Tab/client.tsx 4:0-24 5:85-88

ERROR in ./node_modules/@microsoft/teams.client/dist/index.mjs 1:0-28
Module not found: Error: Can't resolve './app' in 'C:\git\TeamsApps\webpack5app\node_modules\@microsoft\teams.client\dist'
Did you mean 'app.js'?
BREAKING CHANGE: The request './app' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
 @ ./src/Tab/App.tsx 4:0-64 34:35-49
 @ ./src/Tab/client.tsx 4:0-24 5:85-88
```

Before the change, after building these libraries, import paths in .e.g packages/common/dist/index.mjs would look like:
```
export * from './events';
export * from './http';
export * from './logging';
export * from './storage';
```
After, they're correctly
```
export * from './events/index.mjs';
export * from './http/index.mjs';
export * from './logging/index.mjs';
export * from './storage/index.mjs';
```

Similarly, before the change, packages/common/dist/http/client.mjs contained:
```
import { ConsoleLogger } from '../logging';
```
And now it's correctly:
```
import { ConsoleLogger } from '../logging/index.mjs';
```

How tested:
 - Built from the project root as well as within an individual package and verified that the import paths are correctly rewritten in the dist folder.
 - Built on both Mac and WIndows and looked at the dist folder.
 - Set up a simple Teamss tab app using these libraries to use teams-js context / msal / graph.
 - Before the change: verified that I can build the app with vite/rollup, rspack, and webpack 4; but webpack 5 fails as above
 - After the change, verified that I can build using all four and that the app still runs
 - After the change, also verified that the app tree-shakes properly on all four. Vite gives best results; webpack 4 the worst, but they all do their level best
 
 

