### PR TITLE
chore: prevent deprecated packages from being published

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -152,6 +152,8 @@ extends:
                 $packageJson = Get-Content $packageJsonPath | ConvertFrom-Json
                 if ($packageJson.private -eq $true) {
                   Write-Host "Skipping $($_.Name) (marked as private)"
+                } elseif ($packageJson.deprecated) {
+                  Write-Host "Skipping $($_.Name) (marked as deprecated)"
                 } else {
                   Write-Host "Packing $($_.Name)..."
                   Set-Location $_.FullName

--- a/external/a2a/package.json
+++ b/external/a2a/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@microsoft/teams.a2a",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
   "deprecated": "@microsoft/teams.a2a is deprecated. Use `@a2a-js/sdk` directly with a dedicated AI framework like the `openai` SDK. See examples/a2a for the new pattern.",
   "main": "./dist/index.js",

--- a/external/mcp/package.json
+++ b/external/mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@microsoft/teams.mcp",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
   "deprecated": "@microsoft/teams.mcp is deprecated. Use `@modelcontextprotocol/sdk` directly. See examples/ai-mcp and examples/mcp-server for the new pattern.",
   "main": "./dist/index.js",

--- a/external/mcpclient/package.json
+++ b/external/mcpclient/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@microsoft/teams.mcpclient",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
   "deprecated": "@microsoft/teams.mcpclient is deprecated. Use `@modelcontextprotocol/sdk` directly with a dedicated AI framework like the `openai` SDK. See examples/ai-mcp for the new pattern.",
   "main": "./dist/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@microsoft/teams.ai",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
   "deprecated": "@microsoft/teams.ai is deprecated. Use a dedicated AI framework directly (e.g., the `openai` SDK with `chat.completions.runTools`). See examples/ai-mcp for the new pattern.",
   "main": "./dist/index.js",

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@microsoft/teams.dev",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
+  "deprecated": "@microsoft/teams.dev is deprecated. Use Microsoft 365 Agents Playground (https://learn.microsoft.com/en-us/microsoft-365/agents-sdk/test-with-toolkit-project) instead for local testing of your agent.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@microsoft/teams.openai",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
   "deprecated": "@microsoft/teams.openai is deprecated. Use the `openai` SDK directly (the `AzureOpenAI` client with `chat.completions.runTools`). See examples/ai-mcp for the new pattern.",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Mark all deprecated packages as `private: true` so they are excluded from `npm pack` during publish runs. Also adds a `deprecated` field check in the publish pipeline as a secondary safeguard.

### Packages affected
- `@microsoft/teams.ai`
- `@microsoft/teams.openai`
- `@microsoft/teams.dev`
- `@microsoft/teams.mcp`
- `@microsoft/teams.mcpclient`
- `@microsoft/teams.a2a`

### Changes
1. Added `"private": true` to each deprecated package's `package.json`
2. Added `"deprecated"` field to `@microsoft/teams.dev` (was missing)
3. Updated `.azdo/publish.yml` to skip packages with a `deprecated` field

### Note
All packages except `@microsoft/teams.dev` are already marked deprecated on npm. `teams.dev` needs an org admin to run `npm deprecate`.