### PR TITLE
Add Agent 365 token support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -899,12 +899,12 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
-      "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.3.0.tgz",
+      "integrity": "sha512-fXtJX811pX8y8QlrQqBSH6+plvWyKZDI0IxkheAcyAw9OtcpXyFivmTC7eGUqutLWaDlKXuQ3yOESD4zAmkjHg==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.6.2",
+        "@azure/msal-common": "16.10.0",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -912,9 +912,9 @@
       }
     },
     "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "16.6.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
-      "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.10.0.tgz",
+      "integrity": "sha512-iYtjpanlv6963Jprs0MvzIap07V+QhultjQctfbEDQCflsDAEeO3R7XnVA5gk30fhoBFLdgJT7VqO0TGsEsN9w==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -19201,7 +19201,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-node": "^5.2.2",
+        "@azure/msal-node": "^5.3.0",
         "@microsoft/teams.api": "*",
         "@microsoft/teams.common": "*",
         "@microsoft/teams.graph": "*",

--- a/packages/api/src/auth/cloud-environment.ts
+++ b/packages/api/src/auth/cloud-environment.ts
@@ -18,6 +18,8 @@ export type CloudEnvironment = {
   readonly tokenIssuer: string;
   /** The Microsoft Graph token scope (e.g. "https://graph.microsoft.com/.default") */
   readonly graphScope: string;
+  /** The Agent 365 Bot API token scope. */
+  readonly agenticBotScope: string;
 };
 
 /** Microsoft public (commercial) cloud. */
@@ -29,6 +31,7 @@ export const PUBLIC: CloudEnvironment = Object.freeze({
   openIdMetadataUrl: 'https://login.botframework.com/v1/.well-known/openidconfiguration',
   tokenIssuer: 'https://api.botframework.com',
   graphScope: 'https://graph.microsoft.com/.default',
+  agenticBotScope: 'https://botapi.skype.com/.default',
 });
 
 /** US Government Community Cloud High (GCCH). */
@@ -40,6 +43,8 @@ export const US_GOV: CloudEnvironment = Object.freeze({
   openIdMetadataUrl: 'https://login.botframework.azure.us/v1/.well-known/openidconfiguration',
   tokenIssuer: 'https://api.botframework.us',
   graphScope: 'https://graph.microsoft.us/.default',
+  // TODO: Use the sovereign Agent 365 Bot API scope when one is available.
+  agenticBotScope: 'https://botapi.skype.com/.default',
 });
 
 /** US Government Department of Defense (DoD). */
@@ -51,6 +56,8 @@ export const US_GOV_DOD: CloudEnvironment = Object.freeze({
   openIdMetadataUrl: 'https://login.botframework.azure.us/v1/.well-known/openidconfiguration',
   tokenIssuer: 'https://api.botframework.us',
   graphScope: 'https://dod-graph.microsoft.us/.default',
+  // TODO: Use the sovereign Agent 365 Bot API scope when one is available.
+  agenticBotScope: 'https://botapi.skype.com/.default',
 });
 
 /** China cloud (21Vianet). */
@@ -62,6 +69,8 @@ export const CHINA: CloudEnvironment = Object.freeze({
   openIdMetadataUrl: 'https://login.botframework.azure.cn/v1/.well-known/openidconfiguration',
   tokenIssuer: 'https://api.botframework.azure.cn',
   graphScope: 'https://microsoftgraph.chinacloudapi.cn/.default',
+  // TODO: Use the China cloud Agent 365 Bot API scope when one is available.
+  agenticBotScope: 'https://botapi.skype.com/.default',
 });
 
 /**
@@ -80,6 +89,7 @@ export function withOverrides(
     openIdMetadataUrl: overrides.openIdMetadataUrl ?? base.openIdMetadataUrl,
     tokenIssuer: overrides.tokenIssuer ?? base.tokenIssuer,
     graphScope: overrides.graphScope ?? base.graphScope,
+    agenticBotScope: overrides.agenticBotScope ?? base.agenticBotScope,
   });
 }
 

--- a/packages/api/src/auth/credentials.ts
+++ b/packages/api/src/auth/credentials.ts
@@ -1,6 +1,8 @@
 /**
  * credentials for app authentication
  */
