### PR TITLE
Bump version to 2.0.13-preview; RELEASE.md adds tagging step

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,6 +23,20 @@ This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.Gi
    - Increment the patch version (e.g. `"2.0.7-preview.{height}"` → `"2.0.8-preview.{height}"`)
    - Commit and push (or PR)
 
+5. **Create the git tag and GitHub Release page** after packages land on npm:
+   ```bash
+   gh release create v<version> -R microsoft/teams.ts \
+     --target release --title "v<version>" --draft \
+     --generate-notes --notes-start-tag v<previous-version>
+   ```
+   The auto-generated notes walk back from `release`, which is squash-merged — so the list will only show the release PR. To get the real PR delta from `main`, query by date:
+   ```bash
+   gh api -X GET search/issues \
+     -f q='repo:microsoft/teams.ts is:pr is:merged base:main merged:>=<previous-release-publish-date>' \
+     --jq '.items[] | "* \(.title) by @\(.user.login) in \(.html_url)"' | tac > /tmp/notes.md
+   ```
+   Edit the draft (`gh release edit <id> --notes-file /tmp/notes.md`), then publish from the GitHub UI to create the tag.
+
 ## Hotfixes
 
 To fix a bug in a released version without including new preview changes:

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.12-preview.{height}",
+  "version": "2.0.13-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release$"


### PR DESCRIPTION
## Summary

Post-2.0.12 housekeeping on main.

- `version.json`: `2.0.12-preview.{height}` → `2.0.13-preview.{height}` — preview builds off main start fresh height counters after the 2.0.12 stable cut. Mirrors PR #577.
- `RELEASE.md`: adds **step 5** to "Creating a Release" covering the git tag + GitHub Release page step, including the date-based `gh api` query that surfaces the real PR delta from main (auto-generated notes against the squash-merged release branch only show the release PR itself).

## Test plan

- [x] `cat version.json` shows `2.0.13-preview.{height}`
- [x] RELEASE.md renders cleanly in preview