### PR TITLE
Default targeted replies for targeted inbound messages

### DIFF
--- a/examples/targeted-messages/README.md
+++ b/examples/targeted-messages/README.md
@@ -52,7 +52,7 @@ To make a command behave like `send private` or `send public`:
 4. Only send the private response when that check passes.
 5. You do **not** need to manually set `withRecipient(activity.from, true)` in this example — `ActivityContext` will mark the response targeted automatically when the inbound message was targeted.
 
-That combo makes the bot treat the slash-command message as private and lets you choose whether the response should be private or public. If the response still looks wrong, restart the example so it picks up the latest `ActivityContext` change.
+That combo makes the bot treat the slash-command message as private and lets you choose whether the response should be private or public.
 
 ## Run
 

--- a/examples/targeted-messages/README.md
+++ b/examples/targeted-messages/README.md
@@ -12,6 +12,7 @@ Targeted messages are messages that only a specific recipient can see - other pa
 | `test update` | Sends a targeted message, then updates it after 3 seconds |
 | `test delete` | Sends a targeted message, then deletes it after 3 seconds |
 | `test public` | Sends a public reply (visible to everyone) |
+| `send private` | Only sends a private message if the incoming message is targeted |
 | `test inbound` | Reads `activity.recipient.isTargeted` and reports whether the inbound message was targeted at the bot |
 | `help` | Shows available commands |
 
@@ -24,15 +25,33 @@ The `appPackage/manifest.json` uses `manifestVersion: "devPreview"` because the 
 
 Slash commands arrive at the bot as regular `MessageActivity` events with `activity.recipient.isTargeted === true`, which the `test inbound` handler in this sample demonstrates.
 
+The `send private` command is useful for verifying whether the inbound message was targeted. If it isn't, the bot says `Send it to me privately first!`.
+
 ## Testing in a Group Chat
 
 To properly test targeted messages:
 
 1. Add the bot to a **group chat** with 2+ people
-2. Send `test send`
+2. Pick the command from the `/` slash menu, or type `send private` as a slash command
 3. **Expected result**: 
-   - You (the sender) should see the "🔒 Targeted message"
+   - You (the sender) should see the targeted message
    - Other participants should **NOT** see it
+
+If you type `send private` as a normal message in 1:1 chat, it will not come through as a targeted message, so the private branch won’t fire.
+
+You can also try `send private` to verify the bot only sends a private response when the inbound message is targeted.
+
+## Making a command private
+
+To make a command behave like `send private`:
+
+1. In `appPackage/manifest.json`, keep `supportsTargetedMessages: true` on the bot.
+2. Add the command under a slash-triggered `commandLists` entry for `team` / `groupChat`.
+3. In your handler, check `activity.recipient?.isTargeted === true`.
+4. Only send the private response when that check passes.
+5. You do **not** need to manually set `withRecipient(activity.from, true)` in this example — `ActivityContext` will mark the response targeted automatically when the inbound message was targeted.
+
+That combo makes the bot treat the slash-command message as private and keeps the response private too. If the response still looks public, restart the example so it picks up the latest `ActivityContext` change.
 
 ## Run
 

--- a/examples/targeted-messages/README.md
+++ b/examples/targeted-messages/README.md
@@ -12,6 +12,7 @@ Targeted messages are messages that only a specific recipient can see - other pa
 | `test update` | Sends a targeted message, then updates it after 3 seconds |
 | `test delete` | Sends a targeted message, then deletes it after 3 seconds |
 | `test public` | Sends a public reply (visible to everyone) |
+| `send public` | Only sends a public message if the incoming message is targeted |
 | `send private` | Only sends a private message if the incoming message is targeted |
 | `test inbound` | Reads `activity.recipient.isTargeted` and reports whether the inbound message was targeted at the bot |
 | `help` | Shows available commands |
@@ -25,7 +26,7 @@ The `appPackage/manifest.json` uses `manifestVersion: "devPreview"` because the 
 
 Slash commands arrive at the bot as regular `MessageActivity` events with `activity.recipient.isTargeted === true`, which the `test inbound` handler in this sample demonstrates.
 
-The `send private` command is useful for verifying whether the inbound message was targeted. If it isn't, the bot says `Send it to me privately first!`.
+The `send public` and `send private` commands are useful for verifying whether the inbound message was targeted. If it isn't, the bot says `Send it to me privately first!`.
 
 ## Testing in a Group Chat
 
