### PR TITLE
Bump version to 2.0.12-preview; fix stray np in publish.yml

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -57,7 +57,7 @@ extends:
             container: host
 
         - task: NodeTool@0
-np          displayName: 'Use Node 24.x'
+          displayName: 'Use Node 24.x'
           inputs:
             versionSpec: '24.x'
             checkLatest: true

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.11-preview.{height}",
+  "version": "2.0.12-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release$"


### PR DESCRIPTION
## Summary
- Bumps `version.json` from `2.0.11-preview.{height}` to `2.0.12-preview.{height}` post-2.0.11 release
- Removes stray `np` prefix on the `Use Node 24.x` step in `.azdo/publish.yml` that was generating spurious pipeline noise

## Test plan
- [ ] Verify next CI build picks up `2.0.12-preview.x` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)