### PR TITLE
Bump MSAL Node to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -850,19 +850,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/@azure/identity/node_modules/@azure/msal-node": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
-      "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/msal-common": "16.6.2",
-        "jsonwebtoken": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/@azure/logger": {
       "version": "1.3.0",
       "license": "MIT",
@@ -892,29 +879,25 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.8.10",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+      "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.17.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.6.2",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "15.17.0",
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+      "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@azure/msal-node/node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@azure/openai": {
@@ -19203,7 +19186,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-node": "^3.8.1",
+        "@azure/msal-node": "^5.2.2",
         "@microsoft/teams.api": "*",
         "@microsoft/teams.common": "*",
         "@microsoft/teams.graph": "*",

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -38,7 +38,7 @@
     "generate": "npx quicktype -s schema -l typescript ./manifest.schema.json -o ./src/manifest.ts --prefer-unions --prefer-types --just-types"
   },
   "dependencies": {
-    "@azure/msal-node": "^3.8.1",
+    "@azure/msal-node": "^5.2.2",
     "@microsoft/teams.api": "*",
     "@microsoft/teams.common": "*",
     "@microsoft/teams.graph": "*",

--- a/packages/apps/src/token-manager.spec.ts
+++ b/packages/apps/src/token-manager.spec.ts
@@ -40,7 +40,7 @@ const createMockAuthResult = (accessToken: string): AuthenticationResult => ({
   cloudGraphHostName: '',
   msGraphHost: '',
   code: '',
-  fromNativeBroker: false
+  fromPlatformBroker: false
 });
 
 describe('TokenManager', () => {


### PR DESCRIPTION
## Summary
- Bumps `@azure/msal-node` in `@microsoft/teams.apps` to v5.2.2.
- Updates the token manager test mock for MSAL's `fromNativeBroker` -> `fromPlatformBroker` rename.

## Why
- Gets our direct MSAL dependency onto the current v5 line and removes the direct vulnerable `uuid` dependency path from `@microsoft/teams.apps`.

## Interesting bits
- I left BotBuilder alone, so `npm audit` still reports the existing BotBuilder/Restify transitive stuff. No spicy force-downgrades today.

## Testing
Tested using User Managed Identity, FIC (UMI) and FIC system, and ofcourse secrets.