### PR TITLE
fix(deps): Audit for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@types/express": "^5.0.0",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -83,7 +83,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -138,7 +138,7 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -155,7 +155,7 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "dotenv": "^16.5.0",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -172,7 +172,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -191,7 +191,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -242,7 +242,7 @@
         "@types/node": "^22.5.4",
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -397,7 +397,7 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -415,7 +415,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -470,7 +470,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -487,7 +487,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -808,7 +808,9 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "4.13.0",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -818,13 +820,47 @@
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^4.2.0",
-        "@azure/msal-node": "^3.5.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
         "open": "^10.1.0",
         "tslib": "^2.2.0"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/msal-browser": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
+      "integrity": "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.2"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/msal-common": {
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+      "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/msal-node": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+      "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.2",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@azure/logger": {
@@ -5708,7 +5744,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6906,7 +6944,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7865,12 +7905,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -8415,10 +8483,12 @@
       }
     },
     "node_modules/browserify-sign": {
-      "version": "4.2.5",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+      "integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
       "license": "ISC",
       "dependencies": {
-        "bn.js": "^5.2.2",
+        "bn.js": "^5.2.3",
         "browserify-rsa": "^4.1.1",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
@@ -10865,10 +10935,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -10957,7 +11029,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -11955,7 +12029,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -14602,7 +14678,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.3",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14669,7 +14747,9 @@
       }
     },
     "node_modules/nodemon/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15580,8 +15660,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -16349,7 +16434,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18469,7 +18556,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -18859,7 +18948,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -19144,22 +19235,6 @@
         "node": ">=20"
       }
     },
-    "packages/apps/node_modules/axios": {
-      "version": "1.15.2",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "packages/apps/node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/botbuilder": {
       "name": "@microsoft/teams.botbuilder",
       "version": "0.0.0",
@@ -19249,22 +19324,6 @@
         "node": ">=20"
       }
     },
-    "packages/common/node_modules/axios": {
-      "version": "1.15.2",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "packages/common/node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/config": {
       "name": "@microsoft/teams.config",
       "version": "0.0.0",
@@ -19310,22 +19369,6 @@
       },
       "peerDependencies": {
         "@microsoft/teams.apps": "*"
-      }
-    },
-    "packages/dev/node_modules/axios": {
-      "version": "1.15.2",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "packages/dev/node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/devtools": {


### PR DESCRIPTION
## Summary

Lockfile-only bumps via `npm audit fix` (no `--force`). Closes all high-severity advisories.

**Before**: 20 prod vulns (2 high, 14 moderate, 4 low)
**After**: 13 prod vulns (0 high, 9 moderate, 4 low)

## What got bumped

| Package | From → To | Severity cleared |
|---|---|---|
| axios | 1.13.5 → 1.16.1 | **high** — 15 advisories (SSRF via `NO_PROXY` bypass, prototype pollution in `validateStatus` / `parseReviver` / `withXSRFToken` / form-data, CRLF injection in multipart, null byte injection, unbounded recursion DoS) |
| fast-uri | 3.1.0 → 3.1.2 | **high** |
| ws | 8.19.0 → 8.21.0 | moderate (uninitialized memory disclosure) |
| @azure/msal-node | added 5.2.2 (hoisted; older copies stay under botbuilder) | moderate (uuid transitive) |
| uuid | 11.1.0 → 11.1.1 | moderate |
| @azure/identity | 4.13.0 → 4.13.1 | moderate |
| express-rate-limit | 8.3.1 → 8.5.2 | moderate (via ip-address) |
| ip-address | 10.1.0 → 10.2.0 | moderate |
| brace-expansion | 5.0.5 → 5.0.6, 2.0.2 → 2.1.1 | moderate |
| browserify-sign | 4.2.5 → 4.2.6 | low (elliptic) |
| picomatch | 2.3.1 → 2.3.2 | — |
| proxy-from-env | 1.1.0 → 2.1.0 | — |

## What's NOT addressed

13 advisories remain, all in the **Bot Framework SDK** transitive chain via `packages/botbuilder` (which pins `botbuilder@4.23.1`):

- `botbuilder`, `botbuilder-core`, `botframework-connector`, `botframework-schema`, `botframework-streaming`
- `@azure/core-http`, nested `@azure/msal-node` (under botbuilder/botframework-connector), `uuid` (transitive)
- `restify` (direct dep of botframework)
- `elliptic`, `crypto-browserify`, `browserify-sign`, `create-ecdh` (low-severity cryptography chain via botbuilder)

`npm audit fix`'s suggested resolution is `botbuilder@4.11.2`, which is **older** than our pinned 4.23.1 and would lose features. Declining. Same shape as teams.py's `jsonpickle` situation — Bot Framework SDK is archived and pins old transitives.

## Test plan

- [x] `npm run build` — all 33 targets clean
- [x] `npm test` — all 14 targets, 279+ unit tests pass
- [x] **E2E smoke test** — echo bot against `cg-test-bot-py` via canary ABS:
  - Inbound activity received, JWT trust-boundary validated successfully (also exercises #586 hardening)
  - msal-node token acquisition succeeded
  - Bot replied via axios POST to canary `serviceUrl`
  - Reply visible in Teams client