### PR TITLE
Sample: opt targeted-messages example into slash commands

### DIFF
--- a/examples/targeted-messages/README.md
+++ b/examples/targeted-messages/README.md
@@ -9,10 +9,20 @@ Targeted messages are messages that only a specific recipient can see - other pa
 | Command | Behavior |
 |---------|----------|
 | `test send` | Sends a targeted message (only you see it) |
-| `test reply` | Replies with a targeted message |
 | `test update` | Sends a targeted message, then updates it after 3 seconds |
-| `test delete` | Sends a targeted message, then deletes it after 5 seconds |
+| `test delete` | Sends a targeted message, then deletes it after 3 seconds |
+| `test public` | Sends a public reply (visible to everyone) |
+| `test inbound` | Reads `activity.recipient.isTargeted` and reports whether the inbound message was targeted at the bot |
 | `help` | Shows available commands |
+
+## Manifest configuration
+
+The `appPackage/manifest.json` uses `manifestVersion: "devPreview"` because the slash-command opt-in fields are only defined in the devPreview schema:
+
+- `bots[].supportsTargetedMessages: true` — opts the bot into receiving slash-command-style targeted messages.
+- `bots[].commandLists[].triggers: ["slash"]` — declares the listed commands as slash commands. They appear in the Teams `/` picker for group chats and channels.
+
+Slash commands arrive at the bot as regular `MessageActivity` events with `activity.recipient.isTargeted === true`, which the `test inbound` handler in this sample demonstrates.
 
 ## Testing in a Group Chat
 

--- a/examples/targeted-messages/appPackage/manifest.json
+++ b/examples/targeted-messages/appPackage/manifest.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.20/MicrosoftTeams.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "version": "1.0.0",
-  "manifestVersion": "1.20",
+  "manifestVersion": "devPreview",
   "id": "${{TEAMS_APP_ID}}",
   "name": {
     "short": "targeted-messages",
@@ -40,7 +40,21 @@
       "isNotificationOnly": false,
       "supportsCalling": false,
       "supportsVideo": false,
-      "supportsFiles": false
+      "supportsFiles": false,
+      "supportsTargetedMessages": true,
+      "commandLists": [
+        {
+          "scopes": ["team", "groupChat"],
+          "triggers": ["slash"],
+          "commands": [
+            { "title": "test send", "description": "Send a targeted message visible only to you" },
+            { "title": "test update", "description": "Send a targeted message then update it after 3 seconds" },
+            { "title": "test delete", "description": "Send a targeted message then delete it after 3 seconds" },
+            { "title": "test public", "description": "Send a public message visible to everyone" },
+            { "title": "test inbound", "description": "Show whether the inbound message was targeted at the bot" }
+          ]
+        }
+      ]
     }
   ],
   "validDomains": ["${{BOT_DOMAIN}}", "*.botframework.com"],

--- a/examples/targeted-messages/src/index.ts
+++ b/examples/targeted-messages/src/index.ts
@@ -55,6 +55,16 @@ app.on('message', async ({ send, activity, api }) => {
       new MessageActivity('👋 This is a **targeted message** — only YOU can see this!')
         .withRecipient(activity.from, true)
     );
+  } else if (text.includes('test inbound')) {
+    // Detect whether the inbound message was itself targeted at the bot
+    // (i.e. delivered as a slash command). Slash commands arrive as message
+    // activities with `activity.recipient.isTargeted === true`.
+    const wasTargeted = activity.recipient?.isTargeted === true;
+    await send(
+      wasTargeted
+        ? '✅ Your message was delivered to me as a targeted message.'
+        : 'ℹ️ Your message was delivered to me as a regular (broadcast) message.'
+    );
   } else if (text.includes('help')) {
     await send(
       '**🎯 Targeted Messages Demo**\n\n' +
@@ -62,7 +72,8 @@ app.on('message', async ({ send, activity, api }) => {
       '- `test send` - Send a targeted message (only visible to you)\n' +
       '- `test update` - Send a targeted message, then update it after 3 seconds\n' +
       '- `test delete` - Send a targeted message, then delete it after 3 seconds\n' +
-      '- `test public` - Send a public reply (visible to all)\n\n' +
+      '- `test public` - Send a public reply (visible to all)\n' +
+      '- `test inbound` - Show whether the inbound message was targeted at the bot\n\n' +
       '_Targeted messages are only visible to you, even in group chats!_'
     );
   } else {


### PR DESCRIPTION
Updates the `targeted-messages` example manifest to opt into slash commands per the docs spec (microsoft/teams-sdk#2843, MicrosoftDocs/msteams-docs#14182), and adds a handler that demonstrates how slash commands surface to the bot.

## Changes

- **`examples/targeted-messages/appPackage/manifest.json`**:
  - Bump `$schema` and `manifestVersion` to `devPreview` (the slash-commands opt-in fields are only defined in the devPreview schema today).
  - Add `bots[].supportsTargetedMessages: true` to opt the bot into receiving slash-command-style targeted messages.
  - Add `bots[].commandLists[].triggers: ["slash"]` declaring `test send` / `test update` / `test delete` / `test public` / `test inbound` as slash commands surfaced in the Teams `/` picker (scoped to `team` and `groupChat`).
- **`examples/targeted-messages/src/index.ts`** — new `test inbound` handler that reads `activity.recipient?.isTargeted` and reports whether the inbound message was delivered as a targeted message (the signal slash commands arrive with).
- **`examples/targeted-messages/README.md`** — refreshed commands table, new "Manifest configuration" section documenting the new fields.

## Test plan

- [x] `npx turbo build --filter=@examples/targeted-messages` clean
- [x] `examples/targeted-messages/appPackage/manifest.json` validates against the Teams devPreview schema (placeholder `${{...}}` tokens excepted)
- [x] Sample bot's `test inbound` handler verified live in Teams: broadcast branch fires when the inbound is not targeted (the targeted branch will fire once slash commands start delivering with `recipient.isTargeted = true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)