### PR TITLE
Release 2.0.11: include main, exclude quoted replies

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
       - name: Lint
         run: npm run lint
       - name: Build

--- a/examples/botbuilder/src/index.ts
+++ b/examples/botbuilder/src/index.ts
@@ -2,7 +2,7 @@ import { TeamsActivityHandler } from 'botbuilder';
 
 import { App } from '@microsoft/teams.apps';
 import { BotBuilderPlugin } from '@microsoft/teams.botbuilder';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 export class ActivityHandler extends TeamsActivityHandler {

--- a/examples/echo/src/index.ts
+++ b/examples/echo/src/index.ts
@@ -1,6 +1,6 @@
 import { MessageActivity } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 import { MockReminderService } from './mock-reminder-service';

--- a/examples/graph/src/index.ts
+++ b/examples/graph/src/index.ts
@@ -1,5 +1,5 @@
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import * as endpoints from '@microsoft/teams.graph-endpoints';
 
 const app = new App({
@@ -10,7 +10,7 @@ const app = new App({
      */
     defaultConnectionName: 'graph'
   },
-  // Instead of setting in ConsoleLogger like below, you can also 
+  // Instead of setting in ConsoleLogger like below, you can also
   // set LOG_LEVEL=debug or LOG_LEVEL=trace env var for verbose SDK logging
   logger: new ConsoleLogger('@tests/auth', { level: 'debug' }),
     // This is an example of overriding the token URL for a specific region (e.g., Europe).

--- a/examples/http-adapters/package.json
+++ b/examples/http-adapters/package.json
@@ -18,7 +18,7 @@
     "@microsoft/teams.common": "*",
     "cors": "^2.8.5",
     "express": "^5.0.0",
-    "hono": "^4.12.14",
+    "hono": "^4.12.16",
     "restify": "^11.1.0"
   },
   "devDependencies": {

--- a/examples/lights/src/index.ts
+++ b/examples/lights/src/index.ts
@@ -2,8 +2,7 @@ import '@azure/openai/types';
 import { ChatPrompt, Message } from '@microsoft/teams.ai';
 import { MessageActivity } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
-import { LocalStorage } from '@microsoft/teams.common/storage';
+import { ConsoleLogger, LocalStorage } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 import { OpenAIChatModel } from '@microsoft/teams.openai';
 

--- a/examples/mcp-server/src/app.ts
+++ b/examples/mcp-server/src/app.ts
@@ -2,7 +2,7 @@ import express from 'express';
 
 import { AdaptiveCardActionMessageResponse } from '@microsoft/teams.api';
 import { App, ExpressAdapter } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 
 import { state } from './state';
 

--- a/examples/meetings/src/index.ts
+++ b/examples/meetings/src/index.ts
@@ -1,6 +1,6 @@
 import { App } from '@microsoft/teams.apps';
 import { AdaptiveCard, TextBlock, OpenUrlAction, ActionSet } from '@microsoft/teams.cards';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 
 const app = new App({
   logger: new ConsoleLogger('@examples/meetings', { level: 'debug' })

--- a/examples/message-extensions/src/index.ts
+++ b/examples/message-extensions/src/index.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { cardAttachment } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
 import { IAdaptiveCard } from '@microsoft/teams.cards';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 import {

--- a/examples/proactive-messaging/src/index.ts
+++ b/examples/proactive-messaging/src/index.ts
@@ -7,7 +7,7 @@
 
 import { App } from '@microsoft/teams.apps';
 import { ActionSet, AdaptiveCard, OpenUrlAction, TextBlock } from '@microsoft/teams.cards';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 
 async function sendProactiveMessage(app: App, conversationId: string, message: string) {
   console.log(`Sending proactive message to conversation: ${conversationId}`);

--- a/examples/reactions/README.md
+++ b/examples/reactions/README.md
@@ -30,15 +30,17 @@ const client = new Client(serviceUrl);
 // Add a reaction
 await client.reactions.add(conversationId, activityId, 'like');
 
-// Remove a reaction
-await client.reactions.remove(conversationId, activityId, 'like');
+// Delete a reaction
+await client.reactions.delete(conversationId, activityId, 'like');
 ```
 
 ## Supported Reaction Types
 
 - `like` - 👍
 - `heart` - ❤️
-- `laugh` - 😂
-- `surprised` - 😮
-- `sad` - 😢
-- `angry` - 😠
+- `1f440_eyes` - 👀
+- `2705_whiteheavycheckmark` - ✅
+- `launch` - 🚀
+- `1f4cc_pushpin` - 📌
+
+The `MessageReactionType` parameter also accepts any string, so you can pass other reaction IDs from the Teams reactions reference.

--- a/examples/reactions/src/index.ts
+++ b/examples/reactions/src/index.ts
@@ -1,6 +1,6 @@
 import { Client, MessageReactionActivity } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 
 const app = new App({
   logger: new ConsoleLogger('@examples/reactions', { level: 'debug' })
@@ -23,7 +23,7 @@ app.on('message', async ({ reply, activity, log, api }) => {
         'I demonstrate how to use the ReactionClient API!\n\n' +
         '**Commands:**\n' +
         '- Type "add [reaction]" - I\'ll add that reaction to your message\n' +
-        '- Type "remove [reaction]" - I\'ll remove a reaction from your message\n' +
+        '- Type "remove [reaction]" - I\'ll add that reaction and then remove it 2s later\n' +
         '- Add any reaction to my messages and I\'ll tell you about it!',
     });
     return;
@@ -48,21 +48,29 @@ app.on('message', async ({ reply, activity, log, api }) => {
     return;
   }
 
-  // Handle commands to remove reactions
+  // Handle commands to remove reactions. To make this demo-able on an
+  // incoming message that doesn't already carry the reaction, we add it
+  // first, then delete it after a short delay so the user sees the cycle.
   const removeMatch = userMessage.match(/remove\s+(\S+)/);
   if (removeMatch && api) {
     const reactionType = removeMatch[1] as ReactionParameter;
     try {
-      await api.reactions.remove(
+      await api.reactions.add(
         activity.conversation.id,
         activity.id,
         reactionType
       );
-      await reply(`Removed the ${reactionType} reaction from your message!`);
-      log.info(`Removed ${reactionType} reaction from message ${activity.id}`);
+      await reply(`Added a ${reactionType} reaction, removing in 2s...`);
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await api.reactions.delete(
+        activity.conversation.id,
+        activity.id,
+        reactionType
+      );
+      log.info(`Cycled ${reactionType} reaction on message ${activity.id}`);
     } catch (error) {
-      log.error('Failed to remove reaction:', error);
-      await reply('Sorry, I had trouble removing that reaction.');
+      log.error('Failed to cycle reaction:', error);
+      await reply('Sorry, I had trouble cycling that reaction.');
     }
     return;
   }

--- a/examples/tab/src/index.ts
+++ b/examples/tab/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 const app = new App({

--- a/examples/targeted-messages/src/index.ts
+++ b/examples/targeted-messages/src/index.ts
@@ -1,6 +1,6 @@
 import { MessageActivity } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 const app = new App({
@@ -8,118 +8,66 @@ const app = new App({
   plugins: [new DevtoolsPlugin()],
 });
 
-app.on('message', async ({ send, reply, activity, api }) => {
-  await reply({ type: 'typing' });
-  
+app.on('message', async ({ send, activity, api }) => {
   const text = activity.text?.toLowerCase() || '';
 
-  // ============================================
-  // Test targeted SEND (create)
-  // ============================================
-  if (text.includes('test send')) {
-    const targetedMessage = new MessageActivity(
-      '🔒 [SEND] Targeted message - only YOU can see this!'
-    ).withRecipient(activity.from, true);
-
-    const result = await send(targetedMessage);
-    console.log('Targeted SEND result:', result);
-    return;
-  }
-
-  // ============================================
-  // Test targeted REPLY
-  // ============================================
-  if (text.includes('test reply')) {
-    const targetedReply = new MessageActivity(
-      '🔒 [REPLY] Targeted reply - only YOU can see this!'
-    ).withRecipient(activity.from, true);
-
-    const result = await reply(targetedReply);
-    console.log('Targeted REPLY result:', result);
-    return;
-  }
-
-  // ============================================
-  // Test targeted UPDATE
-  // ============================================
   if (text.includes('test update')) {
-    // First send a targeted message
-    const targetedMessage = new MessageActivity(
-      '🔒 [UPDATE] Original targeted message...'
-    ).withRecipient(activity.from, true);
+    const conversationId = activity.conversation?.id ?? '';
+    const result = await send(
+      new MessageActivity('📝 This message will be **updated** in 3 seconds...')
+        .withRecipient(activity.from, true)
+    );
 
-    const result = await send(targetedMessage);
-    console.log('Initial targeted message ID:', result.id);
-
-    // Wait then update
     setTimeout(async () => {
       try {
         const updatedMessage = new MessageActivity(
-          '🔒 [UPDATE] ✅ UPDATED targeted message! (only you see this)'
+          `✏️ **Updated!** This message was modified at ${new Date().toISOString().slice(11, 19)}`
         );
-
         await api.conversations
-          .activities(activity.conversation.id)
+          .activities(conversationId)
           .updateTargeted(result.id, updatedMessage);
-        console.log('Targeted UPDATE completed');
       } catch (err: any) {
-        console.error('Targeted UPDATE error:', err?.response?.data || err?.message || err);
+        console.error('[UPDATE] Error:', err?.message || err);
       }
     }, 3000);
-    return;
-  }
+  } else if (text.includes('test delete')) {
+    const conversationId = activity.conversation?.id ?? '';
+    const result = await send(
+      new MessageActivity('🗑️ This message will be **deleted** in 3 seconds...')
+        .withRecipient(activity.from, true)
+    );
 
-  // ============================================
-  // Test targeted DELETE
-  // ============================================
-  if (text.includes('test delete')) {
-    // First send a targeted message
-    const targetedMessage = new MessageActivity(
-      '🔒 [DELETE] This targeted message will be DELETED in 5 seconds...'
-    ).withRecipient(activity.from, true);
-
-    const result = await send(targetedMessage);
-    console.log('Targeted message to delete, ID:', result.id);
-
-    // Wait then delete using the targeted API
     setTimeout(async () => {
       try {
         await api.conversations
-          .activities(activity.conversation.id)
+          .activities(conversationId)
           .deleteTargeted(result.id);
-        console.log('Targeted DELETE completed');
       } catch (err: any) {
-        console.error('Targeted DELETE error:', err?.response?.data || err?.message || err);
+        console.error('[DELETE] Error:', err?.message || err);
       }
-    }, 5000);
-    return;
-  }
-
-  // ============================================
-  // Help / Default
-  // ============================================
-  if (text.includes('help')) {
-    await reply(
-      '**Targeted Messages Test Bot**\n\n' +
-      '**Commands:**\n' +
-      '- `test send` - Send a targeted message\n' +
-      '- `test reply` - Reply with a targeted message\n' +
-      '- `test update` - Send then update a targeted message\n' +
-      '- `test delete` - Send then delete a targeted message\n\n' +
-      '💡 *Test in a group chat to verify others don\'t see targeted messages!*'
+    }, 3000);
+  } else if (text.includes('test public')) {
+    await send(
+      new MessageActivity('📋 Here is the public result — everyone can see this!')
     );
-    return;
+  } else if (text.includes('test send')) {
+    await send(
+      new MessageActivity('👋 This is a **targeted message** — only YOU can see this!')
+        .withRecipient(activity.from, true)
+    );
+  } else if (text.includes('help')) {
+    await send(
+      '**🎯 Targeted Messages Demo**\n\n' +
+      '**Commands:**\n' +
+      '- `test send` - Send a targeted message (only visible to you)\n' +
+      '- `test update` - Send a targeted message, then update it after 3 seconds\n' +
+      '- `test delete` - Send a targeted message, then delete it after 3 seconds\n' +
+      '- `test public` - Send a public reply (visible to all)\n\n' +
+      '_Targeted messages are only visible to you, even in group chats!_'
+    );
+  } else {
+    await send(`You said: '${activity.text}'\n\nType \`help\` to see available commands.`);
   }
-
-  // Default
-  await reply('Say "help" for available commands.');
-});
-
-app.on('install.add', async ({ send }) => {
-  await send(
-    '👋 Hi! I demonstrate targeted messages.\n\n' +
-    'Say **help** to see available commands.'
-  );
 });
 
 app.start().catch(console.error);

--- a/examples/threading/src/index.ts
+++ b/examples/threading/src/index.ts
@@ -1,5 +1,5 @@
 import { App, toThreadedConversationId } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 const app = new App({

--- a/external/mcp/src/plugin.spec.ts
+++ b/external/mcp/src/plugin.spec.ts
@@ -1,10 +1,35 @@
-import { McpPlugin } from './plugin';
+import express from 'express';
 
-// Test subclass to access protected method
+import { McpPlugin, McpPluginOptions } from './plugin';
+
+// Test subclass to access protected methods
 class TestMcpPlugin extends McpPlugin {
   public testIsCallToolResult(value: any): boolean {
     return this.isCallToolResult(value);
   }
+
+  public testCheckAuth(req: express.Request, res: express.Response): Promise<boolean> {
+    return this.checkAuth(req, res);
+  }
+}
+
+function mockRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  res.set = jest.fn().mockReturnValue(res);
+  return res as express.Response;
+}
+
+function mockReq(): express.Request {
+  return {} as express.Request;
+}
+
+function makePlugin(options?: McpPluginOptions): TestMcpPlugin {
+  const plugin = new TestMcpPlugin(options);
+  // Stub the logger dependency normally injected by @Logger()
+  (plugin as any).logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  return plugin;
 }
 
 describe('McpPlugin', () => {
@@ -74,6 +99,65 @@ describe('McpPlugin', () => {
         content: 'not an array',
       };
       expect(plugin.testIsCallToolResult(result)).toBe(false);
+    });
+  });
+
+  describe('checkAuth', () => {
+    it('allows the request when requireAuth is not configured', async () => {
+      const plugin = makePlugin();
+      const res = mockRes();
+      const ok = await plugin.testCheckAuth(mockReq(), res);
+      expect(ok).toBe(true);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('allows the request when requireAuth returns true', async () => {
+      const plugin = makePlugin({ requireAuth: () => true });
+      const res = mockRes();
+      const ok = await plugin.testCheckAuth(mockReq(), res);
+      expect(ok).toBe(true);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('allows the request when requireAuth resolves true', async () => {
+      const plugin = makePlugin({ requireAuth: async () => true });
+      const res = mockRes();
+      const ok = await plugin.testCheckAuth(mockReq(), res);
+      expect(ok).toBe(true);
+    });
+
+    it('rejects with 401 when requireAuth returns false', async () => {
+      const plugin = makePlugin({ requireAuth: () => false });
+      const res = mockRes();
+      const ok = await plugin.testCheckAuth(mockReq(), res);
+      expect(ok).toBe(false);
+      expect(res.set).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer');
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.send).toHaveBeenCalledWith('unauthorized');
+    });
+
+    it('rejects with 401 when requireAuth throws', async () => {
+      const plugin = makePlugin({
+        requireAuth: () => {
+          throw new Error('bad token');
+        },
+      });
+      const res = mockRes();
+      const ok = await plugin.testCheckAuth(mockReq(), res);
+      expect(ok).toBe(false);
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+
+    it('rejects with 401 when async requireAuth rejects', async () => {
+      const plugin = makePlugin({
+        requireAuth: async () => {
+          throw new Error('bad token');
+        },
+      });
+      const res = mockRes();
+      const ok = await plugin.testCheckAuth(mockReq(), res);
+      expect(ok).toBe(false);
+      expect(res.status).toHaveBeenCalledWith(401);
     });
   });
 });

--- a/external/mcp/src/plugin.ts
+++ b/external/mcp/src/plugin.ts
@@ -92,6 +92,14 @@ export type McpPluginOptions = ServerOptions & {
    * @default `http://localhost:5173`
    */
   readonly inspector?: string;
+
+  /**
+   * Gate inbound MCP requests behind an authentication check. Called once per
+   * request; return `true` to allow, `false` (or throw) to reject with 401.
+   * When unset, all requests are accepted and a warning is emitted at plugin
+   * startup.
+   */
+  readonly requireAuth?: (req: express.Request) => boolean | Promise<boolean>;
 };
 
 /**
@@ -122,6 +130,7 @@ export class McpPlugin implements IPlugin {
   protected transport: McpSSETransportOptions | McpStdioTransportOptions = {
     type: 'sse',
   };
+  protected requireAuth?: (req: express.Request) => boolean | Promise<boolean>;
 
   constructor(options: McpServer | McpPluginOptions = {}) {
     this.inspector =
@@ -139,8 +148,11 @@ export class McpPlugin implements IPlugin {
           options,
         );
 
-    if (!(options instanceof McpServer) && options.transport) {
-      this.transport = options.transport;
+    if (!(options instanceof McpServer)) {
+      if (options.transport) {
+        this.transport = options.transport;
+      }
+      this.requireAuth = options.requireAuth;
     }
   }
 
@@ -206,12 +218,33 @@ export class McpPlugin implements IPlugin {
 
   onStart({ port }: IPluginStartEvent) {
     if (this.transport.type === 'sse') {
+      if (!this.requireAuth) {
+        this.logger.warn(
+          `McpPlugin started without requireAuth. All MCP requests at ${this.transport.path || '/mcp'} will be accepted. Pass requireAuth in McpPluginOptions to enforce authentication.`
+        );
+      }
       this.logger.info(
         `listening at http://localhost:${port}${this.transport.path || '/mcp'}`,
       );
     } else {
       this.logger.info('listening on stdin');
     }
+  }
+
+  protected async checkAuth(
+    req: express.Request,
+    res: express.Response
+  ): Promise<boolean> {
+    if (!this.requireAuth) return true;
+    try {
+      const ok = await this.requireAuth(req);
+      if (ok) return true;
+    } catch (err) {
+      this.logger.debug('requireAuth threw:', err);
+    }
+    if (req.aborted) return false;
+    res.set('WWW-Authenticate', 'Bearer').status(401).send('unauthorized');
+    return false;
   }
 
   protected onInitStdio(options: McpStdioTransportOptions) {
@@ -229,6 +262,13 @@ export class McpPlugin implements IPlugin {
         'Please use: new App({ httpServerAdapter: new ExpressAdapter() })'
       );
     }
+
+    // Auth gate applied to the entire MCP path prefix so any current or future
+    // handler registered under this path is covered.
+    adapter.use(path, async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+      if (!(await this.checkAuth(req, res))) return;
+      next();
+    });
 
     // Register GET endpoint for SSE connections
     adapter.get(path, (_: express.Request, res: express.Response) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,7 +172,7 @@
         "@microsoft/teams.common": "*",
         "cors": "^2.8.5",
         "express": "^5.0.0",
-        "hono": "^4.12.14",
+        "hono": "^4.12.16",
         "restify": "^11.1.0"
       },
       "devDependencies": {
@@ -319,13 +319,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "examples/http-adapters/node_modules/hono": {
-      "version": "4.12.14",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
       }
     },
     "examples/http-adapters/node_modules/media-typer": {
@@ -2002,6 +1995,431 @@
     "node_modules/@emotion/hash": {
       "version": "0.9.2",
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.27.3",
@@ -9928,6 +10346,8 @@
     },
     "node_modules/env-cmd": {
       "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-11.0.0.tgz",
+      "integrity": "sha512-gnG7H1PlwPqsGhFJNTv68lsDGyQdK+U9DwLVitcj1+wGq7LeOBgUzZd2puZ710bHcH9NfNeGWe2sbw7pdvAqDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10135,6 +10555,431 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/escalade": {
@@ -11458,9 +12303,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.16",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
-      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -17850,10 +18695,80 @@
         "turbo-windows-arm64": "2.8.11"
       }
     },
+    "node_modules/turbo-darwin-64": {
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.8.11.tgz",
+      "integrity": "sha512-XKaCWaz4OCt77oYYvGCIRpvYD4c/aNaKjRkUpv+e8rN3RZb+5Xsyew4yRO+gaHdMIUhQznXNXfHlhs+/p7lIhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.8.11.tgz",
+      "integrity": "sha512-VvynLHGUNvQ9k7GZjRPSsRcK4VkioTfFb7O7liAk4nHKjEcMdls7GqxzjVWgJiKz3hWmQGaP9hRa9UUnhVWCxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.8.11.tgz",
+      "integrity": "sha512-cbSn37dcm+EmkQ7DD0euy7xV7o2el4GAOr1XujvkAyKjjNvQ+6QIUeDgQcwAx3D17zPpDvfDMJY2dLQadWnkmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.8.11.tgz",
+      "integrity": "sha512-+trymp2s2aBrhS04l6qFxcExzZ8ffndevuUB9c5RCeqsVpZeiWuGQlWNm5XjOmzoMayxRARZ5ma7yiWbGMiLqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/turbo-windows-64": {
       "version": "2.8.11",
       "cpu": [
         "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.8.11.tgz",
+      "integrity": "sha512-JOM4uF2vuLsJUvibdR6X9QqdZr6BhC6Nhlrw4LKFPsXZZI/9HHLoqAiYRpE4MuzIwldCH/jVySnWXrI1SKto0g==",
+      "cpu": [
+        "arm64"
       ],
       "dev": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "https://github.com/microsoft/teams.ts",
   "bugs": "https://github.com/microsoft/teams.ts/issues",
-  "packageManager": "npm@10.8.1",
+  "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=20"
   },

--- a/packages/ai/src/local-memory.spec.ts
+++ b/packages/ai/src/local-memory.spec.ts
@@ -1,0 +1,256 @@
+import { LocalMemory } from './local-memory';
+import { Message, ModelMessage } from './message';
+import { IChatModel } from './models';
+
+// Mock chat model for collapse tests
+const mockCollapseModel: IChatModel<any> = {
+  send: jest.fn().mockResolvedValue({
+    role: 'model',
+    content: 'Summarized conversation',
+  }),
+};
+
+describe('LocalMemory', () => {
+  let memory: LocalMemory;
+
+  beforeEach(() => {
+    memory = new LocalMemory();
+    jest.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should initialize with empty messages by default', () => {
+      expect(memory.length()).toBe(0);
+      expect(memory.values()).toEqual([]);
+    });
+
+    it('should initialize with provided messages', () => {
+      const messages: Message[] = [
+        { role: 'user', content: 'Hello' },
+        { role: 'model', content: 'Hi there' },
+      ];
+      const memoryWithMessages = new LocalMemory({ messages });
+      expect(memoryWithMessages.length()).toBe(2);
+    });
+  });
+
+  describe('get', () => {
+    it('should return message at valid index', async () => {
+      await memory.push({ role: 'user', content: 'Hello' });
+      expect(memory.get(0)).toEqual({ role: 'user', content: 'Hello' });
+    });
+
+    it('should return undefined for negative index', () => {
+      expect(memory.get(-1)).toBeUndefined();
+    });
+
+    it('should return undefined for out of bounds index', () => {
+      expect(memory.get(100)).toBeUndefined();
+    });
+
+    it('should return undefined for empty memory', () => {
+      expect(memory.get(0)).toBeUndefined();
+    });
+  });
+
+  describe('push', () => {
+    it('should add message to memory', async () => {
+      await memory.push({ role: 'user', content: 'Hello' });
+      expect(memory.length()).toBe(1);
+    });
+
+    it('should handle empty memory without crashing', async () => {
+      // This tests the fix for null role crash
+      const emptyMemory = new LocalMemory({ max: 1 });
+      
+      // Should not throw when pushing to empty memory
+      await expect(emptyMemory.push({ role: 'user', content: 'First' })).resolves.toBeUndefined();
+      expect(emptyMemory.length()).toBe(1);
+    });
+
+    it('should trim messages when exceeding max', async () => {
+      const smallMemory = new LocalMemory({ max: 2 });
+      
+      await smallMemory.push({ role: 'user', content: 'Message 1' });
+      await smallMemory.push({ role: 'model', content: 'Response 1' });
+      await smallMemory.push({ role: 'user', content: 'Message 2' });
+      
+      // Should have trimmed to max
+      expect(smallMemory.length()).toBeLessThanOrEqual(2);
+    });
+
+    it('should not crash when trimming removes all messages', async () => {
+      // Edge case: very small max with function messages
+      const tinyMemory = new LocalMemory({ max: 1 });
+      
+      const modelWithFunctionCalls: ModelMessage = {
+        role: 'model',
+        content: '',
+        function_calls: [{ id: '1', name: 'test', arguments: {} }],
+      };
+      
+      await tinyMemory.push(modelWithFunctionCalls);
+      // Push another message - should trigger trim logic
+      await expect(tinyMemory.push({ role: 'function', content: 'result', function_id: '1' })).resolves.toBeUndefined();
+    });
+  });
+
+  describe('pop', () => {
+    it('should remove and return first message', async () => {
+      await memory.push({ role: 'user', content: 'First' });
+      await memory.push({ role: 'user', content: 'Second' });
+      
+      const popped = memory.pop();
+      expect(popped).toEqual({ role: 'user', content: 'First' });
+      expect(memory.length()).toBe(1);
+    });
+
+    it('should return undefined for empty memory', () => {
+      expect(memory.pop()).toBeUndefined();
+    });
+  });
+
+  describe('values', () => {
+    it('should return a copy of messages array', async () => {
+      await memory.push({ role: 'user', content: 'Hello' });
+      const values = memory.values();
+      
+      // Modifying returned array should not affect memory
+      values.push({ role: 'user', content: 'Modified' });
+      expect(memory.length()).toBe(1);
+    });
+  });
+
+  describe('where', () => {
+    it('should filter messages by predicate', async () => {
+      await memory.push({ role: 'user', content: 'Hello' });
+      await memory.push({ role: 'model', content: 'Hi' });
+      await memory.push({ role: 'user', content: 'How are you?' });
+      
+      const userMessages = memory.where((msg) => msg.role === 'user');
+      expect(userMessages).toHaveLength(2);
+    });
+  });
+
+  describe('collapse', () => {
+    it('should not collapse without collapse option', async () => {
+      const memoryNoCollapse = new LocalMemory({ max: 5 });
+      
+      for (let i = 0; i < 5; i++) {
+        await memoryNoCollapse.push({ role: 'user', content: `Message ${i}` });
+      }
+      
+      // Collapse is not configured, so all messages should remain
+      expect(memoryNoCollapse.length()).toBe(5);
+    });
+
+    it('should collapse with model when configured', async () => {
+      const collapseMemory = new LocalMemory({
+        max: 3,
+        collapse: {
+          strategy: 'full',
+          model: mockCollapseModel,
+        },
+      });
+
+      // Add messages up to max
+      await collapseMemory.push({ role: 'user', content: 'Message 1' });
+      await collapseMemory.push({ role: 'model', content: 'Response 1' });
+      await collapseMemory.push({ role: 'user', content: 'Message 2' });
+
+      // This should trigger collapse
+      expect(mockCollapseModel.send).toHaveBeenCalled();
+    });
+
+    it('should handle collapse with empty messages safely', async () => {
+      const collapseMemory = new LocalMemory({
+        max: 2,
+        collapse: {
+          strategy: 'half',
+          model: mockCollapseModel,
+        },
+      });
+
+      // Should not crash when collapse is called with edge cases
+      await expect(collapseMemory.push({ role: 'user', content: 'Hello' })).resolves.toBeUndefined();
+    });
+
+    it('should skip function messages when finding collapse end boundary', async () => {
+      const collapseMemory = new LocalMemory({
+        max: 4,
+        collapse: {
+          strategy: 'half',
+          model: mockCollapseModel,
+        },
+      });
+
+      // Add messages including function calls
+      await collapseMemory.push({ role: 'user', content: 'Hello' });
+      await collapseMemory.push({
+        role: 'model',
+        content: '',
+        function_calls: [{ id: '1', name: 'test', arguments: {} }],
+      } as ModelMessage);
+      await collapseMemory.push({ role: 'function', content: 'result', function_id: '1' });
+      await collapseMemory.push({ role: 'model', content: 'Final response' });
+
+      // This tests that the collapse boundary detection works correctly
+      // and doesn't crash when iterating past function messages
+      expect(collapseMemory.length()).toBeGreaterThan(0);
+    });
+
+    it('should not crash when collapse end boundary exceeds array length', async () => {
+      // This is the specific bug fix test
+      const collapseMemory = new LocalMemory({
+        max: 2,
+        collapse: {
+          strategy: 'half',
+          model: mockCollapseModel,
+        },
+      });
+
+      // Create a scenario where the while loop in collapse could go out of bounds
+      const functionCallMessage: ModelMessage = {
+        role: 'model',
+        content: '',
+        function_calls: [{ id: '1', name: 'fn1', arguments: {} }],
+      };
+
+      await collapseMemory.push(functionCallMessage);
+      await collapseMemory.push({ role: 'function', content: 'result', function_id: '1' });
+
+      // The collapse should not crash even when trying to find a non-function message
+      // at the end of the array
+      await expect(
+        collapseMemory.push({ role: 'user', content: 'trigger collapse' })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('edge cases for null safety', () => {
+    it('should handle accessing messages[0] when array becomes empty during trim', async () => {
+      // This specifically tests the fix: len > 0 && check
+      const edgeMemory = new LocalMemory({ max: 1 });
+      
+      // Add a function message that will need to be trimmed
+      await edgeMemory.push({ role: 'function', content: 'orphan result', function_id: '0' });
+      
+      // Push another - the while loop should safely handle the empty check
+      await expect(
+        edgeMemory.push({ role: 'user', content: 'new message' })
+      ).resolves.toBeUndefined();
+    });
+
+    it('should use optional chaining for messages[0].role access', async () => {
+      // Test that we don't get "Cannot read property 'role' of undefined"
+      const testMemory = new LocalMemory({ max: 1 });
+      
+      // Simulate edge case by adding and immediately having to trim
+      await testMemory.push({ role: 'user', content: 'First' });
+      await testMemory.push({ role: 'user', content: 'Second' });
+      
+      // Should not throw
+      expect(testMemory.length()).toBeLessThanOrEqual(1);
+    });
+  });
+});

--- a/packages/ai/src/local-memory.ts
+++ b/packages/ai/src/local-memory.ts
@@ -45,9 +45,10 @@ export class LocalMemory implements IMemory {
     }
 
     while (
-      len > (this.options.max || 100) ||
-      (this.messages[0].role === 'model' && this.messages[0].function_calls?.length) ||
-      this.messages[0].role === 'function'
+      len > 0 &&
+      (len > (this.options.max || 100) ||
+      (this.messages[0]?.role === 'model' && this.messages[0]?.function_calls?.length) ||
+      this.messages[0]?.role === 'function')
     ) {
       const removed = this.pop();
 
@@ -87,8 +88,9 @@ export class LocalMemory implements IMemory {
 
     let last = this.messages[end];
 
-    while ((last.role === 'model' && last.function_calls?.length) || last.role === 'function') {
+    while (last && ((last.role === 'model' && last.function_calls?.length) || last.role === 'function')) {
       end++;
+      if (end >= this.messages.length) break;
       last = this.messages[end];
     }
 

--- a/packages/api/src/activities/activity.spec.ts
+++ b/packages/api/src/activities/activity.spec.ts
@@ -1,6 +1,7 @@
 import { Account, ConversationAccount } from '../models';
 
 import { Activity } from './activity';
+import { MessageActivity } from './message';
 
 describe('Activity', () => {
   const user: Account = {
@@ -239,6 +240,45 @@ describe('Activity', () => {
           ],
         },
       ]);
+    });
+  });
+
+  describe('addTargetedMessageInfo', () => {
+    it('should strip quotedReply entities', () => {
+      const activity = new MessageActivity('hello')
+        .addEntity({ type: 'quotedReply', quotedReply: { messageId: '123' } })
+        .addEntity({ type: 'mention', text: '<at>bot</at>', mentioned: bot })
+        .addTargetedMessageInfo('123');
+
+      expect(activity.entities).toEqual([
+        { type: 'mention', text: '<at>bot</at>', mentioned: bot },
+        { type: 'targetedMessageInfo', messageId: '123' },
+      ]);
+    });
+
+    it('should strip quoted placeholder from text', () => {
+      const activity = new MessageActivity('hello <quoted messageId="123"/>')
+        .addTargetedMessageInfo('123');
+
+      expect(activity.text).toEqual('hello');
+    });
+
+    it('should not add duplicate targetedMessageInfo', () => {
+      const activity = new MessageActivity('hello')
+        .addTargetedMessageInfo('123')
+        .addTargetedMessageInfo('456');
+
+      expect(activity.entities?.filter((e) => e.type === 'targetedMessageInfo')).toHaveLength(1);
+    });
+
+    it('should strip quotedReply even when targetedMessageInfo already present', () => {
+      const activity = new MessageActivity('hello')
+        .addTargetedMessageInfo('123')
+        .addEntity({ type: 'quotedReply', quotedReply: { messageId: '123' } })
+        .addTargetedMessageInfo('123');
+
+      expect(activity.entities?.some((e) => e.type === 'quotedReply')).toBe(false);
+      expect(activity.entities?.filter((e) => e.type === 'targetedMessageInfo')).toHaveLength(1);
     });
   });
 });

--- a/packages/api/src/activities/activity.ts
+++ b/packages/api/src/activities/activity.ts
@@ -426,6 +426,41 @@ export class Activity<T extends string = string> implements IActivity<T> {
   }
 
   /**
+   * Add a targeted message info entity for prompt preview.
+   * Skips if already present. In reactive flows, `ctx.send()` and `ctx.reply()`
+   * populate this automatically — use this helper for proactive or deferred sends.
+   * An invalid or expired messageId causes APX to silently drop the preview
+   * while still delivering the message.
+   *
+   * @param messageId the message ID of the targeted message (from the incoming activity's `id`)
+   *
+   * @experimental This API is in preview and may change in the future.
+   * Diagnostic: ExperimentalTeamsTargeted
+   */
+  addTargetedMessageInfo(messageId: string) {
+    if (this.entities) {
+      this.entities = this.entities.filter((e) => e.type !== 'quotedReply');
+    }
+
+    if (this.type === 'message') {
+      const msg = this as unknown as { text?: string };
+
+      if (msg.text) {
+        msg.text = msg.text.replace(`<quoted messageId="${messageId}"/>`, '').trim();
+      }
+    }
+
+    if (this.entities?.some((e) => e.type === 'targetedMessageInfo')) {
+      return this;
+    }
+
+    return this.addEntity({
+      type: 'targetedMessageInfo',
+      messageId,
+    });
+  }
+
+  /**
    * is this a streaming activity
    */
   isStreaming() {

--- a/packages/api/src/activities/message/message-reaction.ts
+++ b/packages/api/src/activities/message/message-reaction.ts
@@ -75,7 +75,7 @@ export class MessageReactionActivity
 
   /**
    * Remove a message reaction.
-   * @deprecated Use the api.reactions.remove instead.
+   * @deprecated Use the api.reactions.delete instead.
    */
   removeReaction(reaction: MessageReaction) {
     if (!this.reactionsRemoved) {

--- a/packages/api/src/clients/bot/index.ts
+++ b/packages/api/src/clients/bot/index.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
 
@@ -14,16 +17,16 @@ export class BotClient {
     this.signIn.http = v;
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _clientSettings: Partial<ApiClientSettings>;
 
-  constructor(options?: Client | ClientOptions, clientSettings?: Partial<ApiClientSettings>) {
+  constructor(options?: HttpClient | HttpClientOptions, clientSettings?: Partial<ApiClientSettings>) {
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._clientSettings = mergeApiClientSettings(clientSettings);

--- a/packages/api/src/clients/bot/sign-in.spec.ts
+++ b/packages/api/src/clients/bot/sign-in.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { BotSignInClient } from './sign-in';
 

--- a/packages/api/src/clients/bot/sign-in.ts
+++ b/packages/api/src/clients/bot/sign-in.ts
@@ -1,6 +1,9 @@
 import qs from 'qs';
 
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { SignInUrlResponse } from '../../models';
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
@@ -31,16 +34,16 @@ export class BotSignInClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
   }

--- a/packages/api/src/clients/conversation/activity.spec.ts
+++ b/packages/api/src/clients/conversation/activity.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { ConversationActivityClient } from './activity';
 

--- a/packages/api/src/clients/conversation/activity.ts
+++ b/packages/api/src/clients/conversation/activity.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { Activity } from '../../activities';
 import { resolveAadObjectId, Resource, TeamsChannelAccount } from '../../models';
@@ -15,18 +18,18 @@ export class ConversationActivityClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);

--- a/packages/api/src/clients/conversation/index.ts
+++ b/packages/api/src/clients/conversation/index.ts
@@ -1,6 +1,9 @@
 import qs from 'qs';
 
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { Account, Conversation, ConversationResource } from '../../models';
 
@@ -59,22 +62,22 @@ export class ConversationClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _activities: ConversationActivityClient;
   protected _members: ConversationMemberClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
-  
+
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
     this._activities = new ConversationActivityClient(serviceUrl, this.http, this._apiClientSettings);
     this._members = new ConversationMemberClient(serviceUrl, this.http, this._apiClientSettings);

--- a/packages/api/src/clients/conversation/member.ts
+++ b/packages/api/src/clients/conversation/member.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { PagedMembersResult, resolveAadObjectId, TeamsChannelAccount } from '../../models';
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
@@ -12,18 +15,18 @@ export class ConversationMemberClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
   }

--- a/packages/api/src/clients/conversation/members.spec.ts
+++ b/packages/api/src/clients/conversation/members.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { ConversationMemberClient } from './member';
 

--- a/packages/api/src/clients/index.ts
+++ b/packages/api/src/clients/index.ts
@@ -1,4 +1,7 @@
-import * as http from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { CloudEnvironment } from '../auth/cloud-environment';
 
@@ -17,10 +20,6 @@ export class Client {
   readonly conversations: ConversationClient;
   readonly teams: TeamClient;
   readonly meetings: MeetingClient;
-  /**
-   * @experimental This API is in preview and may change in the future.
-   * Diagnostic: ExperimentalTeamsReactions
-   */
   readonly reactions: ReactionClient;
 
   get http() {
@@ -35,18 +34,18 @@ export class Client {
     this.reactions.http = v;
     this._http = v;
   }
-  protected _http: http.Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: http.Client | http.ClientOptions, apiClientSettings?: Partial<ApiClientSettings>, cloud?: CloudEnvironment) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>, cloud?: CloudEnvironment) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new http.Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new http.Client({
+      this._http = new HttpClient({
         ...options,
         headers: {
           ...options?.headers,

--- a/packages/api/src/clients/meeting.spec.ts
+++ b/packages/api/src/clients/meeting.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { MeetingClient } from './meeting';
 

--- a/packages/api/src/clients/meeting.ts
+++ b/packages/api/src/clients/meeting.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import {
   MeetingInfo,
@@ -18,18 +21,18 @@ export class MeetingClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);

--- a/packages/api/src/clients/reaction/reaction.spec.ts
+++ b/packages/api/src/clients/reaction/reaction.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { ReactionClient } from './reaction';
 
@@ -36,10 +36,10 @@ describe('ReactionClient', () => {
     expect(spy).toHaveBeenCalledWith('/v3/conversations/conv1/activities/act1/reactions/like');
   });
 
-  it('should remove reaction', async () => {
+  it('should delete reaction', async () => {
     const client = new ReactionClient('');
     const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
-    await client.remove('conv1', 'act1', 'like');
+    await client.delete('conv1', 'act1', 'like');
     expect(spy).toHaveBeenCalledWith('/v3/conversations/conv1/activities/act1/reactions/like');
   });
 
@@ -64,10 +64,10 @@ describe('ReactionClient', () => {
     expect(spy).toHaveBeenCalledWith('/v3/conversations/conv1/activities/act1/reactions/like');
   });
 
-  it('should URL-encode parameters in remove', async () => {
+  it('should URL-encode parameters in delete', async () => {
     const client = new ReactionClient('');
     const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
-    await client.remove('conv+1/test=', 'act+1/test=', 'heart');
+    await client.delete('conv+1/test=', 'act+1/test=', 'heart');
     expect(spy).toHaveBeenCalledWith('/v3/conversations/conv%2B1%2Ftest%3D/activities/act%2B1%2Ftest%3D/reactions/heart');
   });
 });

--- a/packages/api/src/clients/reaction/reaction.ts
+++ b/packages/api/src/clients/reaction/reaction.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { MessageReactionType } from '../../models/message/message-reaction';
 
@@ -6,9 +9,6 @@ import { ApiClientSettings, mergeApiClientSettings } from '../api-client-setting
 
 /**
  * Client for adding and removing emoji reactions on messages in a conversation.
- *
- * @experimental This API is in preview and may change in the future.
- * Diagnostic: ExperimentalTeamsReactions
  */
 export class ReactionClient {
   readonly serviceUrl: string;
@@ -19,18 +19,18 @@ export class ReactionClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
@@ -38,9 +38,6 @@ export class ReactionClient {
 
   /**
    * Add a reaction to a message.
-   *
-   * @experimental This API is in preview and may change in the future.
-   * Diagnostic: ExperimentalTeamsReactions
    */
   async add(conversationId: string, activityId: string, reactionType: MessageReactionType) {
     const res = await this.http.put<void>(
@@ -50,12 +47,9 @@ export class ReactionClient {
   }
 
   /**
-   * Remove a reaction from a message.
-   *
-   * @experimental This API is in preview and may change in the future.
-   * Diagnostic: ExperimentalTeamsReactions
+   * Delete a reaction from a message.
    */
-  async remove(conversationId: string, activityId: string, reactionType: MessageReactionType) {
+  async delete(conversationId: string, activityId: string, reactionType: MessageReactionType) {
     const res = await this.http.delete<void>(
       `${this.serviceUrl}/v3/conversations/${encodeURIComponent(conversationId)}/activities/${encodeURIComponent(activityId)}/reactions/${encodeURIComponent(reactionType)}`
     );

--- a/packages/api/src/clients/team.spec.ts
+++ b/packages/api/src/clients/team.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { TeamClient } from './team';
 

--- a/packages/api/src/clients/team.ts
+++ b/packages/api/src/clients/team.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { ChannelInfo, TeamDetails } from '../models';
 
@@ -13,18 +16,18 @@ export class TeamClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(serviceUrl: string, options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
 
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);

--- a/packages/api/src/clients/user/index.ts
+++ b/packages/api/src/clients/user/index.ts
@@ -1,4 +1,7 @@
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
 
@@ -13,16 +16,16 @@ export class UserClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);

--- a/packages/api/src/clients/user/token.spec.ts
+++ b/packages/api/src/clients/user/token.spec.ts
@@ -1,4 +1,4 @@
-import { Client } from '@microsoft/teams.common/http';
+import { Client } from '@microsoft/teams.common';
 
 import { UserTokenClient } from './token';
 
@@ -91,7 +91,7 @@ describe('UserTokenClient', () => {
     );
   });
 
-  
+
   it('should get AAD token in regional endpoint', async () => {
     const client = new UserTokenClient({}, { oauthUrl: 'https://europe.token.botframework.com' });
     const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});

--- a/packages/api/src/clients/user/token.ts
+++ b/packages/api/src/clients/user/token.ts
@@ -1,6 +1,9 @@
 import qs from 'qs';
 
-import { Client, ClientOptions } from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { ChannelID, TokenExchangeRequest, TokenResponse, TokenStatus } from '../../models';
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
@@ -53,16 +56,16 @@ export class UserTokenClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: Client;
+  protected _http: HttpClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
-  constructor(options?: Client | ClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
+  constructor(options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     if (!options) {
-      this._http = new Client();
+      this._http = new HttpClient();
     } else if ('request' in options) {
       this._http = options;
     } else {
-      this._http = new Client(options);
+      this._http = new HttpClient(options);
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);

--- a/packages/api/src/models/entity/index.ts
+++ b/packages/api/src/models/entity/index.ts
@@ -4,8 +4,10 @@ import { ClientInfoEntity } from './client-info-entity';
 import { MentionEntity } from './mention-entity';
 import { MessageEntity } from './message-entity';
 import { ProductInfoEntity } from './product-info-entity';
+import { QuotedReplyEntity } from './quoted-reply-entity';
 import { SensitiveUsageEntity } from './sensitive-usage-entity';
 import { StreamInfoEntity } from './stream-info-entity';
+import { TargetedMessageInfoEntity } from './targeted-message-info-entity';
 
 export type Entity =
   | ClientInfoEntity
@@ -15,7 +17,9 @@ export type Entity =
   | StreamInfoEntity
   | CitationEntity
   | SensitiveUsageEntity
-  | ProductInfoEntity;
+  | ProductInfoEntity
+  | QuotedReplyEntity
+  | TargetedMessageInfoEntity;
 
 export * from './client-info-entity';
 export * from './mention-entity';
@@ -25,3 +29,5 @@ export * from './stream-info-entity';
 export * from './citation-entity';
 export * from './sensitive-usage-entity';
 export * from './product-info-entity';
+export * from './quoted-reply-entity';
+export * from './targeted-message-info-entity';

--- a/packages/api/src/models/entity/quoted-reply-entity.ts
+++ b/packages/api/src/models/entity/quoted-reply-entity.ts
@@ -1,0 +1,63 @@
+/**
+ * Data for a quoted reply entity.
+ *
+ * @experimental This API is coming soon and may change in the future.
+ * Diagnostic: ExperimentalTeamsQuotedReplies
+ */
+export type QuotedReplyData = {
+  /**
+   * ID of the message being quoted
+   */
+  messageId: string;
+
+  /**
+   * ID of the sender of the quoted message
+   */
+  senderId?: string | null;
+
+  /**
+   * display name of the sender of the quoted message
+   */
+  senderName?: string | null;
+
+  /**
+   * preview text of the quoted message
+   */
+  preview?: string | null;
+
+  /**
+   * timestamp of the quoted message (IC3 epoch value, e.g. "1772050244572").
+   * Populated on inbound; ignored on outbound.
+   */
+  time?: string | null;
+
+  /**
+   * whether the quoted message has been deleted
+   */
+  isReplyDeleted?: boolean;
+
+  /**
+   * whether the message reference has been validated
+   */
+  validatedMessageReference?: boolean;
+};
+
+/**
+ * Entity containing quoted reply information.
+ *
+ * @experimental This API is coming soon and may change in the future.
+ * Diagnostic: ExperimentalTeamsQuotedReplies
+ */
+export type QuotedReplyEntity = {
+  readonly type: 'quotedReply';
+
+  /**
+   * the quoted reply data
+   */
+  quotedReply: QuotedReplyData;
+
+  /**
+   * other properties
+   */
+  [key: string]: any;
+};

--- a/packages/api/src/models/entity/targeted-message-info-entity.ts
+++ b/packages/api/src/models/entity/targeted-message-info-entity.ts
@@ -1,0 +1,20 @@
+/**
+ * Entity that carries the messageId of the original targeted message
+ * for prompt preview rendering.
+ *
+ * @experimental This API is in preview and may change in the future.
+ * Diagnostic: ExperimentalTeamsTargeted
+ */
+export type TargetedMessageInfoEntity = {
+  readonly type: 'targetedMessageInfo';
+
+  /**
+   * The message ID of the targeted message.
+   */
+  messageId: string;
+
+  /**
+   * other properties
+   */
+  [key: string]: any;
+};

--- a/packages/api/src/models/message/message-reaction.ts
+++ b/packages/api/src/models/message/message-reaction.ts
@@ -3,18 +3,12 @@ import { MessageUser } from './message-user';
 /**
  * The type of emoji reaction that can be applied to a message.
  * Possible values include: 'like', 'heart', '1f440_eyes', '2705_whiteheavycheckmark', 'launch', '1f4cc_pushpin'
- *
- * @experimental This API is in preview and may change in the future.
- * Diagnostic: ExperimentalTeamsReactions
  */
 export type MessageReactionType = 'like' | 'heart' | '1f440_eyes' | '2705_whiteheavycheckmark' | 'launch' | '1f4cc_pushpin' | (string & {});
 
 
 /**
  * Represents a reaction on a message, including the reaction type, timestamp, and user.
- *
- * @experimental This API is in preview and may change in the future.
- * Diagnostic: ExperimentalTeamsReactions
  */
 export type MessageReaction = {
   /** The emoji reaction type applied to the message. */

--- a/packages/apps/src/activity-sender.spec.ts
+++ b/packages/apps/src/activity-sender.spec.ts
@@ -1,11 +1,11 @@
 import { ActivityParams, ConversationReference } from '@microsoft/teams.api';
-import * as $http from '@microsoft/teams.common/http';
+import  {Client as HttpClient } from '@microsoft/teams.common';
 
 import { ActivitySender } from './activity-sender';
 
 describe('ActivitySender', () => {
   let sender: ActivitySender;
-  let mockHttpClient: $http.Client;
+  let mockHttpClient: HttpClient;
   let ref: ConversationReference;
 
   beforeEach(() => {
@@ -60,13 +60,17 @@ describe('ActivitySender', () => {
     });
 
     it('should POST with isTargetedActivity query param for targeted messages', async () => {
+      const groupRef = {
+        ...ref,
+        conversation: { id: 'conv-123', conversationType: 'groupChat' },
+      };
       const activity = {
         type: 'message',
         text: 'targeted',
         recipient: { id: 'user-1', name: 'User', role: 'user', isTargeted: true },
       } as ActivityParams;
 
-      await sender.send(activity, ref);
+      await sender.send(activity, groupRef);
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         'https://smba.trafficmanager.net/teams/v3/conversations/conv-123/activities?isTargetedActivity=true',
@@ -75,6 +79,10 @@ describe('ActivitySender', () => {
     });
 
     it('should PUT with isTargetedActivity query param for targeted updates', async () => {
+      const groupRef = {
+        ...ref,
+        conversation: { id: 'conv-123', conversationType: 'groupChat' },
+      };
       const activity = {
         type: 'message',
         text: 'targeted update',
@@ -82,7 +90,7 @@ describe('ActivitySender', () => {
         recipient: { id: 'user-1', name: 'User', role: 'user', isTargeted: true },
       } as ActivityParams;
 
-      await sender.send(activity, ref);
+      await sender.send(activity, groupRef);
 
       expect(mockHttpClient.put).toHaveBeenCalledWith(
         'https://smba.trafficmanager.net/teams/v3/conversations/conv-123/activities/existing-id?isTargetedActivity=true',
@@ -121,6 +129,33 @@ describe('ActivitySender', () => {
         'https://custom-service.botframework.com/v3/conversations/conv-456/activities',
         expect.any(Object)
       );
+    });
+
+    it('should throw when sending targeted message in personal chat', async () => {
+      const activity: ActivityParams = {
+        type: 'message',
+        text: 'hello',
+        recipient: { id: 'user-1', name: 'User', role: 'user', isTargeted: true },
+      };
+
+      await expect(sender.send(activity, ref)).rejects.toThrow(
+        'Targeted messages are not supported in 1:1 (personal) chats.'
+      );
+    });
+
+    it('should allow targeted message in group chat', async () => {
+      const groupRef = {
+        ...ref,
+        conversation: { id: 'conv-123', conversationType: 'groupChat' },
+      };
+      const activity: ActivityParams = {
+        type: 'message',
+        text: 'hello',
+        recipient: { id: 'user-1', name: 'User', role: 'user', isTargeted: true },
+      };
+
+      const result = await sender.send(activity, groupRef);
+      expect(result).toEqual(expect.objectContaining({ id: 'activity-1' }));
     });
   });
 

--- a/packages/apps/src/activity-sender.ts
+++ b/packages/apps/src/activity-sender.ts
@@ -1,6 +1,5 @@
 import { ActivityParams, Client, ConversationReference, SentActivity } from '@microsoft/teams.api';
-import * as $http from '@microsoft/teams.common/http';
-import { ILogger } from '@microsoft/teams.common/logging';
+import { Client as HttpClient, ILogger } from '@microsoft/teams.common';
 
 import { HttpStream } from './http/http-stream';
 import { IStreamer, IActivitySender } from './types';
@@ -11,7 +10,7 @@ import { IStreamer, IActivitySender } from './types';
  */
 export class ActivitySender implements IActivitySender {
   constructor(
-    private client: $http.Client,
+    private client: HttpClient,
     private logger: ILogger
   ) { }
 
@@ -28,6 +27,10 @@ export class ActivitySender implements IActivitySender {
 
     // Check if this is a targeted message
     const isTargeted = activity.recipient?.isTargeted === true;
+
+    if (isTargeted && ref.conversation.conversationType === 'personal') {
+      throw new Error('Targeted messages are not supported in 1:1 (personal) chats.');
+    }
 
     // Decide create vs update, with targeted variants
     if (activity.id) {

--- a/packages/apps/src/api.ts
+++ b/packages/apps/src/api.ts
@@ -1,7 +1,2 @@
-import * as api from '@microsoft/teams.api';
-import * as graph from '@microsoft/teams.graph';
-
-export const ApiClient = api.Client;
-export type ApiClient = api.Client;
-export const GraphClient = graph.Client;
-export type GraphClient = graph.Client;
+export { Client as ApiClient } from '@microsoft/teams.api';
+export { Client as GraphClient } from '@microsoft/teams.graph';

--- a/packages/apps/src/app.oauth.ts
+++ b/packages/apps/src/app.oauth.ts
@@ -6,7 +6,7 @@ import {
   ISignInVerifyStateInvokeActivity,
   TokenExchangeInvokeResponse,
 } from '@microsoft/teams.api';
-import * as graph from '@microsoft/teams.graph';
+import { Client as GraphClient } from '@microsoft/teams.graph';
 
 import { App } from './app';
 import * as contexts from './contexts';
@@ -35,7 +35,7 @@ export async function onTokenExchange<TPlugin extends IPlugin>(
       },
     });
 
-    ctx.userGraph = new graph.Client(
+    ctx.userGraph = new GraphClient(
       this.client.clone({
         token: token.token,
       }),
@@ -85,7 +85,7 @@ export async function onVerifyState<TPlugin extends IPlugin>(
       code: activity.value.state,
     });
 
-    ctx.userGraph = new graph.Client(
+    ctx.userGraph = new GraphClient(
       this.client.clone({
         token: token.token,
       }),

--- a/packages/apps/src/app.plugin.spec.ts
+++ b/packages/apps/src/app.plugin.spec.ts
@@ -1,4 +1,4 @@
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 
 import { ICoreActivity, IErrorEvent } from './events';
 import { createTestApp } from './test-utils';

--- a/packages/apps/src/app.spec.ts
+++ b/packages/apps/src/app.spec.ts
@@ -258,6 +258,28 @@ describe('App', () => {
     });
   });
 
+  describe('http client User-Agent', () => {
+    it('should merge App User-Agent with User-Agent from client options', async () => {
+      const app = new App({
+        httpServerAdapter: new TestAdapter(),
+        client: {
+          headers: {
+            'user-agent': 'MyApp/1.0',
+          },
+        },
+      });
+      const spy = jest.spyOn((app.client as any).http, 'get').mockResolvedValueOnce({});
+
+      await app.client.get('/test');
+
+      expect(spy).toHaveBeenCalledWith('/test', {
+        headers: {
+          'User-Agent': expect.stringMatching(/^teams\.ts\[apps\]\/.* MyApp\/1\.0$/),
+        },
+      });
+    });
+  });
+
   describe('service URL configuration', () => {
     const originalEnv = process.env.SERVICE_URL;
 

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -13,10 +13,15 @@ import {
   toActivityParams,
   TokenCredentials,
 } from '@microsoft/teams.api';
-import { EventEmitter } from '@microsoft/teams.common/events';
-import * as http from '@microsoft/teams.common/http';
-import { ConsoleLogger, ILogger } from '@microsoft/teams.common/logging';
-import { IStorage, LocalStorage } from '@microsoft/teams.common/storage';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions,
+  ConsoleLogger,
+  EventEmitter,
+  ILogger,
+  IStorage,
+  LocalStorage
+} from '@microsoft/teams.common';
 
 import pkg from '../package.json';
 
@@ -103,7 +108,7 @@ export type AppOptions<TPlugin extends IPlugin> = {
   /**
    * http client or client options used to make api requests
    */
-  readonly client?: http.Client | http.ClientOptions | (() => http.Client);
+  readonly client?: HttpClient | HttpClientOptions | (() => HttpClient);
 
   /**
    * logger instance to use
@@ -192,7 +197,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
   readonly log: ILogger;
   readonly server: HttpServer;
   readonly http?: HttpPlugin;
-  readonly client: http.Client;
+  readonly client: HttpClient;
   readonly storage: IStorage;
   readonly entraTokenValidator?: middleware.JwtValidator;
   readonly tokenManager: TokenManager;
@@ -282,7 +287,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
     this.cloud = this.options.cloud ?? (cloudEnvName ? cloudFromName(cloudEnvName) : PUBLIC);
 
     if (!options.client) {
-      this.client = new http.Client({
+      this.client = new HttpClient({
         headers: {
           'User-Agent': this._userAgent,
         },
@@ -300,10 +305,8 @@ export class App<TPlugin extends IPlugin = IPlugin> {
         },
       });
     } else {
-      this.client = new http.Client({
-        ...options.client,
+      this.client = new HttpClient(options.client).clone({
         headers: {
-          ...options.client.headers,
           'User-Agent': this._userAgent,
         },
       });

--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -8,8 +8,7 @@ import {
   TokenExchangeResource,
   TokenPostResource,
 } from '@microsoft/teams.api';
-import { ILogger } from '@microsoft/teams.common/logging';
-import { IStorage } from '@microsoft/teams.common/storage';
+import { ILogger, IStorage } from '@microsoft/teams.common';
 
 import { ApiClient, GraphClient } from '../api';
 
@@ -262,6 +261,96 @@ describe('ActivityContext', () => {
         const sentActivity = (mockSender.send as jest.Mock).mock.calls[0][0];
         expect(sentActivity.id).toBe('existing-activity-id');
         expect(sentActivity.recipient.isTargeted).toBe(true);
+      });
+    });
+
+    describe('prompt preview', () => {
+      it('auto-populates targetedMessageInfo entity when incoming activity is targeted', async () => {
+        const activity = new MessageActivity('Hello world')
+          .withFrom({ id: 'test-user', name: 'Test User', role: 'user' })
+          .withRecipient({ id: 'bot-id', name: 'Bot', role: 'bot' }, true)
+          .withChannelId('test-channel')
+          .withConversation({ id: 'test-conversation', conversationType: 'channel', isGroup: false })
+          .withId('1772129782775');
+
+        context = buildActivityContext(activity);
+
+        await context.send('Here is your agenda');
+
+        expect(mockSender.send).toHaveBeenCalledTimes(1);
+        expect(mockSender.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: 'Here is your agenda',
+            type: 'message',
+            entities: expect.arrayContaining([
+              expect.objectContaining({
+                type: 'targetedMessageInfo',
+                messageId: '1772129782775',
+              }),
+            ]),
+          }),
+          mockRef
+        );
+      });
+
+      it('does not auto-populate targetedMessageInfo when incoming activity is not targeted', async () => {
+        const activity = buildIncomingMessageActivity('Hello world');
+        context = buildActivityContext(activity);
+
+        await context.send('Response');
+
+        expect(mockSender.send).toHaveBeenCalledTimes(1);
+        const sentActivity = (mockSender.send as jest.Mock).mock.calls[0][0];
+        expect(sentActivity.entities).toBeUndefined();
+      });
+
+      it('does not overwrite existing targetedMessageInfo entity', async () => {
+        const activity = new MessageActivity('Hello world')
+          .withFrom({ id: 'test-user', name: 'Test User', role: 'user' })
+          .withRecipient({ id: 'bot-id', name: 'Bot', role: 'bot' }, true)
+          .withChannelId('test-channel')
+          .withConversation({ id: 'test-conversation', conversationType: 'channel', isGroup: false })
+          .withId('1772129782775');
+
+        context = buildActivityContext(activity);
+
+        const outgoing = new MessageActivity('Response')
+          .addTargetedMessageInfo('custom-message-id');
+
+        await context.send(outgoing);
+
+        expect(mockSender.send).toHaveBeenCalledTimes(1);
+        const sentActivity = (mockSender.send as jest.Mock).mock.calls[0][0];
+        const targetedEntities = sentActivity.entities.filter((e: any) => e.type === 'targetedMessageInfo');
+        expect(targetedEntities).toHaveLength(1);
+        expect(targetedEntities[0].messageId).toBe('custom-message-id');
+      });
+
+      it('auto-populates targetedMessageInfo on reply to targeted message', async () => {
+        const activity = new MessageActivity('Hello world')
+          .withFrom({ id: 'test-user', name: 'Test User', role: 'user' })
+          .withRecipient({ id: 'bot-id', name: 'Bot', role: 'bot' }, true)
+          .withChannelId('test-channel')
+          .withConversation({ id: 'test-conversation', conversationType: 'channel', isGroup: false })
+          .withId('1772129782775');
+
+        context = buildActivityContext(activity);
+
+        await context.reply('Here is your agenda');
+
+        expect(mockSender.send).toHaveBeenCalledTimes(1);
+        expect(mockSender.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'message',
+            entities: expect.arrayContaining([
+              expect.objectContaining({
+                type: 'targetedMessageInfo',
+                messageId: '1772129782775',
+              }),
+            ]),
+          }),
+          mockRef
+        );
       });
     });
   });

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -15,8 +15,7 @@ import {
   TokenPostResource,
   TypingActivity,
 } from '@microsoft/teams.api';
-import { ILogger } from '@microsoft/teams.common/logging';
-import { IStorage } from '@microsoft/teams.common/storage';
+import { ILogger, IStorage } from '@microsoft/teams.common';
 
 import { ApiClient, GraphClient } from '../api';
 import { IStreamer } from '../types';
@@ -248,6 +247,32 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     if (params.type === 'message' && params.recipient?.isTargeted && !params.id) {
       if (!params.recipient) {
         params.recipient = this.activity.from;
+      }
+    }
+
+    // Auto-populate targetedMessageInfo entity for prompt preview
+    // when replying to a targeted message in the reactive flow.
+    if (
+      params.type === 'message' &&
+      this.activity.recipient?.isTargeted === true
+    ) {
+      if (params.entities) {
+        params.entities = params.entities.filter((e) => e.type !== 'quotedReply');
+      }
+
+      if (params.text) {
+        params.text = params.text.replace(`<quoted messageId="${this.activity.id}"/>`, '').trim();
+      }
+
+      if (!params.entities?.some((e) => e.type === 'targetedMessageInfo')) {
+        if (!params.entities) {
+          params.entities = [];
+        }
+
+        params.entities.push({
+          type: 'targetedMessageInfo',
+          messageId: this.activity.id,
+        });
       }
     }
 

--- a/packages/apps/src/middleware/strip-mentions-text.ts
+++ b/packages/apps/src/middleware/strip-mentions-text.ts
@@ -1,15 +1,19 @@
-import * as api from '@microsoft/teams.api';
+import {
+  type Activity,
+  type StripMentionsTextOptions,
+  stripMentionsText as apiStripMentionsText
+} from '@microsoft/teams.api';
 
 import { IActivityContext } from '../contexts';
 
-export function stripMentionsText(options?: api.StripMentionsTextOptions) {
-  return ({ activity, next }: IActivityContext<api.Activity, any>) => {
+export function stripMentionsText(options?: StripMentionsTextOptions) {
+  return ({ activity, next }: IActivityContext<Activity, any>) => {
     if (
       activity.type === 'message' ||
       activity.type === 'messageUpdate' ||
       activity.type === 'typing'
     ) {
-      activity.text = api.stripMentionsText(activity, options);
+      activity.text = apiStripMentionsText(activity, options);
     }
 
     return next();

--- a/packages/botbuilder/src/plugin.ts
+++ b/packages/botbuilder/src/plugin.ts
@@ -18,8 +18,7 @@ import {
   Plugin,
   manifest,
 } from '@microsoft/teams.apps';
-import { ILogger } from '@microsoft/teams.common';
-import * as $http from '@microsoft/teams.common/http';
+import { Client as HttpClient, ILogger } from '@microsoft/teams.common';
 
 import pkg from '../package.json';
 
@@ -37,7 +36,7 @@ export class BotBuilderPlugin implements IPlugin {
   declare readonly logger: ILogger;
 
   @Dependency()
-  declare readonly client: $http.Client;
+  declare readonly client: HttpClient;
 
   @HttpServer()
   declare readonly httpServer: IHttpServer;

--- a/packages/cli/templates/typescript/ai/src/index.ts
+++ b/packages/cli/templates/typescript/ai/src/index.ts
@@ -1,6 +1,6 @@
 import { App } from '@microsoft/teams.apps';
 import { ChatPrompt, Message } from '@microsoft/teams.ai';
-import { LocalStorage } from '@microsoft/teams.common/storage';
+import { LocalStorage } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 import { OpenAIChatModel } from '@microsoft/teams.openai';
 

--- a/packages/cli/templates/typescript/tab/src/index.ts
+++ b/packages/cli/templates/typescript/tab/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { App } from '@microsoft/teams.apps';
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 import { DevtoolsPlugin } from '@microsoft/teams.dev';
 
 const app = new App({

--- a/packages/client/src/app.spec.ts
+++ b/packages/client/src/app.spec.ts
@@ -67,9 +67,9 @@ jest.mock('@azure/msal-browser', () => {
   };
 });
 
-jest.mock('@microsoft/teams.common/http', () => {
+jest.mock('@microsoft/teams.common', () => {
   return {
-    ...jest.requireActual('@microsoft/teams.common/http'),
+    ...jest.requireActual('@microsoft/teams.common'),
     Client: jest.fn().mockImplementation(() => {
       return {
         post: httpClientPostMock,

--- a/packages/client/src/app.ts
+++ b/packages/client/src/app.ts
@@ -1,9 +1,13 @@
-import * as msal from '@azure/msal-browser';
+import {
+  createNestablePublicClientApplication,
+  type Configuration,
+  type IPublicClientApplication,
+  type SilentRequest,
+} from '@azure/msal-browser';
 
-import * as teamsJs from '@microsoft/teams-js';
-import * as http from '@microsoft/teams.common/http';
-import { ILogger, ConsoleLogger } from '@microsoft/teams.common/logging';
-import * as graph from '@microsoft/teams.graph';
+import { app } from '@microsoft/teams-js';
+import { ConsoleLogger, Client as HttpClient, ILogger } from '@microsoft/teams.common';
+import { Client as GraphClient } from '@microsoft/teams.graph';
 
 import { buildGraphClient } from './graph-utils';
 import {
@@ -23,7 +27,7 @@ export type MsalOptions = (
        * This is useful if you want to use a custom MSAL instance or if you want to share the
        * same MSAL instance across multiple apps.
        */
-      readonly msalInstance?: msal.IPublicClientApplication;
+      readonly msalInstance?: IPublicClientApplication;
       readonly configuration?: never;
     }
   | {
@@ -31,7 +35,7 @@ export type MsalOptions = (
       /**
        * MSAL configuration to use when constructing an MSAL instance used
        * to make authenticated function calls to remote endpoints. */
-      readonly configuration?: msal.Configuration;
+      readonly configuration?: Configuration;
     }
 ) & {
   /**
@@ -85,7 +89,7 @@ type AppState =
   | {
       phase: 'started';
       startedAt: Date;
-      msalInstance: msal.IPublicClientApplication;
+      msalInstance: IPublicClientApplication;
     };
 
 /**
@@ -93,7 +97,7 @@ type AppState =
  */
 export type ExecOptions = (
   | {
-      readonly msalTokenRequest?: msal.SilentRequest;
+      readonly msalTokenRequest?: SilentRequest;
       readonly permission?: never;
     }
   | { readonly msalTokenRequest?: never; readonly permission?: string }
@@ -108,8 +112,8 @@ export type ExecOptions = (
  */
 export class App {
   readonly options: AppOptions;
-  readonly http: http.Client;
-  readonly graph: graph.Client;
+  readonly http: HttpClient;
+  readonly graph: GraphClient;
   readonly clientId: string;
   protected _state: AppState = { phase: 'stopped' };
 
@@ -141,7 +145,7 @@ export class App {
     this.clientId = clientId;
     this.options = options;
     this._log = options?.logger || new ConsoleLogger('@teams/client');
-    this.http = new http.Client({
+    this.http = new HttpClient({
       baseUrl: options?.remoteApiOptions?.baseUrl,
     });
     this.graph = buildGraphClient(() => this.appStateGuard(), this._log);
@@ -161,14 +165,14 @@ export class App {
     this._log.debug('app starting');
     this._state = { phase: 'starting' };
 
-    await teamsJs.app.initialize();
+    await app.initialize();
 
     let msalInstance = this.options.msalOptions?.msalInstance;
     if (!msalInstance) {
       const msalConfig =
         this.options.msalOptions?.configuration ??
         buildMsalConfig(this.clientId, this._log);
-      msalInstance = await msal.createNestablePublicClientApplication(
+      msalInstance = await createNestablePublicClientApplication(
         msalConfig
       );
     }
@@ -201,7 +205,7 @@ export class App {
     options?: ExecOptions
   ): Promise<T> {
     const { msalInstance } = this.appStateGuard();
-    const context = await teamsJs.app.getContext();
+    const context = await app.getContext();
 
     const remoteAppResource =
       this.options.remoteApiOptions?.remoteAppResource ??

--- a/packages/client/src/graph-utils.spec.ts
+++ b/packages/client/src/graph-utils.spec.ts
@@ -2,9 +2,9 @@ const httpClientMock = jest.fn();
 
 import { buildGraphClient } from './graph-utils';
 
-jest.mock('@microsoft/teams.common/http', () => {
+jest.mock('@microsoft/teams.common', () => {
   return {
-    ...jest.requireActual('@microsoft/teams.common/http'),
+    ...jest.requireActual('@microsoft/teams.common'),
     Client: httpClientMock,
   };
 });

--- a/packages/client/src/graph-utils.ts
+++ b/packages/client/src/graph-utils.ts
@@ -1,15 +1,14 @@
-import * as http from '@microsoft/teams.common/http';
-import { ILogger } from '@microsoft/teams.common/logging';
-import * as graph from '@microsoft/teams.graph';
+import { Client as HttpClient, ILogger, type RequestContext } from '@microsoft/teams.common';
+import { Client as GraphClient } from '@microsoft/teams.graph';
 
 import { acquireMsalAccessToken } from './msal-utils';
 
 export function buildGraphClient(
   getMsalInstance: () => { msalInstance: Parameters<typeof acquireMsalAccessToken>[0] },
   logger: ILogger
-): graph.Client {
+): GraphClient {
   {
-    const graphRequestAccessTokenInterceptor = async (ctx: http.RequestContext) => {
+    const graphRequestAccessTokenInterceptor = async (ctx: RequestContext) => {
       const { msalInstance } = getMsalInstance();
 
       // The developer should already have made sure that the user has consented to the scope
@@ -24,8 +23,8 @@ export function buildGraphClient(
       return ctx.config;
     };
 
-    return new graph.Client(
-      new http.Client({
+    return new GraphClient(
+      new HttpClient({
         interceptors: [{ request: graphRequestAccessTokenInterceptor }],
       })
     );

--- a/packages/client/src/msal-utils.ts
+++ b/packages/client/src/msal-utils.ts
@@ -1,6 +1,12 @@
-import * as msal from '@azure/msal-browser';
+import {
+  type Configuration,
+  type IPublicClientApplication,
+  InteractionRequiredAuthError,
+  LogLevel,
+  type SilentRequest,
+} from '@azure/msal-browser';
 
-import { ILogger } from '@microsoft/teams.common/logging';
+import { ILogger } from '@microsoft/teams.common';
 
 /**
  * Gets a silent request used to acquire an Entra access token for invoking remote functions on behalf of a user.
@@ -11,7 +17,7 @@ import { ILogger } from '@microsoft/teams.common/logging';
 export const getStandardExecSilentRequest = (
   resource: string,
   permission = 'access_as_user'
-): msal.SilentRequest => ({
+): SilentRequest => ({
   scopes: [`${resource}/${permission}`],
 });
 
@@ -22,7 +28,7 @@ export const getStandardExecSilentRequest = (
  * @returns A default MSAL configuration object suitable for creating a
  * @see{IPublicClientApplication} instance for a multi-tenant application.
  */
-export const buildMsalConfig = (clientId: string, logger: ILogger): msal.Configuration => {
+export const buildMsalConfig = (clientId: string, logger: ILogger): Configuration => {
   return {
     auth: {
       clientId,
@@ -35,16 +41,16 @@ export const buildMsalConfig = (clientId: string, logger: ILogger): msal.Configu
         piiLoggingEnabled: false,
         loggerCallback: (level, message) => {
           switch (level) {
-            case msal.LogLevel.Error:
+            case LogLevel.Error:
               logger.error(message);
               return;
-            case msal.LogLevel.Info:
+            case LogLevel.Info:
               logger.info(message);
               return;
-            case msal.LogLevel.Verbose:
+            case LogLevel.Verbose:
               logger.debug(message);
               return;
-            case msal.LogLevel.Warning:
+            case LogLevel.Warning:
               logger.warn(message);
               return;
             default:
@@ -66,8 +72,8 @@ export const buildMsalConfig = (clientId: string, logger: ILogger): msal.Configu
  * @returns A promise that resolves to the acquired access token.
  */
 export const acquireMsalAccessToken = async (
-  msalInstance: Pick<msal.IPublicClientApplication, 'acquireTokenSilent' | 'acquireTokenPopup'>,
-  request: msal.SilentRequest,
+  msalInstance: Pick<IPublicClientApplication, 'acquireTokenSilent' | 'acquireTokenPopup'>,
+  request: SilentRequest,
   logger: ILogger
 ): Promise<string> => {
   try {
@@ -76,7 +82,7 @@ export const acquireMsalAccessToken = async (
   } catch (ex) {
     // InteractionRequiredAuthError indicates that the user may not have consented to the requested
     // scope yet -- for this, we can fall back on acquireTokenPopup instead.
-    const tryAcquireTokenPopup = ex instanceof msal.InteractionRequiredAuthError;
+    const tryAcquireTokenPopup = ex instanceof InteractionRequiredAuthError;
     if (!tryAcquireTokenPopup) {
       logger.error('acquireTokenSilent failed', ex);
       throw ex;
@@ -103,7 +109,7 @@ export const acquireMsalAccessToken = async (
  * @returns A promise that resolves to a boolean indicating whether the user has consented to the scopes.
  */
 export const hasConsentForScopes = async (
-  msalInstance: Pick<msal.IPublicClientApplication, 'acquireTokenSilent'>,
+  msalInstance: Pick<IPublicClientApplication, 'acquireTokenSilent'>,
   scopes: string[],
   logger: ILogger
 ): Promise<boolean> => {
@@ -116,7 +122,7 @@ export const hasConsentForScopes = async (
   } catch (ex) {
     // InteractionRequiredAuthError indicates that the user has not consented to the requested scope yet.
     // This is not an error, but may be interesting when trouble shooting.
-    const acquireTokenPopupNeeded = ex instanceof msal.InteractionRequiredAuthError;
+    const acquireTokenPopupNeeded = ex instanceof InteractionRequiredAuthError;
     const logLevel = acquireTokenPopupNeeded ? 'debug' : 'error';
     logger.log(logLevel, 'hasConsentForScopes failed', ex);
     return false;

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -8,6 +8,7 @@
   "files": [
     "eslint.config.js",
     "jest.config.js",
+    "rewrite-esm-imports.js",
     "tsup.config.js"
   ],
   "publishConfig": {

--- a/packages/config/rewrite-esm-imports.js
+++ b/packages/config/rewrite-esm-imports.js
@@ -1,0 +1,96 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const KNOWN_RUNTIME_EXTENSIONS = new Set([
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".json",
+  ".node",
+  ".wasm",
+]);
+
+function hasKnownRuntimeExtension(specifier) {
+  const bareSpecifier = specifier.split(/[?#]/, 1)[0];
+  const lastSegment = bareSpecifier.slice(bareSpecifier.lastIndexOf("/") + 1);
+
+  if (!lastSegment || lastSegment === "." || lastSegment === "..") {
+    return false;
+  }
+
+  const dotIndex = lastSegment.lastIndexOf(".");
+  if (dotIndex <= 0) {
+    return false;
+  }
+
+  const ext = lastSegment.slice(dotIndex).toLowerCase();
+  return KNOWN_RUNTIME_EXTENSIONS.has(ext);
+}
+
+function rewriteRelativeMjsSpecifier(specifier, sourceFilePath) {
+  // Skip if specifier already has a known runtime extension.
+  if (hasKnownRuntimeExtension(specifier)) {
+    return specifier;
+  }
+
+  const sourceDir = path.dirname(sourceFilePath);
+  const resolvedBase = path.resolve(sourceDir, specifier);
+  const resolvedFile = `${resolvedBase}.mjs`;
+  const resolvedIndex = path.join(resolvedBase, "index.mjs");
+
+  if (fs.existsSync(resolvedFile)) {
+    return `${specifier}.mjs`;
+  }
+
+  if (fs.existsSync(resolvedIndex)) {
+    const cleanSpecifier = specifier.endsWith("/")
+      ? specifier.slice(0, -1)
+      : specifier;
+    return `${cleanSpecifier}/index.mjs`;
+  }
+
+  return specifier;
+}
+
+function rewriteMjsSpecifiers(content, sourceFilePath) {
+  const rewrite = (_, prefix, specifier, suffix) => {
+    return `${prefix}${rewriteRelativeMjsSpecifier(specifier, sourceFilePath)}${suffix}`;
+  };
+
+  return content
+    .replace(/(from\s+['"])(\.{1,2}\/[^'"\n]+)(['"])/g, rewrite)
+    .replace(/(import\s+['"])(\.{1,2}\/[^'"\n]+)(['"])/g, rewrite)
+    .replace(/(import\(\s*['"])(\.{1,2}\/[^'"\n]+)(['"]\s*\))/g, rewrite);
+}
+
+function rewriteMjsImportsInDist(distDir) {
+  if (!fs.existsSync(distDir)) {
+    return;
+  }
+
+  const visit = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath);
+        continue;
+      }
+
+      if (!entry.isFile() || !entry.name.endsWith(".mjs")) {
+        continue;
+      }
+
+      const source = fs.readFileSync(fullPath, "utf8");
+      const rewritten = rewriteMjsSpecifiers(source, fullPath);
+      if (rewritten !== source) {
+        fs.writeFileSync(fullPath, rewritten, "utf8");
+      }
+    }
+  };
+
+  visit(distDir);
+}
+
+module.exports = {
+  rewriteMjsImportsInDist,
+};

--- a/packages/config/tsup.config.js
+++ b/packages/config/tsup.config.js
@@ -1,3 +1,8 @@
+const path = require("node:path");
+const { rewriteMjsImportsInDist } = require("./rewrite-esm-imports");
+
+const OUT_DIR = "dist";
+
 /** @type {import('tsup').Options} */
 module.exports = {
   dts: true,
@@ -7,7 +12,10 @@ module.exports = {
   treeshake: true,
   splitting: true,
   clean: true,
-  outDir: 'dist',
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts'],
-  format: ['cjs', 'esm'],
+  outDir: OUT_DIR,
+  entry: ["src/**/*.ts", "!src/**/*.spec.ts"],
+  format: ["cjs", "esm"],
+  async onSuccess() {
+    rewriteMjsImportsInDist(path.join(process.cwd(), OUT_DIR));
+  },
 };

--- a/packages/dev/src/routes/context.ts
+++ b/packages/dev/src/routes/context.ts
@@ -1,5 +1,5 @@
 import { Activity, InvokeResponse, IToken } from '@microsoft/teams.api';
-import { ILogger } from '@microsoft/teams.common/logging';
+import { ILogger } from '@microsoft/teams.common';
 
 export type RouteContext = {
   readonly port: number;

--- a/packages/devtools/src/components/Logger/Logger.ts
+++ b/packages/devtools/src/components/Logger/Logger.ts
@@ -1,4 +1,4 @@
-import { ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger } from '@microsoft/teams.common';
 
 const Logger = new ConsoleLogger('@teams/devtools');
 

--- a/packages/graph/src/index.spec.ts
+++ b/packages/graph/src/index.spec.ts
@@ -1,19 +1,19 @@
 import { AxiosError } from 'axios';
 
-import * as http from '@microsoft/teams.common/http';
+import { Client as HttpClient } from '@microsoft/teams.common';
 
 import { Client, GraphError } from './index';
 
 import type { EndpointRequest } from './types';
 
 // Mock the http module
-jest.mock('@microsoft/teams.common/http', () => ({
+jest.mock('@microsoft/teams.common', () => ({
   Client: jest.fn(),
 }));
 
 describe('Client', () => {
-  let mockHttpClient: jest.Mocked<http.Client>;
-  let mockBetaHttpClient: jest.Mocked<http.Client>;
+  let mockHttpClient: jest.Mocked<HttpClient>;
+  let mockBetaHttpClient: jest.Mocked<HttpClient>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -41,7 +41,7 @@ describe('Client', () => {
     // Setup clone to return beta client
     mockHttpClient.clone.mockReturnValue(mockBetaHttpClient);
 
-    (http.Client as jest.MockedClass<typeof http.Client>).mockImplementation(
+    (HttpClient as jest.MockedClass<typeof HttpClient>).mockImplementation(
       () => mockHttpClient,
     );
   });
@@ -49,7 +49,7 @@ describe('Client', () => {
   describe('constructor', () => {
     it('should create client with default base URL', () => {
       new Client();
-      expect(http.Client).toHaveBeenCalledWith({
+      expect(HttpClient).toHaveBeenCalledWith({
         baseUrl: 'https://graph.microsoft.com/v1.0',
         headers: {
           'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ describe('Client', () => {
         baseUrlRoot: 'https://graph.microsoft.us',
       });
 
-      expect(http.Client).toHaveBeenCalledWith({
+      expect(HttpClient).toHaveBeenCalledWith({
         baseUrlRoot: 'https://graph.microsoft.us',
         baseUrl: 'https://graph.microsoft.us/v1.0',
         headers: {
@@ -81,7 +81,7 @@ describe('Client', () => {
         timeout: 10000,
       });
 
-      expect(http.Client).toHaveBeenCalledWith({
+      expect(HttpClient).toHaveBeenCalledWith({
         baseUrlRoot: 'https://graph.microsoft.de',
         timeout: 10000,
         baseUrl: 'https://graph.microsoft.de/v1.0',
@@ -130,7 +130,7 @@ describe('Client', () => {
     it('should honor graphOptions.baseUrlRoot when no options provided', () => {
       new Client(undefined, { baseUrlRoot: 'https://graph.microsoft.us' });
 
-      expect(http.Client).toHaveBeenCalledWith({
+      expect(HttpClient).toHaveBeenCalledWith({
         baseUrl: 'https://graph.microsoft.us/v1.0',
         headers: {
           'Content-Type': 'application/json',
@@ -145,7 +145,7 @@ describe('Client', () => {
         { baseUrlRoot: 'https://graph.microsoft.us' }
       );
 
-      expect(http.Client).toHaveBeenCalledWith({
+      expect(HttpClient).toHaveBeenCalledWith({
         baseUrlRoot: 'https://graph.microsoft.com',
         baseUrl: 'https://graph.microsoft.us/v1.0',
         headers: {

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,4 +1,7 @@
-import * as http from '@microsoft/teams.common/http';
+import {
+  Client as HttpClient,
+  type ClientOptions as HttpClientOptions
+} from '@microsoft/teams.common';
 
 import { getInjectedUrl, getInjectedRequestConfig } from './utils/url';
 
@@ -45,7 +48,7 @@ export class GraphError extends Error {
 
 const defaultBaseUrlRoot = 'https://graph.microsoft.com';
 
-type Options = (http.Client | http.ClientOptions) & {
+type Options = (HttpClient | HttpClientOptions) & {
   /** Graph service root. By default, the global commercial URL "https://graph.microsoft.com" is used,
    * but certain tenants may wish to override this to direct Graph API calls to a different cloud instance.
    */
@@ -64,22 +67,22 @@ type GraphOptions = {
  */
 export class Client {
   protected baseUrlRoot;
-  protected _http: http.Client;
-  protected betaHttp?: http.Client;
+  protected _http: HttpClient;
+  protected betaHttp?: HttpClient;
 
   /**
    * The underlying HTTP client, pre-configured with Graph base URL and headers.
    * Use for raw Graph API requests not covered by endpoint functions.
    */
-  get http(): http.Client {
+  get http(): HttpClient {
     return this._http;
   }
 
   /**
    * Creates a Graph client.
    *
-   * @param options - The HTTP client to use; an existing {@link http.Client} will be cloned,
-   * or an {@link http.ClientOptions} bag will be used to build a new one.
+   * @param options - The HTTP client to use; an existing {@link HttpClient} will be cloned,
+   * or an {@link HttpClientOptions} bag will be used to build a new one.
    * HTTP-level settings like headers, interceptors, and timeouts belong here.
    * @param graphOptions - Graph-specific options. Takes precedence over `options.baseUrlRoot`
    * when both are set.
@@ -95,7 +98,7 @@ export class Client {
   constructor(options?: Options, graphOptions?: GraphOptions) {
     this.baseUrlRoot = graphOptions?.baseUrlRoot ?? options?.baseUrlRoot ?? defaultBaseUrlRoot;
     if (!options) {
-      this._http = new http.Client({
+      this._http = new HttpClient({
         baseUrl: `${this.baseUrlRoot}/v1.0`,
         headers: {
           'Content-Type': 'application/json',
@@ -111,7 +114,7 @@ export class Client {
         },
       });
     } else {
-      this._http = new http.Client({
+      this._http = new HttpClient({
         ...options,
         baseUrl: `${this.baseUrlRoot}/v1.0`,
         headers: {
@@ -192,7 +195,7 @@ export class Client {
     }
   }
 
-  private getHttpClient(schemaVersion: SchemaVersion): http.Client {
+  private getHttpClient(schemaVersion: SchemaVersion): HttpClient {
     if (schemaVersion === 'v1.0') {
       return this._http;
     }

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -1,4 +1,4 @@
-import * as http from '@microsoft/teams.common/http';
+import { type RequestConfig } from '@microsoft/teams.common';
 
 export type SchemaVersion = 'beta' | 'v1.0';
 
@@ -8,7 +8,7 @@ export type SchemaVersion = 'beta' | 'v1.0';
  */
 export type CallOptions = {
   /** HTTP request configuration */
-  requestConfig?: http.RequestConfig;
+  requestConfig?: RequestConfig;
 };
 
 export type ParamDefs = Partial<Record<'query' | 'header' | 'path', string[]>>;
@@ -20,6 +20,6 @@ export type EndpointRequest<TResponse> = {
   paramDefs?: ParamDefs;
   params?: Record<string, any>;
   body?: any;
-  config?: http.RequestConfig;
+  config?: RequestConfig;
   responseType?: TResponse;
 };

--- a/packages/graph/src/utils/url.ts
+++ b/packages/graph/src/utils/url.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 
-import * as http from '@microsoft/teams.common/http';
+import { type RequestConfig } from '@microsoft/teams.common';
 
 import { ParamDefs } from '../types';
 
@@ -25,8 +25,8 @@ export function getInjectedUrl(
 export function getInjectedRequestConfig(
   params: ParamDefs,
   data: Record<string, any>,
-  requestConfig?: http.RequestConfig,
-): http.RequestConfig | undefined {
+  requestConfig?: RequestConfig,
+): RequestConfig | undefined {
   const paramHeaders = (params.header ?? []).reduce<Record<string, any>>(
     (agg, param) => {
       if (data[param]) {

--- a/packages/openai/src/audio.ts
+++ b/packages/openai/src/audio.ts
@@ -3,7 +3,7 @@ import OpenAI, { toFile } from 'openai';
 import { Fetch } from 'openai/core.mjs';
 
 import { IAudioModel, TextToAudioParams, AudioToTextParams } from '@microsoft/teams.ai';
-import { ILogger, ConsoleLogger } from '@microsoft/teams.common/logging';
+import { ILogger, ConsoleLogger } from '@microsoft/teams.common';
 
 export type OpenAIAudioPluginOptions = {
   readonly model: string;

--- a/packages/openai/src/chat.ts
+++ b/packages/openai/src/chat.ts
@@ -10,7 +10,7 @@ import {
   Message,
   ModelMessage,
 } from '@microsoft/teams.ai';
-import { ConsoleLogger, ILogger } from '@microsoft/teams.common/logging';
+import { ConsoleLogger, ILogger } from '@microsoft/teams.common';
 
 export type ChatCompletionCreateParams = Omit<
   OpenAI.ChatCompletionCreateParams,

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release$"


### PR DESCRIPTION
## Summary

Brings `main` into `release` for the 2.0.11 release, with quoted-replies (PR #482) excluded.

Single squashed commit containing the diff between `release` (2.0.10) and `main`, minus the quoted-replies feature.

## What's in this release

- All commits merged to main since 2.0.10 (the previous release), notably:
  - **Reactions GA** (PR #575) — `[Experimental]` removed; `ReactionClient.remove()` → `delete()`
  - User-agent fix (PR #573)
  - Prompt Preview Support (PR #536)
  - Various dependency bumps and bug fixes

## What's NOT in this release

**Quoted-replies feature (PR #482) is excluded:**
- `prependQuote()`, `addQuote()` builder methods — absent
- `context.quote()` and quote-aware `reply()` behavior — reverted to legacy `replyToId` + blockquote
- `examples/quoting` — removed
- QR-related tests — removed

**Kept intentionally:**
- `QuotedReplyEntity` type stays in the `Entity` union so inbound activities carrying `quotedReply` entities still parse
- `addTargetedMessageInfo` runtime strip-QR logic (filters `e.type === 'quotedReply'`) — preserves prompt-preview cleanup

## Version

`version.json`: `2.0.10` → `2.0.11`

## Test plan

- [x] `npm run lint` — 33/33 packages
- [x] `npm run build` — 35/35 packages
- [x] `npm run test` — 730/730 tests across 61 suites
- [x] `npm pack --workspaces` — all tarballs produced; verified `quoted-reply-entity.d.ts` ships in `@microsoft/teams.api`; no `prependQuote`/`addQuote` symbols in bundled `dist/`
- [ ] ADO Public publish pipeline (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CI note

skip-test-verification — the `release` branch is out of sync with `main` for three template/example pairs (templates: `ai`; examples: `echo`, `graph`). This PR brings them along as part of the bulk main→release merge but doesn't try to re-pair them, since that's an orthogonal fix and would muddy this PR's "single squashed release diff" intent.
