### PR TITLE
Security hardening: tighten cross-origin policies

### DIFF
--- a/packages/apps/src/http/express-adapter.spec.ts
+++ b/packages/apps/src/http/express-adapter.spec.ts
@@ -171,6 +171,30 @@ describe('ExpressAdapter', () => {
       }
     });
 
+    it('should not set Access-Control-Allow-Origin on served files', async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'express-static-test-'));
+      const testHtml = path.join(tmpDir, 'index.html');
+      fs.writeFileSync(testHtml, '<html><body>Test Page</body></html>');
+
+      try {
+        server = http.createServer();
+        adapter = new ExpressAdapter(server);
+
+        adapter.serveStatic('/tabs/test', tmpDir);
+
+        const response = await supertest(server)
+          .get('/tabs/test/index.html')
+          .expect(200);
+
+        expect(response.headers['access-control-allow-origin']).toBeUndefined();
+        expect(response.headers['access-control-allow-methods']).toBeUndefined();
+        expect(response.headers['access-control-allow-headers']).toBeUndefined();
+      } finally {
+        fs.unlinkSync(testHtml);
+        fs.rmdirSync(tmpDir);
+      }
+    });
+
     it('should serve index.html when accessing directory path with trailing slash', async () => {
       // Create a temporary directory with an index.html file
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'express-static-test-'));

--- a/packages/apps/src/http/express-adapter.ts
+++ b/packages/apps/src/http/express-adapter.ts
@@ -1,6 +1,5 @@
 import http from 'http';
 
-import cors from 'cors';
 import express from 'express';
 
 import { ConsoleLogger, ILogger } from '@microsoft/teams.common';
@@ -118,10 +117,17 @@ export class ExpressAdapter implements IHttpServerAdapter {
   }
 
   /**
-   * Serve static files from a directory
+   * Serve static files from a directory.
+   *
+   * No CORS headers are set: Teams loads tab content inside an iframe (subject
+   * to the page's CSP `frame-ancestors` directive), not via cross-origin
+   * `fetch`/XHR, so a wildcard `Access-Control-Allow-Origin` was permissive
+   * without a corresponding use case. Callers that need cross-origin reads of
+   * the served assets should layer their own CORS middleware at the consuming
+   * route.
    */
   serveStatic(path: string, directory: string): void {
-    this.express.use(path, cors(), express.static(directory));
+    this.express.use(path, express.static(directory));
   }
 
   /**

--- a/packages/dev/src/plugin.ts
+++ b/packages/dev/src/plugin.ts
@@ -74,7 +74,20 @@ export class DevtoolsPlugin {
     const dist = path.join(__dirname, 'devtools-web');
     this.express = express();
     this.http = http.createServer(this.express);
-    this.ws = new WebSocketServer({ server: this.http, path: '/devtools/sockets' });
+    this.ws = new WebSocketServer({
+      server: this.http,
+      path: '/devtools/sockets',
+
+      // Reject cross-origin WebSocket upgrades. The DevTools UI is always
+      // loaded same-origin, so Origin must equal the request Host; absent
+      // Origin is rejected.
+      verifyClient: (info: { origin: string; secure: boolean; req: http.IncomingMessage }) => {
+        const host = info.req.headers.host;
+        if (!host || !info.origin) return false;
+        const expected = `${info.secure ? 'https' : 'http'}://${host}`;
+        return info.origin.toLowerCase() === expected.toLowerCase();
+      },
+    });
     this.ws.on('connection', this.onSocketConnection.bind(this));
     this.express.use('/devtools', express.static(dist));
     // Catch-all route for SPA - must come after static middleware


### PR DESCRIPTION
## Summary

Two narrow tightenings of cross-origin policy in the TS SDK.

## Changes

### 1. `ExpressAdapter.serveStatic` — drop wildcard `cors()` middleware

Tab static content was served with a wildcard `Access-Control-Allow-Origin` header. Teams loads tab content inside an iframe, governed by CSP `frame-ancestors`, not by CORS. The wildcard served no documented use case and risked surprising any future endpoint mounted under the same path.

Callers that legitimately need cross-origin reads of the served assets can layer their own CORS middleware at the consuming route.

### 2. `DevtoolsPlugin` WebSocket — require same-origin upgrades

The DevTools WebSocket server previously accepted upgrades from any origin (the `ws` library's default when no `verifyClient` is provided). The DevTools UI is always loaded from the same origin as the bot server, so legitimate clients send an Origin header matching the request Host. A `verifyClient` callback now rejects upgrades whose Origin does not match the request Host; absent Origin is also rejected.

## What this does not change

- No public API change. No behavior change for in-app same-origin usage.
- `HttpPlugin` (already marked deprecated in-code) still uses a global `cors()`; that path will be removed with the plugin.

## Validation

- Full monorepo `npm run build`, `npm run test`, `npm run lint` clean.
- `examples/tab` sample: tab index, JS, and CSS still served with HTTP 200 and no `Access-Control-Allow-Origin` header. Cross-origin probe returns the asset with no `Access-Control-Allow-*` headers, so browsers would block cross-origin fetch as intended.
- `examples/echo` with devtools enabled: same-origin WebSocket upgrade succeeds (101); cross-origin and missing-Origin probes return 401 from the `ws` library.