@@ -39,11 +40,11 @@ To properly test targeted messages:
 
 If you type `send private` as a normal message in 1:1 chat, it will not come through as a targeted message, so the private branch won’t fire.
 
-You can also try `send private` to verify the bot only sends a private response when the inbound message is targeted.
+You can also try `send public` to verify the bot only sends a public response when the inbound message is targeted, or `send private` to verify the bot only sends a private response when the inbound message is targeted.
 
 ## Making a command private
 
-To make a command behave like `send private`:
+To make a command behave like `send private` or `send public`:
 
 1. In `appPackage/manifest.json`, keep `supportsTargetedMessages: true` on the bot.
 2. Add the command under a slash-triggered `commandLists` entry for `team` / `groupChat`.
@@ -51,7 +52,7 @@ To make a command behave like `send private`:
 4. Only send the private response when that check passes.
 5. You do **not** need to manually set `withRecipient(activity.from, true)` in this example — `ActivityContext` will mark the response targeted automatically when the inbound message was targeted.
 
-That combo makes the bot treat the slash-command message as private and keeps the response private too. If the response still looks public, restart the example so it picks up the latest `ActivityContext` change.
+That combo makes the bot treat the slash-command message as private and lets you choose whether the response should be private or public. If the response still looks wrong, restart the example so it picks up the latest `ActivityContext` change.
 
 ## Run
 

--- a/examples/targeted-messages/appPackage/manifest.json
+++ b/examples/targeted-messages/appPackage/manifest.json
@@ -51,6 +51,7 @@
             { "title": "test update", "description": "Send a targeted message then update it after 3 seconds" },
             { "title": "test delete", "description": "Send a targeted message then delete it after 3 seconds" },
             { "title": "test public", "description": "Send a public message visible to everyone" },
+            { "title": "send private", "description": "Only send a private message if the inbound message is targeted" },
             { "title": "test inbound", "description": "Show whether the inbound message was targeted at the bot" }
           ]
         }

--- a/examples/targeted-messages/appPackage/manifest.json
+++ b/examples/targeted-messages/appPackage/manifest.json
@@ -51,7 +51,7 @@
             { "title": "test update", "description": "Send a targeted message then update it after 3 seconds" },
             { "title": "test delete", "description": "Send a targeted message then delete it after 3 seconds" },
             { "title": "test public", "description": "Send a public message visible to everyone" },
-            { "title": "send public", "description": "Only send a public message if the inbound message is targeted" },
+            { "title": "send public", "description": "Only send a public message if the inbound message is targeted; pass a recipient to opt out" },
             { "title": "send private", "description": "Only send a private message if the inbound message is targeted" },
             { "title": "test inbound", "description": "Show whether the inbound message was targeted at the bot" }
           ]

--- a/examples/targeted-messages/appPackage/manifest.json
+++ b/examples/targeted-messages/appPackage/manifest.json
@@ -51,6 +51,7 @@
             { "title": "test update", "description": "Send a targeted message then update it after 3 seconds" },
             { "title": "test delete", "description": "Send a targeted message then delete it after 3 seconds" },
             { "title": "test public", "description": "Send a public message visible to everyone" },
+            { "title": "send public", "description": "Only send a public message if the inbound message is targeted" },
             { "title": "send private", "description": "Only send a private message if the inbound message is targeted" },
             { "title": "test inbound", "description": "Show whether the inbound message was targeted at the bot" }
           ]

