### PR TITLE
Remove ExperimentalTeamsQuotedReplies markers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@types/express": "^5.0.0",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -83,7 +83,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -139,7 +139,7 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -156,7 +156,7 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "dotenv": "^16.5.0",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -173,7 +173,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -192,7 +192,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -245,7 +245,7 @@
         "@types/node": "^22.5.4",
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -400,7 +400,7 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -418,7 +418,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -473,7 +473,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"
@@ -490,7 +490,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^16.4.5",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.4.5"

--- a/packages/api/src/activities/message/message.ts
+++ b/packages/api/src/activities/message/message.ts
@@ -105,7 +105,6 @@ export interface IMessageActivity extends IActivity<'message'> {
    * get all quoted reply entities from this message
    *
    * @experimental This API is coming soon and may change in the future.
-   * Diagnostic: ExperimentalTeamsQuotedReplies
    */
   getQuotedMessages(): QuotedReplyEntity[];
 }
@@ -387,7 +386,6 @@ export class MessageActivity extends Activity<'message'> implements IMessageActi
    * get all quoted reply entities from this message
    *
    * @experimental This API is coming soon and may change in the future.
-   * Diagnostic: ExperimentalTeamsQuotedReplies
    */
   getQuotedMessages(): QuotedReplyEntity[] {
     return (this.entities ?? []).filter(
@@ -438,7 +436,6 @@ export class MessageActivity extends Activity<'message'> implements IMessageActi
    * @returns this instance for chaining
    *
    * @experimental This API is coming soon and may change in the future.
-   * Diagnostic: ExperimentalTeamsQuotedReplies
    */
   addQuote(messageId: string, text?: string): this {
     if (!this.entities) {
@@ -461,7 +458,6 @@ export class MessageActivity extends Activity<'message'> implements IMessageActi
    * @param messageId - The IC3 message ID of the message to quote
    *
    * @experimental This API is coming soon and may change in the future.
-   * Diagnostic: ExperimentalTeamsQuotedReplies
    */
   prependQuote(messageId: string): this {
     if (!this.entities) {

--- a/packages/api/src/activities/message/message.ts
+++ b/packages/api/src/activities/message/message.ts
@@ -103,8 +103,6 @@ export interface IMessageActivity extends IActivity<'message'> {
 
   /**
    * get all quoted reply entities from this message
-   *
-   * @experimental This API is coming soon and may change in the future.
    */
   getQuotedMessages(): QuotedReplyEntity[];
 }
@@ -384,8 +382,6 @@ export class MessageActivity extends Activity<'message'> implements IMessageActi
 
   /**
    * get all quoted reply entities from this message
-   *
-   * @experimental This API is coming soon and may change in the future.
    */
   getQuotedMessages(): QuotedReplyEntity[] {
     return (this.entities ?? []).filter(
@@ -419,7 +415,6 @@ export class MessageActivity extends Activity<'message'> implements IMessageActi
    * @param isTargeted - If true, marks this as a targeted message visible only to the recipient
    * @returns this instance for chaining
    *
-   * @experimental This API is coming soon and may change in the future.
    * Diagnostic: ExperimentalTeamsTargeted
    */
   withRecipient(account: Account, isTargeted: boolean = false): this {
@@ -434,8 +429,6 @@ export class MessageActivity extends Activity<'message'> implements IMessageActi
    * @param messageId - The ID of the message to quote
    * @param text - Optional text, appended to the quoted message placeholder
    * @returns this instance for chaining
-   *
-   * @experimental This API is coming soon and may change in the future.
    */
   addQuote(messageId: string, text?: string): this {
     if (!this.entities) {
@@ -456,8 +449,6 @@ export class MessageActivity extends Activity<'message'> implements IMessageActi
    * Prepend a quotedReply entity and `<quoted messageId="..."/>` placeholder
    * before existing text. Used by reply()/quote() for quote-above-response.
    * @param messageId - The IC3 message ID of the message to quote
-   *
-   * @experimental This API is coming soon and may change in the future.
    */
   prependQuote(messageId: string): this {
     if (!this.entities) {

--- a/packages/api/src/models/entity/quoted-reply-entity.ts
+++ b/packages/api/src/models/entity/quoted-reply-entity.ts
@@ -1,7 +1,5 @@
 /**
  * Data for a quoted reply entity.
- *
- * @experimental This API is coming soon and may change in the future.
  */
 export type QuotedReplyData = {
   /**
@@ -43,8 +41,6 @@ export type QuotedReplyData = {
 
 /**
  * Entity containing quoted reply information.
- *
- * @experimental This API is coming soon and may change in the future.
  */
 export type QuotedReplyEntity = {
   readonly type: 'quotedReply';

--- a/packages/api/src/models/entity/quoted-reply-entity.ts
+++ b/packages/api/src/models/entity/quoted-reply-entity.ts
@@ -2,7 +2,6 @@
  * Data for a quoted reply entity.
  *
  * @experimental This API is coming soon and may change in the future.
- * Diagnostic: ExperimentalTeamsQuotedReplies
  */
 export type QuotedReplyData = {
   /**
@@ -46,7 +45,6 @@ export type QuotedReplyData = {
  * Entity containing quoted reply information.
  *
  * @experimental This API is coming soon and may change in the future.
- * Diagnostic: ExperimentalTeamsQuotedReplies
  */
 export type QuotedReplyEntity = {
   readonly type: 'quotedReply';

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -173,8 +173,6 @@ export interface IBaseActivityContext<T extends Activity = Activity, TExtraCtx e
    * send a reply quoting a specific message by ID
    * @param messageId the ID of the message to quote
    * @param activity activity to send
-   *
-   * @experimental This API is coming soon and may change in the future.
    */
   quote: (messageId: string, activity: ActivityLike) => Promise<SentActivity>;
 
@@ -306,8 +304,6 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
    * Teams renders the quoted message as a preview bubble above the response text.
    * @param messageId - The ID of the message to quote
    * @param activity - The activity to send — a quote placeholder for messageId will be prepended to its text
-   *
-   * @experimental This API is coming soon and may change in the future.
    */
   async quote(messageId: string, activity: ActivityLike) {
     activity = toActivityParams(activity);

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -175,7 +175,6 @@ export interface IBaseActivityContext<T extends Activity = Activity, TExtraCtx e
    * @param activity activity to send
    *
    * @experimental This API is coming soon and may change in the future.
-   * Diagnostic: ExperimentalTeamsQuotedReplies
    */
   quote: (messageId: string, activity: ActivityLike) => Promise<SentActivity>;
 
@@ -309,7 +308,6 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
    * @param activity - The activity to send — a quote placeholder for messageId will be prepended to its text
    *
    * @experimental This API is coming soon and may change in the future.
-   * Diagnostic: ExperimentalTeamsQuotedReplies
    */
   async quote(messageId: string, activity: ActivityLike) {
     activity = toActivityParams(activity);


### PR DESCRIPTION
Quoted replies are now GA. Removes all `ExperimentalTeamsQuotedReplies` diagnostic comments from JSDoc annotations.

## Changes
- `packages/apps/src/contexts/activity.ts`
- `packages/api/src/activities/message/message.ts`
- `packages/api/src/models/entity/quoted-reply-entity.ts`

All tests pass (774/774).