### PR TITLE
SuggestedActionSubmitActivity for suggestedAction/submit invoke

### DIFF
--- a/examples/suggested-action/README.md
+++ b/examples/suggested-action/README.md
@@ -1,0 +1,25 @@
+# Example: Suggested Action Submit
+
+A bot that demonstrates the `Action.Submit` suggested action and the `suggestedActions/submit` invoke it produces when clicked.
+
+## Behavior
+
+| Trigger | Behavior |
+|---------|----------|
+| Any user message | Bot replies with `Approve` / `Reject` suggested-action chips (`type: "Action.Submit"`, each with a structured `value`) |
+| User clicks a chip | Platform dispatches a `suggestedActions/submit` invoke; bot reads `activity.value` and echoes it back |
+
+## Notes
+
+- `Action.Submit` chips do not post a chat-visible message on the user's behalf — only the bot receives the click as a typed invoke.
+- The chip's `value` is delivered verbatim on the activity's `value` field.
+
+## Experimental API
+
+`'Action.Submit'` card action type, `ISuggestedActionSubmitInvokeActivity`, and the `suggested-action.submit` route are marked `@experimental` because the underlying platform feature is still rolling out.
+
+## Run
+
+```bash
+npm run dev
+```

--- a/examples/suggested-action/eslint.config.js
+++ b/examples/suggested-action/eslint.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@microsoft/teams.config/eslint.config').default;

--- a/examples/suggested-action/package.json
+++ b/examples/suggested-action/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@examples/suggested-action",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "main": "dist/index",
+  "types": "dist/index",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "clean": "npx rimraf ./dist",
+    "lint": "npx eslint",
+    "lint:fix": "npx eslint --fix",
+    "build": "npx tsc",
+    "start": "node .",
+    "dev": "tsx watch -r dotenv/config src/index.ts",
+    "dev:teamsfx": "npx cross-env NODE_OPTIONS='--inspect=9239' npx env-cmd -f .env npm run dev",
+    "dev:teamsfx:testtool": "npx cross-env NODE_OPTIONS='--inspect=9239' npx env-cmd -f .env npm run dev",
+    "dev:teamsfx:launch-testtool": "npx env-cmd --silent -f env/.env.testtool teamsapptester start"
+  },
+  "dependencies": {
+    "@microsoft/teams.apps": "*"
+  },
+  "devDependencies": {
+    "@microsoft/teams.config": "*",
+    "@types/node": "^22.5.4",
+    "dotenv": "^16.4.5",
+    "rimraf": "^6.0.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.4.5",
+    "env-cmd": "latest"
+  }
+}

--- a/examples/suggested-action/src/index.ts
+++ b/examples/suggested-action/src/index.ts
@@ -1,0 +1,33 @@
+import { MessageActivity, SuggestedActions } from '@microsoft/teams.api';
+import { App } from '@microsoft/teams.apps';
+import { ConsoleLogger } from '@microsoft/teams.common';
+
+const app = new App({
+  logger: new ConsoleLogger('@examples/suggested-action', { level: 'debug' }),
+});
+
+// Reply to any user message with two Action.Submit suggested-action chips.
+app.on('message', async ({ send }) => {
+  const reply = new MessageActivity('Approve or reject the request:');
+  reply.suggestedActions = {
+    to: [],
+    actions: [
+      { type: 'Action.Submit', title: 'Approve', value: { vote: 'approve' } },
+      { type: 'Action.Submit', title: 'Reject', value: { vote: 'reject' } },
+    ],
+  } satisfies SuggestedActions;
+
+  await send(reply);
+});
+
+// Handle the resulting suggestedActions/submit invoke when the user clicks a chip.
+app.on('suggested-action.submit', async ({ send, activity, log }) => {
+  const serializedValue = activity.value != null
+    ? JSON.stringify(activity.value)
+    : '<none>';
+
+  log.info(`[SUGGESTED_ACTION_SUBMIT] value=${serializedValue}`);
+  await send(`Got suggestedActions/submit with value: ${serializedValue}`);
+});
+
+app.start().catch(console.error);

--- a/examples/suggested-action/tsconfig.json
+++ b/examples/suggested-action/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@microsoft/teams.config/tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -554,16 +554,6 @@
         "typescript": "^5.4.5"
       }
     },
-    "examples/http-adapters/node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "examples/http-adapters/node_modules/accepts": {
       "version": "2.0.0",
       "license": "MIT",
@@ -790,6 +780,7 @@
     "examples/lights": {
       "name": "@examples/lights",
       "version": "0.0.6",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@microsoft/teams.ai": "*",
@@ -1307,6 +1298,23 @@
         "typescript": "^5.4.5"
       }
     },