--- a/examples/targeted-messages/src/index.ts
+++ b/examples/targeted-messages/src/index.ts
@@ -55,6 +55,18 @@ app.on('message', async ({ send, activity, api }) => {
     await send(
       new MessageActivity('📋 Here is the public result — everyone can see this!')
     );
+  } else if (text.includes('send public')) {
+    const isTargeted = activity.recipient?.isTargeted === true;
+    console.log('[send public]', { isTargeted });
+
+    if (!isTargeted) {
+      await send('Send it to me privately first!');
+    } else {
+      await send(
+        new MessageActivity('🌍 This is a **public message** — everyone can see this!')
+          .withRecipient(activity.from)
+      );
+    }
   } else if (text.includes('test send')) {
     await send(
       new MessageActivity('👋 This is a **targeted message** — only YOU can see this!')
@@ -89,6 +101,7 @@ app.on('message', async ({ send, activity, api }) => {
       '- `test update` - Send a targeted message, then update it after 3 seconds\n' +
       '- `test delete` - Send a targeted message, then delete it after 3 seconds\n' +
       '- `test public` - Send a public reply (visible to all)\n' +
+      '- `send public` - Only send a public message if the incoming message is targeted\n' +
       '- `send private` - Only send a private message if the incoming message is targeted\n' +
       '- `test inbound` - Show whether the inbound message was targeted at the bot\n\n' +
       '_Targeted messages are only visible to you, even in group chats!_'

--- a/examples/targeted-messages/src/index.ts
+++ b/examples/targeted-messages/src/index.ts
@@ -10,6 +10,11 @@ const app = new App({
 
 app.on('message', async ({ send, activity, api }) => {
   const text = activity.text?.toLowerCase() || '';
+  console.log('[message received]', {
+    text: activity.text,
+    isTargeted: activity.recipient?.isTargeted === true,
+    from: activity.from?.id,
+  });
 
   if (text.includes('test update')) {
     const conversationId = activity.conversation?.id ?? '';
@@ -55,6 +60,17 @@ app.on('message', async ({ send, activity, api }) => {
       new MessageActivity('👋 This is a **targeted message** — only YOU can see this!')
         .withRecipient(activity.from, true)
     );
+  } else if (text.includes('send private')) {
+    const isTargeted = activity.recipient?.isTargeted === true;
+    console.log('[send private]', { isTargeted });
+
+    if (!isTargeted) {
+      await send('Send it to me privately first!');
+    } else {
+      await send(
+        new MessageActivity('🔒 This is a **private message** — only YOU can see this!')
+      );
+    }
   } else if (text.includes('test inbound')) {
     // Detect whether the inbound message was itself targeted at the bot
     // (i.e. delivered as a slash command). Slash commands arrive as message
@@ -73,6 +89,7 @@ app.on('message', async ({ send, activity, api }) => {
       '- `test update` - Send a targeted message, then update it after 3 seconds\n' +
       '- `test delete` - Send a targeted message, then delete it after 3 seconds\n' +
       '- `test public` - Send a public reply (visible to all)\n' +
+      '- `send private` - Only send a private message if the incoming message is targeted\n' +
       '- `test inbound` - Show whether the inbound message was targeted at the bot\n\n' +
       '_Targeted messages are only visible to you, even in group chats!_'
     );

--- a/examples/targeted-messages/src/index.ts
+++ b/examples/targeted-messages/src/index.ts
@@ -10,11 +10,6 @@ const app = new App({
 
 app.on('message', async ({ send, activity, api }) => {
   const text = activity.text?.toLowerCase() || '';
-  console.log('[message received]', {
-    text: activity.text,
-    isTargeted: activity.recipient?.isTargeted === true,
-    from: activity.from?.id,
-  });
 
   if (text.includes('test update')) {
     const conversationId = activity.conversation?.id ?? '';
@@ -57,11 +52,11 @@ app.on('message', async ({ send, activity, api }) => {
     );
   } else if (text.includes('send public')) {
     const isTargeted = activity.recipient?.isTargeted === true;
-    console.log('[send public]', { isTargeted });
 
     if (!isTargeted) {
       await send('Send it to me privately first!');
     } else {
+      // Passing a recipient opts out of the auto-targeting default.
       await send(
         new MessageActivity('🌍 This is a **public message** — everyone can see this!')
           .withRecipient(activity.from)
@@ -74,7 +69,6 @@ app.on('message', async ({ send, activity, api }) => {
     );
   } else if (text.includes('send private')) {
     const isTargeted = activity.recipient?.isTargeted === true;
-    console.log('[send private]', { isTargeted });
 
     if (!isTargeted) {
       await send('Send it to me privately first!');

--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -230,6 +230,14 @@ describe('ActivityContext', () => {
       // Reply prepends blockquote, but send() auto-populates addTargetedMessageInfo
       // which strips quotedReply entities — the blockquote text remains since it's
       // the legacy format, not the <quoted .../> placeholder.
+      expect(sentActivity.recipient).toEqual(
+        expect.objectContaining({
+          id: 'test-user',
+          name: 'Test User',
+          role: 'user',
+          isTargeted: true,
+        })
+      );
       expect(sentActivity.entities).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -259,6 +267,28 @@ describe('ActivityContext', () => {
     });
 
     describe('targeted messages', () => {
+      it('defaults send to targeted when inbound message is targeted', async () => {
+        const activity = new MessageActivity('Hello world')
+          .withFrom({ id: 'test-user', name: 'Test User', role: 'user' })
+          .withRecipient({ id: 'bot-id', name: 'Bot', role: 'bot' }, true)
+          .withChannelId('test-channel')
+          .withConversation({ id: 'test-conversation', conversationType: 'channel', isGroup: false })
+          .withId('test-activity-id');
+        context = buildActivityContext(activity);
+
+        await context.send('Secret message');
+
+        expect(mockSender.send).toHaveBeenCalledTimes(1);
+        expect(mockSender.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: 'Secret message',
+            type: 'message',
+            recipient: expect.objectContaining({ id: 'test-user', name: 'Test User', role: 'user', isTargeted: true }),
+          }),
+          mockRef
+        );
+      });
+
       it('sends targeted message with recipient from incoming activity', async () => {
         const activity = buildIncomingMessageActivity('Hello world');
         context = buildActivityContext(activity);
@@ -274,6 +304,28 @@ describe('ActivityContext', () => {
             text: 'Secret message',
             type: 'message',
             recipient: expect.objectContaining({ id: 'test-user', name: 'Test User', role: 'user', isTargeted: true }),
+          }),
+          mockRef
+        );
+      });
+
+      it('allows explicitly public send from a targeted inbound message', async () => {
+        const activity = new MessageActivity('Hello world')
+          .withFrom({ id: 'test-user', name: 'Test User', role: 'user' })
+          .withRecipient({ id: 'bot-id', name: 'Bot', role: 'bot' }, true)
+          .withChannelId('test-channel')
+          .withConversation({ id: 'test-conversation', conversationType: 'channel', isGroup: false })
+          .withId('test-activity-id');
+        context = buildActivityContext(activity);
+
+        await context.send(new MessageActivity('Public message').withRecipient(activity.from));
+
+        expect(mockSender.send).toHaveBeenCalledTimes(1);
+        expect(mockSender.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: 'Public message',
+            type: 'message',
+            recipient: expect.objectContaining({ id: 'test-user', name: 'Test User', role: 'user' }),
           }),
           mockRef
         );

--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -364,6 +364,8 @@ describe('ActivityContext', () => {
           }),
           mockRef
         );
+        const sentActivity = (mockSender.send as jest.Mock).mock.calls[0][0];
+        expect(sentActivity.entities).toBeUndefined();
       });
 
       it('allows explicitly public send from a targeted inbound message', async () => {

--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -289,6 +289,63 @@ describe('ActivityContext', () => {
         );
       });
 
+      it('does not default send to targeted for a different conversation', async () => {
+        const activity = new MessageActivity('Hello world')
+          .withFrom({ id: 'test-user', name: 'Test User', role: 'user' })
+          .withRecipient({ id: 'bot-id', name: 'Bot', role: 'bot' }, true)
+          .withChannelId('test-channel')
+          .withConversation({ id: 'test-conversation', conversationType: 'channel', isGroup: false })
+          .withId('test-activity-id');
+        context = buildActivityContext(activity);
+
+        const otherRef = {
+          ...mockRef,
+          conversation: {
+            ...mockRef.conversation,
+            id: 'other-conversation',
+          },
+        };
+
+        await context.send('Secret message', otherRef);
+
+        expect(mockSender.send).toHaveBeenCalledTimes(1);
+        expect(mockSender.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: 'Secret message',
+            type: 'message',
+          }),
+          otherRef
+        );
+        const sentActivity = (mockSender.send as jest.Mock).mock.calls[0][0];
+        expect(sentActivity.recipient).toBeUndefined();
+        expect(sentActivity.entities).toBeUndefined();
+      });
+
+      it('does not default send to targeted when an explicit different recipient is supplied', async () => {
+        const activity = new MessageActivity('Hello world')
+          .withFrom({ id: 'test-user', name: 'Test User', role: 'user' })
+          .withRecipient({ id: 'bot-id', name: 'Bot', role: 'bot' }, true)
+          .withChannelId('test-channel')
+          .withConversation({ id: 'test-conversation', conversationType: 'channel', isGroup: false })
+          .withId('test-activity-id');
+        context = buildActivityContext(activity);
+
+        const otherRecipient = { id: 'other-user', name: 'Other User', role: 'user' as const };
+        await context.send(new MessageActivity('Public message').withRecipient(otherRecipient));
+
+        expect(mockSender.send).toHaveBeenCalledTimes(1);
+        const sentActivity = (mockSender.send as jest.Mock).mock.calls[0][0];
+        expect(sentActivity).toEqual(
+          expect.objectContaining({
+            text: 'Public message',
+            type: 'message',
+            recipient: expect.objectContaining(otherRecipient),
+          })
+        );
+        expect(sentActivity.recipient.isTargeted).toBeUndefined();
+        expect(sentActivity.entities).toBeUndefined();
+      });
+
       it('sends targeted message with recipient from incoming activity', async () => {
         const activity = buildIncomingMessageActivity('Hello world');
         context = buildActivityContext(activity);
@@ -329,6 +386,7 @@ describe('ActivityContext', () => {
             recipient: expect.objectContaining({ id: 'test-user', name: 'Test User', role: 'user' }),
           })
         );
+        expect(sentActivity.recipient.isTargeted).toBeUndefined();
         expect(sentActivity.entities).toBeUndefined();
       });
 

--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -321,14 +321,15 @@ describe('ActivityContext', () => {
         await context.send(new MessageActivity('Public message').withRecipient(activity.from));
 
         expect(mockSender.send).toHaveBeenCalledTimes(1);
-        expect(mockSender.send).toHaveBeenCalledWith(
+        const sentActivity = (mockSender.send as jest.Mock).mock.calls[0][0];
+        expect(sentActivity).toEqual(
           expect.objectContaining({
             text: 'Public message',
             type: 'message',
             recipient: expect.objectContaining({ id: 'test-user', name: 'Test User', role: 'user' }),
-          }),
-          mockRef
+          })
         );
+        expect(sentActivity.entities).toBeUndefined();
       });
 
       it('sends targeted message with explicit recipient id', async () => {

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -1,6 +1,7 @@
 import {
   Activity,
   ActivityLike,
+  ActivityParams,
   cardAttachment,
   ConversationAccount,
   ConversationReference,
@@ -194,7 +195,7 @@ export interface IBaseActivityContext<T extends Activity = Activity, TExtraCtx e
 export type IActivityContext<T extends Activity = Activity, TExtraContext = unknown> =
   IBaseActivityContext<T> & (TExtraContext extends Record<string, any> ? TExtraContext : {});
 
-type MessageSendParams = ReturnType<typeof toActivityParams> & Partial<IMessageActivity>;
+type MessageActivityParams = ActivityParams & Partial<IMessageActivity> & { type: 'message' };
 
 export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {} = {}>
   implements IBaseActivityContext<T, TExtraCtx> {
@@ -254,7 +255,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
    * @param conversationRef optional conversation reference to send to a different conversation or thread
    */
   async send(activity: ActivityLike, conversationRef?: ConversationReference) {
-    const params = toActivityParams(activity) as MessageSendParams;
+    const params = toActivityParams(activity);
 
     if (this.shouldOutboundBeAutoTargeted(params, conversationRef)) {
       this.applyTargetedRecipient(params);
@@ -278,7 +279,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     return this.activity.recipient?.isTargeted === true;
   }
 
-  private shouldOutboundBeAutoTargeted(params: MessageSendParams, conversationRef?: ConversationReference) {
+  private shouldOutboundBeAutoTargeted(params: ActivityParams, conversationRef?: ConversationReference) {
     if (params.type !== 'message') {
       return false;
     }
@@ -298,18 +299,18 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     return !conversationRef || conversationRef.conversation?.id === this.ref.conversation?.id;
   }
 
-  private applyTargetedRecipient(params: MessageSendParams) {
+  private applyTargetedRecipient(params: ActivityParams) {
     params.recipient = {
       ...this.activity.from,
       isTargeted: true,
     };
   }
 
-  private isTargetedOutbound(params: MessageSendParams) {
+  private isTargetedOutbound(params: ActivityParams): params is MessageActivityParams {
     return params.type === 'message' && params.recipient?.isTargeted === true;
   }
 
-  private stripQuotedReplyMetadata(params: MessageSendParams) {
+  private stripQuotedReplyMetadata(params: MessageActivityParams) {
     if (params.entities) {
       params.entities = params.entities.filter((e) => e.type !== 'quotedReply');
     }
@@ -319,7 +320,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     }
   }
 
-  private addTargetedMessageInfo(params: MessageSendParams) {
+  private addTargetedMessageInfo(params: MessageActivityParams) {
     if (params.entities?.some((e) => e.type === 'targetedMessageInfo')) {
       return;
     }

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -275,66 +275,6 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     return await this.activitySender.send(params, conversationRef ?? this.ref);
   }
 
-  private isIncomingTargeted() {
-    return this.activity.recipient?.isTargeted === true;
-  }
-
-  private shouldOutboundBeAutoTargeted(params: ActivityParams, conversationRef?: ConversationReference) {
-    if (params.type !== 'message') {
-      return false;
-    }
-
-    if (!this.isIncomingTargeted()) {
-      return false;
-    }
-
-    if (!this.isSameConversation(conversationRef)) {
-      return false;
-    }
-
-    return !params.id && !params.recipient;
-  }
-
-  private isSameConversation(conversationRef?: ConversationReference) {
-    return !conversationRef || conversationRef.conversation?.id === this.ref.conversation?.id;
-  }
-
-  private applyTargetedRecipient(params: ActivityParams) {
-    params.recipient = {
-      ...this.activity.from,
-      isTargeted: true,
-    };
-  }
-
-  private isTargetedOutbound(params: ActivityParams): params is MessageActivityParams {
-    return params.type === 'message' && params.recipient?.isTargeted === true;
-  }
-
-  private stripQuotedReplyMetadata(params: MessageActivityParams) {
-    if (params.entities) {
-      params.entities = params.entities.filter((e) => e.type !== 'quotedReply');
-    }
-
-    if (params.text) {
-      params.text = params.text.replace(`<quoted messageId="${this.activity.id}"/>`, '').trim();
-    }
-  }
-
-  private addTargetedMessageInfo(params: MessageActivityParams) {
-    if (params.entities?.some((e) => e.type === 'targetedMessageInfo')) {
-      return;
-    }
-
-    if (!params.entities) {
-      params.entities = [];
-    }
-
-    params.entities.push({
-      type: 'targetedMessageInfo',
-      messageId: this.activity.id,
-    });
-  }
-
   /**
    * send an activity in the current conversation with a visual quote
    * of the inbound message.
@@ -482,6 +422,66 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
       signin: this.signin.bind(this),
       signout: this.signout.bind(this),
     };
+  }
+
+  private isIncomingTargeted() {
+    return this.activity.recipient?.isTargeted === true;
+  }
+
+  private shouldOutboundBeAutoTargeted(params: ActivityParams, conversationRef?: ConversationReference) {
+    if (params.type !== 'message') {
+      return false;
+    }
+
+    if (!this.isIncomingTargeted()) {
+      return false;
+    }
+
+    if (!this.isSameConversation(conversationRef)) {
+      return false;
+    }
+
+    return !params.id && !params.recipient;
+  }
+
+  private isSameConversation(conversationRef?: ConversationReference) {
+    return !conversationRef || conversationRef.conversation?.id === this.ref.conversation?.id;
+  }
+
+  private applyTargetedRecipient(params: ActivityParams) {
+    params.recipient = {
+      ...this.activity.from,
+      isTargeted: true,
+    };
+  }
+
+  private isTargetedOutbound(params: ActivityParams): params is MessageActivityParams {
+    return params.type === 'message' && params.recipient?.isTargeted === true;
+  }
+
+  private stripQuotedReplyMetadata(params: MessageActivityParams) {
+    if (params.entities) {
+      params.entities = params.entities.filter((e) => e.type !== 'quotedReply');
+    }
+
+    if (params.text) {
+      params.text = params.text.replace(`<quoted messageId="${this.activity.id}"/>`, '').trim();
+    }
+  }
+
+  private addTargetedMessageInfo(params: MessageActivityParams) {
+    if (params.entities?.some((e) => e.type === 'targetedMessageInfo')) {
+      return;
+    }
+
+    if (!params.entities) {
+      params.entities = [];
+    }
+
+    params.entities.push({
+      type: 'targetedMessageInfo',
+      messageId: this.activity.id,
+    });
   }
 
 }

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -263,6 +263,9 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     if (this.isTargetedOutbound(params)) {
       this.stripQuotedReplyMetadata(params);
 
+      // `targetedMessageInfo` points at the original targeted inbound message for prompt preview.
+      // Do not add it for generic targeted sends; Teams can reject it if the referenced activity
+      // was not itself delivered as a targeted message.
       if (this.isIncomingTargeted()) {
         this.addTargetedMessageInfo(params);
       }

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -194,6 +194,8 @@ export interface IBaseActivityContext<T extends Activity = Activity, TExtraCtx e
 export type IActivityContext<T extends Activity = Activity, TExtraContext = unknown> =
   IBaseActivityContext<T> & (TExtraContext extends Record<string, any> ? TExtraContext : {});
 
+type MessageSendParams = ReturnType<typeof toActivityParams> & Partial<IMessageActivity>;
+
 export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {} = {}>
   implements IBaseActivityContext<T, TExtraCtx> {
   appId!: string;
@@ -252,46 +254,78 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
    * @param conversationRef optional conversation reference to send to a different conversation or thread
    */
   async send(activity: ActivityLike, conversationRef?: ConversationReference) {
-    const params = toActivityParams(activity);
+    const params = toActivityParams(activity) as MessageSendParams;
 
-    const isIncomingTargeted = this.activity.recipient?.isTargeted === true;
-
-    // If the inbound message was targeted, default outgoing messages to targeted too.
-    // Callers can still opt out by explicitly supplying a non-targeted recipient.
-    if (params.type === 'message' && isIncomingTargeted && !params.id && !params.recipient) {
-      params.recipient = {
-        ...this.activity.from,
-        isTargeted: true,
-      };
+    if (this.shouldOutboundBeAutoTargeted(params, conversationRef)) {
+      this.applyTargetedRecipient(params);
     }
 
-    const isOutgoingTargeted = params.type === 'message' && params.recipient?.isTargeted === true;
-
-    // Auto-populate targetedMessageInfo entity for prompt preview
-    // when replying to a targeted message in the reactive flow.
-    // Only do this for responses that are actually targeted.
-    if (params.type === 'message' && isIncomingTargeted && isOutgoingTargeted) {
-      if (params.entities) {
-        params.entities = params.entities.filter((e) => e.type !== 'quotedReply');
-      }
-
-      if (params.text) {
-        params.text = params.text.replace(`<quoted messageId="${this.activity.id}"/>`, '').trim();
-      }
-
-      if (!params.entities?.some((e) => e.type === 'targetedMessageInfo')) {
-        if (!params.entities) {
-          params.entities = [];
-        }
-
-        params.entities.push({
-          type: 'targetedMessageInfo',
-          messageId: this.activity.id,
-        });
-      }
+    if (this.isTargetedOutbound(params)) {
+      this.stripQuotedReplyMetadata(params);
+      this.addTargetedMessageInfo(params);
     }
 
     return await this.activitySender.send(params, conversationRef ?? this.ref);
+  }
+
+  private isIncomingTargeted() {
+    return this.activity.recipient?.isTargeted === true;
+  }
+
+  private shouldOutboundBeAutoTargeted(params: MessageSendParams, conversationRef?: ConversationReference) {
+    if (params.type !== 'message') {
+      return false;
+    }
+
+    if (!this.isIncomingTargeted()) {
+      return false;
+    }
+
+    if (!this.isSameConversation(conversationRef)) {
+      return false;
+    }
+
+    return !params.id && !params.recipient;
+  }
+
+  private isSameConversation(conversationRef?: ConversationReference) {
+    return !conversationRef || conversationRef.conversation?.id === this.ref.conversation?.id;
+  }
+
+  private applyTargetedRecipient(params: MessageSendParams) {
+    params.recipient = {
+      ...this.activity.from,
+      isTargeted: true,
+    };
+  }
+
+  private isTargetedOutbound(params: MessageSendParams) {
+    return params.type === 'message' && params.recipient?.isTargeted === true;
+  }
+
+  private stripQuotedReplyMetadata(params: MessageSendParams) {
+    if (params.entities) {
+      params.entities = params.entities.filter((e) => e.type !== 'quotedReply');
+    }
+
+    if (params.text) {
+      params.text = params.text.replace(`<quoted messageId="${this.activity.id}"/>`, '').trim();
+    }
+  }
+
+  private addTargetedMessageInfo(params: MessageSendParams) {
+    if (params.entities?.some((e) => e.type === 'targetedMessageInfo')) {
+      return;
+    }
+
+    if (!params.entities) {
+      params.entities = [];
+    }
+
+    params.entities.push({
+      type: 'targetedMessageInfo',
+      messageId: this.activity.id,
+    });
   }
 
   /**

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -262,7 +262,10 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
 
     if (this.isTargetedOutbound(params)) {
       this.stripQuotedReplyMetadata(params);
-      this.addTargetedMessageInfo(params);
+
+      if (this.isIncomingTargeted()) {
+        this.addTargetedMessageInfo(params);
+      }
     }
 
     return await this.activitySender.send(params, conversationRef ?? this.ref);

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -254,26 +254,23 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
   async send(activity: ActivityLike, conversationRef?: ConversationReference) {
     const params = toActivityParams(activity);
 
+    const isIncomingTargeted = this.activity.recipient?.isTargeted === true;
+
     // If the inbound message was targeted, default outgoing messages to targeted too.
     // Callers can still opt out by explicitly supplying a non-targeted recipient.
-    if (
-      params.type === 'message' &&
-      this.activity.recipient?.isTargeted === true &&
-      !params.id &&
-      !params.recipient
-    ) {
+    if (params.type === 'message' && isIncomingTargeted && !params.id && !params.recipient) {
       params.recipient = {
         ...this.activity.from,
         isTargeted: true,
       };
     }
 
+    const isOutgoingTargeted = params.type === 'message' && params.recipient?.isTargeted === true;
+
     // Auto-populate targetedMessageInfo entity for prompt preview
     // when replying to a targeted message in the reactive flow.
-    if (
-      params.type === 'message' &&
-      this.activity.recipient?.isTargeted === true
-    ) {
+    // Only do this for responses that are actually targeted.
+    if (params.type === 'message' && isIncomingTargeted && isOutgoingTargeted) {
       if (params.entities) {
         params.entities = params.entities.filter((e) => e.type !== 'quotedReply');
       }

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -254,12 +254,18 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
   async send(activity: ActivityLike, conversationRef?: ConversationReference) {
     const params = toActivityParams(activity);
 
-    // For targeted send, set the recipient if not already set.
-    // For targeted update (params.id exists), we don't update recipient since recipient cannot be changed.
-    if (params.type === 'message' && params.recipient?.isTargeted && !params.id) {
-      if (!params.recipient) {
-        params.recipient = this.activity.from;
-      }
+    // If the inbound message was targeted, default outgoing messages to targeted too.
+    // Callers can still opt out by explicitly supplying a non-targeted recipient.
+    if (
+      params.type === 'message' &&
+      this.activity.recipient?.isTargeted === true &&
+      !params.id &&
+      !params.recipient
+    ) {
+      params.recipient = {
+        ...this.activity.from,
+        isTargeted: true,
+      };
     }
 
     // Auto-populate targetedMessageInfo entity for prompt preview


### PR DESCRIPTION
## Summary
- make `send` / `reply` default to targeted when replying to a targeted inbound message
- keep explicit public sends, different recipients, and different conversation refs public
- split the targeting logic into helpers so the rules are less spicy
- keep `targetedMessageInfo` limited to targeted inbound replies, so normal explicit targeted sends still work
- add targeted-messages example commands for `send private` and `send public`

Note: this also cleans up a pre-existing dead branch from when `isTargeted` moved onto `recipient` — `params.recipient?.isTargeted` already means `params.recipient` exists.

<img width="943" height="571" alt="image" src="https://github.com/user-attachments/assets/dd828854-3d32-4617-9eb3-3b32c17dbe75" />


## Test plan
- `cd packages/apps && npx jest src/contexts/activity.test.ts --runInBand`
- `cd packages/apps && npm run build`
- `cd examples/targeted-messages && npm run build`