+import { AgenticIdentity } from '../models/agentic-identity';
+
 export type Credentials = ClientCredentials | TokenCredentials | UserManagedIdentityCredentials | FederatedIdentityCredentials;
 
 /**
@@ -13,6 +15,10 @@ export type ClientCredentials = {
   readonly tenantId?: string;
 };
 
+export type TokenRequestOptions = {
+  readonly agenticIdentity?: AgenticIdentity;
+};
+
 /**
  * credentials for authentication
  * of an app via any external auth method
@@ -20,7 +26,7 @@ export type ClientCredentials = {
 export type TokenCredentials = {
   readonly clientId: string;
   readonly tenantId?: string;
-  readonly token: (scope: string | string[], tenantId?: string) => string | Promise<string>;
+  readonly token: (scope: string | string[], tenantId?: string, options?: TokenRequestOptions) => string | Promise<string>;
 };
 
 /**

--- a/packages/api/src/models/agentic-identity.ts
+++ b/packages/api/src/models/agentic-identity.ts
@@ -1,0 +1,9 @@
+/**
+ * Identifies an Agent ID user-shaped identity and its backing agent app.
+ */
+export type AgenticIdentity = {
+  readonly agenticAppId: string;
+  readonly agenticUserId: string;
+  readonly tenantId?: string;
+  readonly agenticAppBlueprintId?: string;
+};

--- a/packages/api/src/models/index.ts
+++ b/packages/api/src/models/index.ts
@@ -35,4 +35,4 @@ export * from './team-details';
 export * from './meeting';
 export * from './channel-id';
 export * from './activity-like';
