### PR TITLE
Fix App user-agent merging

### DIFF
--- a/packages/apps/src/app.spec.ts
+++ b/packages/apps/src/app.spec.ts
@@ -258,6 +258,28 @@ describe('App', () => {
     });
   });
 
+  describe('http client User-Agent', () => {
+    it('should merge App User-Agent with User-Agent from client options', async () => {
+      const app = new App({
+        httpServerAdapter: new TestAdapter(),
+        client: {
+          headers: {
+            'user-agent': 'MyApp/1.0',
+          },
+        },
+      });
+      const spy = jest.spyOn((app.client as any).http, 'get').mockResolvedValueOnce({});
+
+      await app.client.get('/test');
+
+      expect(spy).toHaveBeenCalledWith('/test', {
+        headers: {
+          'User-Agent': expect.stringMatching(/^teams\.ts\[apps\]\/.* MyApp\/1\.0$/),
+        },
+      });
+    });
+  });
+
   describe('service URL configuration', () => {
     const originalEnv = process.env.SERVICE_URL;
 

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -305,10 +305,8 @@ export class App<TPlugin extends IPlugin = IPlugin> {
         },
       });
     } else {
-      this.client = new HttpClient({
-        ...options.client,
+      this.client = new HttpClient(options.client).clone({
         headers: {
-          ...options.client.headers,
           'User-Agent': this._userAgent,
         },
       });


### PR DESCRIPTION
## Summary
- Fix App client option handling so custom `User-Agent` values get merged instead of stomped.
- Add a regression test for lowercase `user-agent` 

## Test plan
- UTs