### PR TITLE
ci: switch publish pipeline to 1ES Official template for CodeQL/SDL

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -28,7 +28,7 @@ resources:
     ref: refs/tags/release
 
 extends:
-  template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     pool:
       name: 1ES-Teams-Windows-2022-DomoreexpGithub


### PR DESCRIPTION
Switch the publish pipeline from `1ES.Unofficial.PipelineTemplate` to `1ES.Official.PipelineTemplate`.

The Official template auto-injects CodeQL 3000 and CredScan on default-branch runs, which is required for SFI-PS2.1 (Continuous SDL) compliance.

This is the same one-line change made to teams.py in https://github.com/microsoft/teams.py/pull/366.