-
+export * from './agentic-identity';

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -37,7 +37,7 @@
     "test": "npx jest"
   },
   "dependencies": {
-    "@azure/msal-node": "^5.2.2",
+    "@azure/msal-node": "^5.3.0",
     "@microsoft/teams.api": "*",
     "@microsoft/teams.common": "*",
     "@microsoft/teams.graph": "*",

--- a/packages/apps/src/token-manager.spec.ts
+++ b/packages/apps/src/token-manager.spec.ts
@@ -230,7 +230,8 @@ describe('TokenManager', () => {
 
       expect(mockTokenProvider).toHaveBeenCalledWith(
         'https://api.botframework.com/.default',
-        'test-tenant-id'
+        'test-tenant-id',
+        undefined
       );
       expect(token).not.toBeNull();
       expect(token?.toString()).toBe('mock-provider-token');
@@ -250,7 +251,8 @@ describe('TokenManager', () => {
 
       expect(mockTokenProvider).toHaveBeenCalledWith(
         'https://graph.microsoft.com/.default',
-        'custom-tenant'
+        'custom-tenant',
+        undefined
       );
       expect(token).not.toBeNull();
       expect(token?.toString()).toBe('mock-graph-provider-token');
@@ -495,6 +497,165 @@ describe('TokenManager', () => {
 
         await tokenManager.getGraphToken('other-tenant-id');
         expect(ConfidentialClientApplication).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('getAgenticToken', () => {
+    const mockAgenticIdentity = {
+      agenticAppId: 'agentic-app-id',
+      agenticUserId: 'agentic-user-id',
+      tenantId: 'agentic-tenant-id',
+    };
+
+    it('should return null when no credentials are configured', async () => {
+      const tokenManager = new TokenManager({}, logger);
+      const token = await tokenManager.getAgenticToken('some-scope', mockAgenticIdentity);
+      expect(token).toBeNull();
+    });
+
+    it('should throw when tenantId cannot be resolved', async () => {
+      const tokenManager = new TokenManager({ clientId: 'id', clientSecret: 'secret' }, logger);
+      await expect(
+        tokenManager.getAgenticToken('scope', { agenticAppId: 'app', agenticUserId: 'user' })
+      ).rejects.toThrow('tenantId is required to get an agentic token');
+    });
+
+    it('should use token provider when TokenCredentials are configured', async () => {
+      const mockTokenProvider = jest.fn().mockResolvedValue('mock-agentic-provider-token');
+      const tokenManager = new TokenManager({
+        clientId: 'test-client-id',
+        token: mockTokenProvider,
+        tenantId: 'test-tenant-id'
+      }, logger);
+
+      const token = await tokenManager.getAgenticToken('target-scope', mockAgenticIdentity);
+
+      expect(mockTokenProvider).toHaveBeenCalledWith(
+        'target-scope',
+        'agentic-tenant-id',
+        { agenticIdentity: mockAgenticIdentity }
+      );
+      expect(token?.toString()).toBe('mock-agentic-provider-token');
+    });
+
+    it('should throw when credentials are not ClientCredentials or TokenCredentials', async () => {
+      const tokenManager = new TokenManager({
+        clientId: 'test-client-id',
+        tenantId: 'test-tenant-id',
+      }, logger);
+
+      await expect(
+        tokenManager.getAgenticToken('scope', mockAgenticIdentity)
+      ).rejects.toThrow('Agentic tokens require ClientCredentials');
+    });
+
+    describe('3-step token exchange with ClientCredentials', () => {
+      let mockAcquireByUserFederated: jest.Mock;
+
+      beforeEach(() => {
+        mockAcquireByUserFederated = jest.fn();
+        (ConfidentialClientApplication as jest.MockedClass<typeof ConfidentialClientApplication>).mockImplementation(() => ({
+          acquireTokenByClientCredential: mockAcquireTokenByClientCredential,
+          acquireTokenByUserFederatedIdentityCredential: mockAcquireByUserFederated,
+        } as unknown as ConfidentialClientApplication));
+      });
+
+      it('should perform 3-step exchange and return final token', async () => {
+        // Call order: step 2 (t2Client.acquireTokenByClientCredential), then t1ForStep3 (base client.acquireTokenByClientCredential)
+        mockAcquireTokenByClientCredential
+          .mockResolvedValueOnce(createMockAuthResult('t2-token'))  // step 2
+          .mockResolvedValueOnce(createMockAuthResult('t1-for-step3'));  // t1ForStep3
+
+        mockAcquireByUserFederated.mockResolvedValue(createMockAuthResult('t3-final-token'));
+
+        const tokenManager = new TokenManager(mockOptions, logger);
+        const token = await tokenManager.getAgenticToken('target-scope', mockAgenticIdentity);
+
+        expect(token?.toString()).toBe('t3-final-token');
+
+        // Verify step 3 call
+        expect(mockAcquireByUserFederated).toHaveBeenCalledWith({
+          scopes: ['target-scope'],
+          assertion: 't2-token',
+          userObjectId: 'agentic-user-id',
+          clientAssertion: 't1-for-step3',
+        });
+      });
+
+      it('should throw when step 1 returns null', async () => {
+        mockAcquireTokenByClientCredential.mockResolvedValue(null);
+
+        const tokenManager = new TokenManager(mockOptions, logger);
+
+        await expect(
+          tokenManager.getAgenticToken('scope', mockAgenticIdentity)
+        ).rejects.toThrow('Agent token exchange step');
+      });
+
+      it('should throw when step 2 returns null', async () => {
+        mockAcquireTokenByClientCredential.mockResolvedValueOnce(null);
+
+        const tokenManager = new TokenManager(mockOptions, logger);
+
+        await expect(
+          tokenManager.getAgenticToken('scope', mockAgenticIdentity)
+        ).rejects.toThrow('Agent token exchange step 2 failed');
+      });
+
+      it('should throw when step 3 returns null', async () => {
+        mockAcquireTokenByClientCredential
+          .mockResolvedValueOnce(createMockAuthResult('t2-token'))
+          .mockResolvedValueOnce(createMockAuthResult('t1-for-step3'));
+
+        mockAcquireByUserFederated.mockResolvedValue(null);
+
+        const tokenManager = new TokenManager(mockOptions, logger);
+
+        await expect(
+          tokenManager.getAgenticToken('scope', mockAgenticIdentity)
+        ).rejects.toThrow('Agent token exchange step 3 failed');
+      });
+
+      it('should use agenticIdentity.tenantId over credentials.tenantId', async () => {
+        mockAcquireTokenByClientCredential
+          .mockResolvedValueOnce(createMockAuthResult('t2'))
+          .mockResolvedValueOnce(createMockAuthResult('t1-step3'));
+        mockAcquireByUserFederated.mockResolvedValue(createMockAuthResult('t3'));
+
+        const tokenManager = new TokenManager(mockOptions, logger);
+        await tokenManager.getAgenticToken('scope', mockAgenticIdentity);
+
+        // The first ConfidentialClientApplication is the base client for T1 — uses agenticIdentity.tenantId
+        expect(ConfidentialClientApplication).toHaveBeenCalledWith(
+          expect.objectContaining({
+            auth: expect.objectContaining({
+              authority: 'https://login.microsoftonline.com/agentic-tenant-id'
+            })
+          })
+        );
+      });
+
+      it('should cache agent identity client and use fresh T1 assertion each call', async () => {
+        mockAcquireTokenByClientCredential
+          .mockResolvedValueOnce(createMockAuthResult('t2-first'))
+          .mockResolvedValueOnce(createMockAuthResult('t1-first-step3'))
+          .mockResolvedValueOnce(createMockAuthResult('t2-second'))
+          .mockResolvedValueOnce(createMockAuthResult('t1-second-step3'));
+        mockAcquireByUserFederated
+          .mockResolvedValueOnce(createMockAuthResult('t3-first'))
+          .mockResolvedValueOnce(createMockAuthResult('t3-second'));
+
+        const tokenManager = new TokenManager(mockOptions, logger);
+
+        await tokenManager.getAgenticToken('scope', mockAgenticIdentity);
+        const clientCountAfterFirst = (ConfidentialClientApplication as jest.Mock).mock.calls.length;
+
+        await tokenManager.getAgenticToken('scope', mockAgenticIdentity);
+        const clientCountAfterSecond = (ConfidentialClientApplication as jest.Mock).mock.calls.length;
+
+        // Agent identity client should be cached (same key) — only 1 new client for the second call (base client is also cached)
+        expect(clientCountAfterSecond).toBe(clientCountAfterFirst);
       });
     });
   });

--- a/packages/apps/src/token-manager.ts
+++ b/packages/apps/src/token-manager.ts
@@ -1,10 +1,11 @@
 
 import { AuthenticationResult, ConfidentialClientApplication, ManagedIdentityApplication, LogLevel as MSALLogLevel, NodeSystemOptions } from '@azure/msal-node';
 
-import { ClientCredentials, CloudEnvironment, Credentials, IToken, JsonWebToken, PUBLIC, TokenCredentials, FederatedIdentityCredentials, UserManagedIdentityCredentials } from '@microsoft/teams.api';
+import { AgenticIdentity, ClientCredentials, CloudEnvironment, Credentials, IToken, JsonWebToken, PUBLIC, TokenCredentials, FederatedIdentityCredentials, UserManagedIdentityCredentials } from '@microsoft/teams.api';
 import { ConsoleLogger, ILogger, LogLevel } from '@microsoft/teams.common';
 
 const DEFAULT_TENANT_FOR_GRAPH_TOKEN = 'common';
+const TOKEN_EXCHANGE_SCOPE = 'api://AzureADTokenExchange/.default';
 
 const MSAL_LOG_LEVEL_TO_LOG_LEVEL: Record<MSALLogLevel, LogLevel> = {
   [MSALLogLevel.Error]: 'error',
@@ -53,6 +54,7 @@ export class TokenManager {
   private cloud: CloudEnvironment;
   private confidentialClientsByTenantId: Record<string, ConfidentialClientApplication> = {};
   private federatedIdentityClientsByTenantId: Record<string, ConfidentialClientApplication> = {};
+  private agentIdentityClientsByTenantAndAppId: Record<string, ConfidentialClientApplication> = {};
   private managedIdentityClient: ManagedIdentityApplication | null = null;
 
   constructor(options: TokenManagerOptions, logger: ILogger) {
@@ -70,8 +72,57 @@ export class TokenManager {
     return await this.getToken(this.cloud.botScope, this.resolveTenantId(undefined, this.cloud.loginTenant));
   }
 
+  async getAppToken(scope: string, tenantId?: string): Promise<IToken | null> {
+    return await this.getToken(scope, this.resolveTenantId(tenantId, this.cloud.loginTenant));
+  }
+
   async getGraphToken(tenantId?: string): Promise<IToken | null> {
     return await this.getToken(this.cloud.graphScope, this.resolveTenantId(tenantId, DEFAULT_TENANT_FOR_GRAPH_TOKEN));
+  }
+
+  async getAgenticToken(
+    scope: string,
+    agenticIdentity: AgenticIdentity
+  ): Promise<IToken | null> {
+    if (!this.credentials) {
+      return null;
+    }
+
+    const tenantId = agenticIdentity.tenantId ?? this.credentials.tenantId;
+    if (!tenantId) {
+      throw new Error('tenantId is required to get an agentic token');
+    }
+
+    if (isTokenCredentials(this.credentials)) {
+      return this.getTokenWithTokenProvider(this.credentials, scope, tenantId, agenticIdentity);
+    }
+
+    if (!isClientCredentials(this.credentials)) {
+      throw new Error('Agentic tokens require ClientCredentials');
+    }
+
+    const t1Assertion = async () => {
+      const confidentialClient = this.getConfidentialClient(this.credentials as ClientCredentials, tenantId);
+      const t1Result = await confidentialClient.acquireTokenByClientCredential({
+        scopes: [TOKEN_EXCHANGE_SCOPE],
+        fmiPath: agenticIdentity.agenticAppId,
+      });
+      return this.getAccessTokenOrThrow(t1Result, 'Agent token exchange step 1 failed');
+    };
+
+    const t2Client = this.getAgentIdentityClient(tenantId, agenticIdentity.agenticAppId, t1Assertion);
+    const t2Result = await t2Client.acquireTokenByClientCredential({ scopes: [TOKEN_EXCHANGE_SCOPE] });
+    const t2 = this.getAccessTokenOrThrow(t2Result, 'Agent token exchange step 2 failed');
+
+    const t1ForStep3 = await t1Assertion();
+    const t3Result = await t2Client.acquireTokenByUserFederatedIdentityCredential({
+      scopes: [scope],
+      assertion: t2,
+      userObjectId: agenticIdentity.agenticUserId,
+      clientAssertion: t1ForStep3,
+    });
+    const t3 = this.getAccessTokenOrThrow(t3Result, 'Agent token exchange step 3 failed');
+    return new JsonWebToken(t3);
   }
 
   private initializeCredentials(options: TokenManagerOptions): Credentials | undefined {
@@ -140,9 +191,8 @@ export class TokenManager {
     return this.handleTokenResponse(result);
   }
 
-  private async getTokenWithTokenProvider(credentials: TokenCredentials, scope: string, tenantId: string): Promise<IToken | null> {
-    const token = await credentials.token(scope, tenantId);
-
+  private async getTokenWithTokenProvider(credentials: TokenCredentials, scope: string, tenantId: string, agenticIdentity?: AgenticIdentity): Promise<IToken | null> {
+    const token = await credentials.token(scope, tenantId, agenticIdentity ? { agenticIdentity } : undefined);
     return new JsonWebToken(token);
   }
   private async getTokenWithManagedIdentity(credentials: UserManagedIdentityCredentials, scope: string) {
@@ -211,6 +261,27 @@ export class TokenManager {
     return client;
   }
 
+  private getAgentIdentityClient(tenantId: string, agenticAppId: string, clientAssertion: () => Promise<string>) {
+    const cacheKey = `${tenantId}:${agenticAppId}`;
+    const cachedClient = this.agentIdentityClientsByTenantAndAppId[cacheKey];
+    if (cachedClient) {
+      return cachedClient;
+    }
+
+    const client = new ConfidentialClientApplication({
+      auth: {
+        clientId: agenticAppId,
+        clientAssertion,
+        authority: `${this.cloud.loginEndpoint}/${tenantId}`
+      },
+      system: {
+        loggerOptions: this.buildLoggerOptions()
+      }
+    });
+    this.agentIdentityClientsByTenantAndAppId[cacheKey] = client;
+    return client;
+  }
+
   private getManagedIdentityClient(credentials: UserManagedIdentityCredentials | FederatedIdentityCredentials): ManagedIdentityApplication {
     if (this.managedIdentityClient) {
       return this.managedIdentityClient;
@@ -257,6 +328,14 @@ export class TokenManager {
     }
 
     return new JsonWebToken(result.accessToken);
+  }
+
+  private getAccessTokenOrThrow(result: AuthenticationResult | null, errorPrefix: string): string {
+    if (!result?.accessToken) {
+      throw new Error(`${errorPrefix}: Failed to get token`);
+    }
+
+    return result.accessToken;
   }
 
   private buildLoggerOptions(): MSALLoggerOptions {


### PR DESCRIPTION
Adds foundational token support for Agent 365 scenarios:

- `AgenticIdentity` type (agenticAppId, agenticUserId, tenantId, agenticAppBlueprintId)
- `agenticBotScope` on `CloudEnvironment` (`https://botapi.skype.com/.default`)
- `TokenRequestOptions` type for extensible token callback options
- `TokenManager.getAgenticToken(agenticIdentity, scope)` — 3-step FMI token exchange (T1 → T2 → T3)
- `TokenManager.getAppToken(scope, tenantId?)` — generalized app token method
- `TokenCredentials.token` signature extended: `(scope, tenantId?, options?: TokenRequestOptions)`