### PR TITLE
Rename ReactionClient.remove() to delete()

### DIFF
--- a/examples/reactions/README.md
+++ b/examples/reactions/README.md
@@ -30,15 +30,17 @@ const client = new Client(serviceUrl);
 // Add a reaction
 await client.reactions.add(conversationId, activityId, 'like');
 
-// Remove a reaction
-await client.reactions.remove(conversationId, activityId, 'like');
+// Delete a reaction
+await client.reactions.delete(conversationId, activityId, 'like');
 ```
 
 ## Supported Reaction Types
 
 - `like` - 👍
 - `heart` - ❤️
-- `laugh` - 😂
-- `surprised` - 😮
-- `sad` - 😢
-- `angry` - 😠
+- `1f440_eyes` - 👀
+- `2705_whiteheavycheckmark` - ✅
+- `launch` - 🚀
+- `1f4cc_pushpin` - 📌
+
+The `MessageReactionType` parameter also accepts any string, so you can pass other reaction IDs from the Teams reactions reference.

--- a/examples/reactions/src/index.ts
+++ b/examples/reactions/src/index.ts
@@ -53,7 +53,7 @@ app.on('message', async ({ reply, activity, log, api }) => {
   if (removeMatch && api) {
     const reactionType = removeMatch[1] as ReactionParameter;
     try {
-      await api.reactions.remove(
+      await api.reactions.delete(
         activity.conversation.id,
         activity.id,
         reactionType

--- a/packages/api/src/activities/message/message-reaction.ts
+++ b/packages/api/src/activities/message/message-reaction.ts
@@ -75,7 +75,7 @@ export class MessageReactionActivity
 
   /**
    * Remove a message reaction.
-   * @deprecated Use the api.reactions.remove instead.
+   * @deprecated Use the api.reactions.delete instead.
    */
   removeReaction(reaction: MessageReaction) {
     if (!this.reactionsRemoved) {

--- a/packages/api/src/clients/reaction/reaction.spec.ts
+++ b/packages/api/src/clients/reaction/reaction.spec.ts
@@ -36,10 +36,10 @@ describe('ReactionClient', () => {
     expect(spy).toHaveBeenCalledWith('/v3/conversations/conv1/activities/act1/reactions/like');
   });
 
-  it('should remove reaction', async () => {
+  it('should delete reaction', async () => {
     const client = new ReactionClient('');
     const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
-    await client.remove('conv1', 'act1', 'like');
+    await client.delete('conv1', 'act1', 'like');
     expect(spy).toHaveBeenCalledWith('/v3/conversations/conv1/activities/act1/reactions/like');
   });
 
@@ -64,10 +64,10 @@ describe('ReactionClient', () => {
     expect(spy).toHaveBeenCalledWith('/v3/conversations/conv1/activities/act1/reactions/like');
   });
 
-  it('should URL-encode parameters in remove', async () => {
+  it('should URL-encode parameters in delete', async () => {
     const client = new ReactionClient('');
     const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
-    await client.remove('conv+1/test=', 'act+1/test=', 'heart');
+    await client.delete('conv+1/test=', 'act+1/test=', 'heart');
     expect(spy).toHaveBeenCalledWith('/v3/conversations/conv%2B1%2Ftest%3D/activities/act%2B1%2Ftest%3D/reactions/heart');
   });
 });

--- a/packages/api/src/clients/reaction/reaction.ts
+++ b/packages/api/src/clients/reaction/reaction.ts
@@ -53,12 +53,12 @@ export class ReactionClient {
   }
 
   /**
-   * Remove a reaction from a message.
+   * Delete a reaction from a message.
    *
    * @experimental This API is in preview and may change in the future.
    * Diagnostic: ExperimentalTeamsReactions
    */
-  async remove(conversationId: string, activityId: string, reactionType: MessageReactionType) {
+  async delete(conversationId: string, activityId: string, reactionType: MessageReactionType) {
     const res = await this.http.delete<void>(
       `${this.serviceUrl}/v3/conversations/${encodeURIComponent(conversationId)}/activities/${encodeURIComponent(activityId)}/reactions/${encodeURIComponent(reactionType)}`
     );


### PR DESCRIPTION
## Summary

Renames the experimental `ReactionClient.remove()` method to `delete()` to align with the equivalents in teams.py (`delete()`) and teams.net (`DeleteAsync()`). The cross-SDK naming inconsistency was the only divergence in the reactions API surface.

The `ReactionClient` class is annotated `@experimental("ExperimentalTeamsReactions")`. This rename is within the breaking-change contract for that diagnostic, so no back-compat alias is added.

## Changes

- `packages/api/src/clients/reaction/reaction.ts` — method rename + JSDoc
- `packages/api/src/clients/reaction/reaction.spec.ts` — updated test names and call sites
- `packages/api/src/activities/message/message-reaction.ts` — `@deprecated` JSDoc on the activity helper now points to `api.reactions.delete`
- `examples/reactions/src/index.ts` — usage updated
- `examples/reactions/README.md` — usage updated, plus refreshed the reaction-types list that was still showing legacy Bot Framework types (`laugh`, `surprised`, `sad`, `angry`) instead of the modern Teams set the SDK actually exports

## Test plan

- [x] `npx turbo test --filter=@microsoft/teams.api` passes (17/17 suites, 145/145 tests; reaction.ts at 100% coverage)
- [x] Smoke-run the reactions example bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)