+    "examples/suggested-action": {
+      "name": "@examples/suggested-action",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/teams.apps": "*"
+      },
+      "devDependencies": {
+        "@microsoft/teams.config": "*",
+        "@types/node": "^22.5.4",
+        "dotenv": "^16.4.5",
+        "env-cmd": "latest",
+        "rimraf": "^6.0.1",
+        "tsx": "^4.20.6",
+        "typescript": "^5.4.5"
+      }
+    },
     "examples/tab": {
       "name": "@examples/tab",
       "version": "0.0.6",
@@ -1368,6 +1376,7 @@
     "external/a2a": {
       "name": "@microsoft/teams.a2a",
       "version": "0.0.0",
+      "deprecated": "@microsoft/teams.a2a is deprecated. Use `@a2a-js/sdk` directly with a dedicated AI framework like the `openai` SDK. See examples/a2a for the new pattern.",
       "license": "MIT",
       "dependencies": {
         "@microsoft/teams.ai": "*",
@@ -1392,6 +1401,7 @@
     "external/mcp": {
       "name": "@microsoft/teams.mcp",
       "version": "0.0.0",
+      "deprecated": "@microsoft/teams.mcp is deprecated. Use `@modelcontextprotocol/sdk` directly. See examples/ai-mcp and examples/mcp-server for the new pattern.",
       "license": "MIT",
       "dependencies": {
         "@microsoft/teams.ai": "*",
@@ -1416,6 +1426,7 @@
     "external/mcpclient": {
       "name": "@microsoft/teams.mcpclient",
       "version": "0.0.0",
+      "deprecated": "@microsoft/teams.mcpclient is deprecated. Use `@modelcontextprotocol/sdk` directly with a dedicated AI framework like the `openai` SDK. See examples/ai-mcp for the new pattern.",
       "license": "MIT",
       "dependencies": {
         "@microsoft/teams.common": "*"
@@ -2993,10 +3004,6 @@
       "resolved": "examples/http-adapters",
       "link": true
     },
-    "node_modules/@examples/lights": {
-      "resolved": "examples/lights",
-      "link": true
-    },
     "node_modules/@examples/mcp-server": {
       "resolved": "examples/mcp-server",
       "link": true
@@ -3019,6 +3026,10 @@
     },
     "node_modules/@examples/reactions": {
       "resolved": "examples/reactions",
+      "link": true
+    },
+    "node_modules/@examples/suggested-action": {
+      "resolved": "examples/suggested-action",
       "link": true
     },
     "node_modules/@examples/tab": {
@@ -20185,6 +20196,7 @@
     "packages/ai": {
       "name": "@microsoft/teams.ai",
       "version": "0.0.0",
+      "deprecated": "@microsoft/teams.ai is deprecated. Use a dedicated AI framework directly (e.g., the `openai` SDK with `chat.completions.runTools`). See examples/ai-mcp for the new pattern.",
       "license": "MIT",
       "dependencies": {
         "@microsoft/teams.common": "*"
@@ -21090,6 +21102,7 @@
     "packages/openai": {
       "name": "@microsoft/teams.openai",
       "version": "0.0.0",
+      "deprecated": "@microsoft/teams.openai is deprecated. Use the `openai` SDK directly (the `AzureOpenAI` client with `chat.completions.runTools`). See examples/ai-mcp for the new pattern.",
       "license": "MIT",
       "dependencies": {
         "@azure/openai": "^2.0.0",

--- a/packages/api/src/activities/invoke/index.ts
+++ b/packages/api/src/activities/invoke/index.ts
@@ -6,6 +6,7 @@ import { IHandoffActionInvokeActivity } from './handoff-action';
 import { MessageInvokeActivity } from './message';
 import { MessageExtensionInvokeActivity } from './message-extension';
 import { SignInInvokeActivity } from './sign-in';
+import { ISuggestedActionSubmitInvokeActivity } from './suggested-action-submit';
 import { TabInvokeActivity } from './tab';
 import { TaskInvokeActivity } from './task';
 
@@ -19,7 +20,8 @@ export type InvokeActivity =
   | MessageInvokeActivity
   | IHandoffActionInvokeActivity
   | SignInInvokeActivity
-  | AdaptiveCardInvokeActivity;
+  | AdaptiveCardInvokeActivity
+  | ISuggestedActionSubmitInvokeActivity;
 
 export * from './file-consent';
 export * from './execute-action';
@@ -30,4 +32,5 @@ export * from './task';
 export * from './message';
 export * from './handoff-action';
 export * from './sign-in';
+export * from './suggested-action-submit';
 export * from './adaptive-card';

--- a/packages/api/src/activities/invoke/suggested-action-submit.spec.ts
+++ b/packages/api/src/activities/invoke/suggested-action-submit.spec.ts
@@ -1,0 +1,26 @@
+import { ISuggestedActionSubmitInvokeActivity } from './suggested-action-submit';
+
+describe('SuggestedActionSubmitInvokeActivity', () => {
+  it('should match the expected wire format', () => {
+    const activity: ISuggestedActionSubmitInvokeActivity = {
+      type: 'invoke',
+      name: 'suggestedActions/submit',
+      value: { vote: 'approve' },
+    } as ISuggestedActionSubmitInvokeActivity;
+
+    expect(activity.type).toEqual('invoke');
+    expect(activity.name).toEqual('suggestedActions/submit');
+    expect(activity.value).toStrictEqual({ vote: 'approve' });
+  });
+
+  it('should accept any structured value', () => {
+    const activity: ISuggestedActionSubmitInvokeActivity = {
+      type: 'invoke',
+      name: 'suggestedActions/submit',
+      value: { action: 'reject', reason: 'budget exceeded' },
+    } as ISuggestedActionSubmitInvokeActivity;
+
+    expect(activity.name).toEqual('suggestedActions/submit');
+    expect(activity.value).toStrictEqual({ action: 'reject', reason: 'budget exceeded' });
+  });
+});

--- a/packages/api/src/activities/invoke/suggested-action-submit.ts
+++ b/packages/api/src/activities/invoke/suggested-action-submit.ts
@@ -1,0 +1,19 @@
+import { IActivity } from '../activity';
+
+/**
+ * Sent when the user clicks a suggested action of type `Action.Submit`.
+ * The structured payload authored on the suggested action is delivered via `value`.
+ *
+ * @experimental This API is in preview and may change in the future.
+ */
+export interface ISuggestedActionSubmitInvokeActivity extends IActivity<'invoke'> {
+  /**
+   * The name of the operation associated with an invoke or event activity.
+   */
+  name: 'suggestedActions/submit';
+
+  /**
+   * The structured value authored on the suggested action chip.
+   */
+  value: any;
+}

--- a/packages/api/src/models/card/card-action.ts
+++ b/packages/api/src/models/card/card-action.ts
@@ -9,6 +9,12 @@ export type CardActionType =
   | 'signin'
   | 'call'
   | 'invoke'
+  /**
+   * Suggested action of type Action.Submit. The action's value is delivered to the bot
+   * as a `suggestedActions/submit` invoke without sending a chat-visible message.
+   *
+   * @experimental This API is in preview and may change in the future.
+   */
   | 'Action.Submit';
 
 export type CardAction = {

--- a/packages/api/src/models/card/card-action.ts
+++ b/packages/api/src/models/card/card-action.ts
@@ -8,7 +8,8 @@ export type CardActionType =
   | 'downloadFile'
   | 'signin'
   | 'call'
-  | 'invoke';
+  | 'invoke'
+  | 'Action.Submit';
 
 export type CardAction = {
   /**

--- a/packages/api/src/models/invoke-response.ts
+++ b/packages/api/src/models/invoke-response.ts
@@ -58,6 +58,7 @@ type InvokeResponseBody = {
   'message/fetchTask': TaskModuleResponse;
   'message/submitAction': void;
   'handoff/action': void;
+  'suggestedActions/submit': void;
   'signin/tokenExchange': TokenExchangeInvokeResponse | void;
   'signin/verifyState': void;
   'signin/failure': void;

--- a/packages/apps/src/router/router.spec.ts
+++ b/packages/apps/src/router/router.spec.ts
@@ -201,6 +201,19 @@ describe('Router', () => {
       } as any)).toHaveLength(1);
     });
 
+    it('should select suggested-action.submit routes', () => {
+      const router = new Router();
+      const handler = jest.fn();
+
+      router.on('invoke', handler);
+      router.on('suggested-action.submit', handler);
+
+      expect(router.select({
+        type: 'invoke',
+        name: 'suggestedActions/submit'
+      } as any)).toHaveLength(2);
+    });
+
     it('should select file consent routes', () => {
       const router = new Router();
       const handler = jest.fn();

--- a/packages/apps/src/routes/invoke/index.ts
+++ b/packages/apps/src/routes/invoke/index.ts
@@ -43,6 +43,7 @@ type InvokeAliases = {
   'message/fetchTask': 'message.fetch-task';
   'message/submitAction': 'message.submit';
   'handoff/action': 'handoff.action';
+  'suggestedActions/submit': 'suggested-action.submit';
   'signin/tokenExchange': 'signin.token-exchange';
   'signin/verifyState': 'signin.verify-state';
   'signin/failure': 'signin.failure';
@@ -70,6 +71,7 @@ export const INVOKE_ALIASES: InvokeAliases = {
   'message/fetchTask': 'message.fetch-task',
   'message/submitAction': 'message.submit',
   'handoff/action': 'handoff.action',
+  'suggestedActions/submit': 'suggested-action.submit',
   'signin/tokenExchange': 'signin.token-exchange',
   'signin/verifyState': 'signin.verify-state',
   'signin/failure': 'signin.failure',


### PR DESCRIPTION
Adds support for suggestedActions/submit invoke activity - dispatched by the platform when a user clicks an Action.Submit suggested-action click. 

- New `ISuggestedActionSubmitInvokeActivity` interface and `suggested-action.submit` route alias. 
- New `Action.Submit` value in CardActionType for constructing outbound suggested-action chips. 
- Marked `@experimental` until the platform feature stabilizes. 
- New examples/suggested-actions sample app.

<img width="1017" height="243" alt="image" src="https://github.com/user-attachments/assets/12861bfd-73a0-4337-a917-500825ace815" />
