### PR TITLE
Mark reactions API as GA and fix sample remove flow

### DIFF
--- a/examples/reactions/src/index.ts
+++ b/examples/reactions/src/index.ts
@@ -23,7 +23,7 @@ app.on('message', async ({ reply, activity, log, api }) => {
         'I demonstrate how to use the ReactionClient API!\n\n' +
         '**Commands:**\n' +
         '- Type "add [reaction]" - I\'ll add that reaction to your message\n' +
-        '- Type "remove [reaction]" - I\'ll remove a reaction from your message\n' +
+        '- Type "remove [reaction]" - I\'ll add that reaction and then remove it 2s later\n' +
         '- Add any reaction to my messages and I\'ll tell you about it!',
     });
     return;
@@ -48,21 +48,29 @@ app.on('message', async ({ reply, activity, log, api }) => {
     return;
   }
 
-  // Handle commands to remove reactions
+  // Handle commands to remove reactions. To make this demo-able on an
+  // incoming message that doesn't already carry the reaction, we add it
+  // first, then delete it after a short delay so the user sees the cycle.
   const removeMatch = userMessage.match(/remove\s+(\S+)/);
   if (removeMatch && api) {
     const reactionType = removeMatch[1] as ReactionParameter;
     try {
+      await api.reactions.add(
+        activity.conversation.id,
+        activity.id,
+        reactionType
+      );
+      await reply(`Added a ${reactionType} reaction, removing in 2s...`);
+      await new Promise((resolve) => setTimeout(resolve, 2000));
       await api.reactions.delete(
         activity.conversation.id,
         activity.id,
         reactionType
       );
-      await reply(`Removed the ${reactionType} reaction from your message!`);
-      log.info(`Removed ${reactionType} reaction from message ${activity.id}`);
+      log.info(`Cycled ${reactionType} reaction on message ${activity.id}`);
     } catch (error) {
-      log.error('Failed to remove reaction:', error);
-      await reply('Sorry, I had trouble removing that reaction.');
+      log.error('Failed to cycle reaction:', error);
+      await reply('Sorry, I had trouble cycling that reaction.');
     }
     return;
   }

--- a/packages/api/src/clients/index.ts
+++ b/packages/api/src/clients/index.ts
@@ -20,10 +20,6 @@ export class Client {
   readonly conversations: ConversationClient;
   readonly teams: TeamClient;
   readonly meetings: MeetingClient;
-  /**
-   * @experimental This API is in preview and may change in the future.
-   * Diagnostic: ExperimentalTeamsReactions
-   */
   readonly reactions: ReactionClient;
 
   get http() {

--- a/packages/api/src/clients/reaction/reaction.ts
+++ b/packages/api/src/clients/reaction/reaction.ts
@@ -9,9 +9,6 @@ import { ApiClientSettings, mergeApiClientSettings } from '../api-client-setting
 
 /**
  * Client for adding and removing emoji reactions on messages in a conversation.
- *
- * @experimental This API is in preview and may change in the future.
- * Diagnostic: ExperimentalTeamsReactions
  */
 export class ReactionClient {
   readonly serviceUrl: string;
@@ -41,9 +38,6 @@ export class ReactionClient {
 
   /**
    * Add a reaction to a message.
-   *
-   * @experimental This API is in preview and may change in the future.
-   * Diagnostic: ExperimentalTeamsReactions
    */
   async add(conversationId: string, activityId: string, reactionType: MessageReactionType) {
     const res = await this.http.put<void>(
@@ -54,9 +48,6 @@ export class ReactionClient {
 
   /**
    * Delete a reaction from a message.
-   *
-   * @experimental This API is in preview and may change in the future.
-   * Diagnostic: ExperimentalTeamsReactions
    */
   async delete(conversationId: string, activityId: string, reactionType: MessageReactionType) {
     const res = await this.http.delete<void>(

--- a/packages/api/src/models/message/message-reaction.ts
+++ b/packages/api/src/models/message/message-reaction.ts
@@ -3,18 +3,12 @@ import { MessageUser } from './message-user';
 /**
  * The type of emoji reaction that can be applied to a message.
  * Possible values include: 'like', 'heart', '1f440_eyes', '2705_whiteheavycheckmark', 'launch', '1f4cc_pushpin'
- *
- * @experimental This API is in preview and may change in the future.
- * Diagnostic: ExperimentalTeamsReactions
  */
 export type MessageReactionType = 'like' | 'heart' | '1f440_eyes' | '2705_whiteheavycheckmark' | 'launch' | '1f4cc_pushpin' | (string & {});
 
 
 /**
  * Represents a reaction on a message, including the reaction type, timestamp, and user.
- *
- * @experimental This API is in preview and may change in the future.
- * Diagnostic: ExperimentalTeamsReactions
  */
 export type MessageReaction = {
   /** The emoji reaction type applied to the message. */


### PR DESCRIPTION
## Summary

Removes the `@experimental` JSDoc tags from `ReactionClient`, `MessageReactionType`, `MessageReaction`, and the `reactions` property on `ApiClient`. The reactions feature is in sync across all three SDKs and the Teams service — no longer preview.

Also fixes the sample's `remove` command, which previously called `api.reactions.delete()` on an incoming message that had no reaction. It now adds the reaction first, waits 2 seconds, then deletes — so the demo visibly shows the full add/delete cycle.

## Cross-SDK coordination

Part of the cross-SDK Reactions-GA pass. Sibling PRs:
- microsoft/teams.py — Mark reactions API as GA
- microsoft/teams.net — Mark reactions API as GA (Libraries + core)
- microsoft/teams-sdk — drop .NET opt-in tip from the reactions guide

## Test plan

- [x] `npm run lint` — 34/34 packages clean
- [x] `npm run build` — 35/35 packages succeed
- [x] `npm run test` — 746/746 tests pass across 61 suites (api at 149/149)
- [ ] Smoke run of `examples/reactions` showing the cycle in Teams

## Versioning

No `version.json` change in this PR. Bump happens as part of the release flow per RELEASE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)