### PR TITLE
fix: use artifactName for pipelineArtifact inputs in publish pipeline

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -189,7 +189,7 @@ extends:
         templateContext:
           inputs:
           - input: pipelineArtifact
-            artifact: npm-packages
+            artifactName: npm-packages
             targetPath: $(Pipeline.Workspace)/npm-packages
         steps:
         - task: NodeTool@0
@@ -237,7 +237,7 @@ extends:
           isProduction: true
           inputs:
           - input: pipelineArtifact
-            artifact: npm-packages
+            artifactName: npm-packages
             targetPath: $(Pipeline.Workspace)/npm-packages
         steps:
         - task: EsrpRelease@10


### PR DESCRIPTION
The 1ES template requires `artifactName` (not `artifact`) for `pipelineArtifact` input declarations in `templateContext`. This was causing:

```
Unexpected value 'artifactName is a required argument for pipelineArtifact input and 1ES.DownloadPipelineArtifact@1 task'
```