### PR TITLE
fix(api): Activity.timestamp should be string instead of Date (type only)

### DIFF
--- a/packages/api/src/activities/activity.spec.ts
+++ b/packages/api/src/activities/activity.spec.ts
@@ -35,8 +35,8 @@ describe('Activity', () => {
       })
       .withRecipient(bot)
       .withServiceUrl('http://localhost')
-      .withTimestamp(new Date())
-      .withLocalTimestamp(new Date());
+      .withTimestamp(new Date('2026-06-04T21:00:00.000Z'))
+      .withLocalTimestamp('2026-06-04T14:00:00.000-07:00');
 
     expect(activity.id).toEqual('1');
     expect(activity.type).toEqual('test');
@@ -52,8 +52,22 @@ describe('Activity', () => {
 
     expect(activity.recipient).toEqual(bot);
     expect(activity.serviceUrl).toEqual('http://localhost');
-    expect(activity.timestamp).toBeDefined();
-    expect(activity.localTimestamp).toBeDefined();
+    expect(activity.timestamp).toEqual('2026-06-04T21:00:00.000Z');
+    expect(activity.localTimestamp).toEqual('2026-06-04T14:00:00.000-07:00');
+  });
+
+  it('should preserve timestamp strings from constructor data', () => {
+    const timestamp = '2026-06-04T21:00:00.000Z';
+    const localTimestamp = '2026-06-04T14:00:00.000-07:00';
+
+    const activity = new Activity({
+      type: 'test',
+      timestamp,
+      localTimestamp,
+    });
+
+    expect(activity.timestamp).toEqual(timestamp);
+    expect(activity.localTimestamp).toEqual(localTimestamp);
   });
 
   it('should build from interface', () => {

--- a/packages/api/src/activities/activity.ts
+++ b/packages/api/src/activities/activity.ts
@@ -629,7 +629,7 @@ export class Activity<T extends string = string> implements IActivity<T> {
   /**
    * Sets the activity timestamp as an ISO-8601 string.
    *
-   * @deprecated Timestamps set on outgoing activities are ignored.
+   * @deprecated  Use ActivityInput/MessageActivityInput/TypingActivityInput when constructing outbound activities.
    */
   withTimestamp(value: Date | string) {
     this.timestamp = value instanceof Date ? value.toISOString() : value;
@@ -644,7 +644,7 @@ export class Activity<T extends string = string> implements IActivity<T> {
   /**
    * Sets the activity's local timestamp as an ISO-8601 string.
    *
-   * @deprecated Local timestamps set on outgoing activities are ignored.
+   * @deprecated Use ActivityInput/MessageActivityInput/TypingActivityInput when constructing outbound activities.
    */
   withLocalTimestamp(value: Date | string) {
     this.localTimestamp = value instanceof Date ? value.toISOString() : value;

--- a/packages/api/src/activities/activity.ts
+++ b/packages/api/src/activities/activity.ts
@@ -34,7 +34,7 @@ export interface IActivity<T extends string = string> {
   /**
    * Contains the date and time that the message was sent, in UTC, expressed in ISO-8601 format.
    */
-  timestamp?: Date;
+  timestamp?: string;
 
   /**
    * A locale name for the contents of the text field.
@@ -50,7 +50,7 @@ export interface IActivity<T extends string = string> {
    *
    * For example, 2016-09-23T13:07:49.4714686-07:00.
    */
-  localTimestamp?: Date;
+  localTimestamp?: string;
 
   /**
    * Contains an ID that uniquely identifies the channel. Set by the channel.
@@ -460,7 +460,7 @@ export class Activity<T extends string = string> implements IActivity<T> {
   /**
    * Contains the date and time that the message was sent, in UTC, expressed in ISO-8601 format.
    */
-  timestamp?: Date;
+  timestamp?: string;
 
   /**
    * A locale name for the contents of the text field.
@@ -476,7 +476,7 @@ export class Activity<T extends string = string> implements IActivity<T> {
    *
    * For example, 2016-09-23T13:07:49.4714686-07:00.
    */
-  localTimestamp?: Date;
+  localTimestamp?: string;
 
   /**
    * Contains an ID that uniquely identifies the channel. Set by the channel.
@@ -626,8 +626,13 @@ export class Activity<T extends string = string> implements IActivity<T> {
     return this;
   }
 
-  withTimestamp(value: Date) {
-    this.timestamp = value;
+  /**
+   * Sets the activity timestamp as an ISO-8601 string.
+   *
+   * @deprecated Timestamps set on outgoing activities are ignored.
+   */
+  withTimestamp(value: Date | string) {
+    this.timestamp = value instanceof Date ? value.toISOString() : value;
     return this;
   }
 
@@ -636,8 +641,13 @@ export class Activity<T extends string = string> implements IActivity<T> {
     return this;
   }
 
-  withLocalTimestamp(value: Date) {
-    this.localTimestamp = value;
+  /**
+   * Sets the activity's local timestamp as an ISO-8601 string.
+   *
+   * @deprecated Local timestamps set on outgoing activities are ignored.
+   */
+  withLocalTimestamp(value: Date | string) {
+    this.localTimestamp = value instanceof Date ? value.toISOString() : value;
     return this;
   }
 

--- a/packages/api/src/activities/event/agent-lifecycle.spec.ts
+++ b/packages/api/src/activities/event/agent-lifecycle.spec.ts
@@ -15,7 +15,7 @@ const BLUEPRINT_ID = '00000000-0000-0000-0000-000000000005';
 const baseActivity = {
   type: 'event',
   id: 'activity-id',
-  timestamp: new Date('2026-06-29T00:00:00Z'),
+  timestamp: '2026-06-29T00:00:00Z',
   serviceUrl: 'https://smba.trafficmanager.net/amer/tenant/',
   channelId: 'agents',
   from: { id: 'system', name: 'System', role: 'bot', tenantId: TENANT_ID },

--- a/packages/devtools/src/stores/ChatStore.ts
+++ b/packages/devtools/src/stores/ChatStore.ts
@@ -40,6 +40,10 @@ interface MessageBase {
   createdDateTime: string;
 }
 
+const toUTCString = (value?: string | Date) => {
+  return (value instanceof Date ? value : new Date(value || Date.now())).toUTCString();
+};
+
 const createMessageBase = (
   event: ActivityEvent<IMessageActivity | ITypingActivity>
 ): MessageBase => {
@@ -66,7 +70,7 @@ const createMessageBase = (
           }
         : undefined,
     },
-    createdDateTime: (event.body.timestamp || new Date()).toUTCString(),
+    createdDateTime: toUTCString(event.body.timestamp),
   };
 };
 
@@ -303,7 +307,7 @@ export const useChatStore = create<ChatStore>()(
           message.body.textContent = event.body.text;
         }
 
-        message.lastModifiedDateTime = (event.body.timestamp || new Date()).toUTCString();
+        message.lastModifiedDateTime = toUTCString(event.body.timestamp);
         state.put(state.chat.id, message);
         return state;
       },


### PR DESCRIPTION
`Activity.timestamp` was lying about being a `Date`. It's a string. Always was. The doc comment literally says "expressed in ISO-8601 format" two lines above the `: Date` annotation 🙃

Inbound activities go through `express.json()` (no reviver), and `Activity.from()` is just `Object.assign` — nothing ever turns it into a `Date`. So `activity.timestamp.toISOString()` in a handler? Crash.

Fix: type `timestamp` and `localTimestamp` as `string`.

Also removing `withTimestamp()` and `withLocalTimestamp()` because timestamps set on outgoing bot activities are ignored by the chat service, so those builder helpers were a bit of a footgun/no-op.
