### PR TITLE
Cache federated identity MSAL clients

### DIFF
--- a/packages/apps/src/token-manager.spec.ts
+++ b/packages/apps/src/token-manager.spec.ts
@@ -386,6 +386,10 @@ describe('TokenManager', () => {
         const tokenManager = new TokenManager(mockSystemFICOptions, logger);
         const token = await tokenManager.getBotToken();
 
+        const clientAssertion = (ConfidentialClientApplication as jest.MockedClass<typeof ConfidentialClientApplication>).mock.calls[0][0].auth.clientAssertion;
+        expect(clientAssertion).toEqual(expect.any(Function));
+        await expect((clientAssertion as () => Promise<string>)()).resolves.toBe('mock-mi-token');
+
         expect(ManagedIdentityApplication).toHaveBeenCalledWith(
           expect.objectContaining({
             managedIdentityIdParams: undefined
@@ -400,7 +404,7 @@ describe('TokenManager', () => {
           expect.objectContaining({
             auth: expect.objectContaining({
               clientId: 'test-client-id',
-              clientAssertion: 'mock-mi-token',
+              clientAssertion: expect.any(Function),
               authority: 'https://login.microsoftonline.com/test-tenant-id'
             })
           })
@@ -429,6 +433,10 @@ describe('TokenManager', () => {
         const tokenManager = new TokenManager(mockUserFICOptions, logger);
         const token = await tokenManager.getBotToken();
 
+        const clientAssertion = (ConfidentialClientApplication as jest.MockedClass<typeof ConfidentialClientApplication>).mock.calls[0][0].auth.clientAssertion;
+        expect(clientAssertion).toEqual(expect.any(Function));
+        await expect((clientAssertion as () => Promise<string>)()).resolves.toBe('mock-umi-token');
+
         expect(ManagedIdentityApplication).toHaveBeenCalledWith(
           expect.objectContaining({
             managedIdentityIdParams: {
@@ -445,7 +453,7 @@ describe('TokenManager', () => {
           expect.objectContaining({
             auth: expect.objectContaining({
               clientId: 'test-client-id',
-              clientAssertion: 'mock-umi-token',
+              clientAssertion: expect.any(Function),
               authority: 'https://login.microsoftonline.com/test-tenant-id'
             })
           })
@@ -466,10 +474,27 @@ describe('TokenManager', () => {
         const tokenManager = new TokenManager(mockUserFICOptions, logger);
 
         await tokenManager.getBotToken();
+        const clientAssertion = (ConfidentialClientApplication as jest.MockedClass<typeof ConfidentialClientApplication>).mock.calls[0][0].auth.clientAssertion;
+        await (clientAssertion as () => Promise<string>)();
         expect(ManagedIdentityApplication).toHaveBeenCalledTimes(1);
 
-        await tokenManager.getGraphToken();
+        await (clientAssertion as () => Promise<string>)();
         expect(ManagedIdentityApplication).toHaveBeenCalledTimes(1);
+      });
+
+      it('should cache and reuse ConfidentialClientApplication per tenant', async () => {
+        mockConfidentialAcquireToken.mockResolvedValue(createMockAuthResult('mock-token'));
+
+        const tokenManager = new TokenManager(mockUserFICOptions, logger);
+
+        await tokenManager.getBotToken();
+        expect(ConfidentialClientApplication).toHaveBeenCalledTimes(1);
+
+        await tokenManager.getGraphToken();
+        expect(ConfidentialClientApplication).toHaveBeenCalledTimes(1);
+
+        await tokenManager.getGraphToken('other-tenant-id');
+        expect(ConfidentialClientApplication).toHaveBeenCalledTimes(2);
       });
     });
   });

--- a/packages/apps/src/token-manager.ts
+++ b/packages/apps/src/token-manager.ts
@@ -197,7 +197,7 @@ export class TokenManager {
         clientAssertion: async () => {
           const managedIdentityTokenRes = await this.getManagedIdentityClient(credentials).acquireToken({ resource: 'api://AzureADTokenExchange' });
           if (!managedIdentityTokenRes) {
-            throw new Error('Failed to get token');
+            throw new Error('Failed to acquire managed identity exchange token for federated identity credential');
           }
           return managedIdentityTokenRes.accessToken;
         },

--- a/packages/apps/src/token-manager.ts
+++ b/packages/apps/src/token-manager.ts
@@ -52,6 +52,7 @@ export class TokenManager {
   private _msalLogger: ILogger;
   private cloud: CloudEnvironment;
   private confidentialClientsByTenantId: Record<string, ConfidentialClientApplication> = {};
+  private federatedIdentityClientsByTenantId: Record<string, ConfidentialClientApplication> = {};
   private managedIdentityClient: ManagedIdentityApplication | null = null;
 
   constructor(options: TokenManagerOptions, logger: ILogger) {
@@ -155,18 +156,7 @@ export class TokenManager {
   }
 
   private async getTokenWithFederatedCredentials(credentials: FederatedIdentityCredentials, scope: string, tenantId: string) {
-    const managedIdentityClient = this.getManagedIdentityClient(credentials);
-    const managedIdentityTokenRes = await managedIdentityClient.acquireToken({ resource: 'api://AzureADTokenExchange' });
-    const confidentialClient = new ConfidentialClientApplication({
-      auth: {
-        clientId: credentials.clientId,
-        clientAssertion: managedIdentityTokenRes.accessToken,
-        authority: `${this.cloud.loginEndpoint}/${tenantId}`
-      },
-      system: {
-        loggerOptions: this.buildLoggerOptions()
-      }
-    });
+    const confidentialClient = this.getFederatedIdentityClient(credentials, tenantId);
     const result = await confidentialClient.acquireTokenByClientCredential({ scopes: [scope] });
     return this.handleTokenResponse(result);
   }
@@ -192,6 +182,32 @@ export class TokenManager {
       }
     });
     this.confidentialClientsByTenantId[tenantId] = client;
+    return client;
+  }
+
+  private getFederatedIdentityClient(credentials: FederatedIdentityCredentials, tenantId: string) {
+    const cachedClient = this.federatedIdentityClientsByTenantId[tenantId];
+    if (cachedClient) {
+      return cachedClient;
+    }
+
+    const client = new ConfidentialClientApplication({
+      auth: {
+        clientId: credentials.clientId,
+        clientAssertion: async () => {
+          const managedIdentityTokenRes = await this.getManagedIdentityClient(credentials).acquireToken({ resource: 'api://AzureADTokenExchange' });
+          if (!managedIdentityTokenRes) {
+            throw new Error('Failed to get token');
+          }
+          return managedIdentityTokenRes.accessToken;
+        },
+        authority: `${this.cloud.loginEndpoint}/${tenantId}`
+      },
+      system: {
+        loggerOptions: this.buildLoggerOptions()
+      }
+    });
+    this.federatedIdentityClientsByTenantId[tenantId] = client;
     return client;
   }
 


### PR DESCRIPTION
Cache the MSAL confidential client used by federated identity credentials.

Why:
Recreating it on every token request means MSAL never gets to use its internal token cache. Reusing it avoids extra token exchanges and makes the FIC path less chatty.

Interesting bits:
The managed identity token is now provided through MSAL's lazy clientAssertion callback, so we only fetch the exchange token when MSAL actually needs it.

Reviewer tips:
Start in packages/apps/src/token-manager.ts. The important bit is the FIC client cache and callback assertion.

Testing:
- Manual VM test of the FIC token flow