### PR TITLE
feat(api): flatten client method chains to reduce call hops

### DIFF
--- a/packages/api/src/activities/message/message-reaction.ts
+++ b/packages/api/src/activities/message/message-reaction.ts
@@ -62,7 +62,7 @@ export class MessageReactionActivity
 
   /**
    * Add a message reaction.
-   * @deprecated Use the api.reactions.add instead.
+   * @deprecated Use api.conversations.addReaction instead.
    */
   addReaction(reaction: MessageReaction) {
     if (!this.reactionsAdded) {
@@ -75,7 +75,7 @@ export class MessageReactionActivity
 
   /**
    * Remove a message reaction.
-   * @deprecated Use the api.reactions.delete instead.
+   * @deprecated Use api.conversations.deleteReaction instead.
    */
   removeReaction(reaction: MessageReaction) {
     if (!this.reactionsRemoved) {

--- a/packages/api/src/clients/bot/index.ts
+++ b/packages/api/src/clients/bot/index.ts
@@ -7,6 +7,9 @@ import { ApiClientSettings, mergeApiClientSettings } from '../api-client-setting
 
 import { BotSignInClient } from './sign-in';
 
+/**
+ * @deprecated The bot client is deprecated and will be removed in a future release.
+ */
 export class BotClient {
   readonly signIn: BotSignInClient;
 

--- a/packages/api/src/clients/bot/sign-in.spec.ts
+++ b/packages/api/src/clients/bot/sign-in.spec.ts
@@ -1,5 +1,7 @@
 import { Client } from '@microsoft/teams.common';
 
+import { Client as ApiClient } from '../index';
+
 import { BotSignInClient } from './sign-in';
 
 describe('BotSignInClient', () => {
@@ -54,6 +56,33 @@ describe('BotSignInClient', () => {
 
     expect(spy).toHaveBeenCalledWith(
       'https://europe.token.botframework.com/api/botsignin/GetSignInUrl?state=test'
+    );
+  });
+});
+
+// The bot client is deprecated but still supported; verify the deprecated
+// `client.bots.signIn` accessor (the old chained path) still reaches
+// BotSignInClient.
+describe('client.bots.signIn (deprecated accessor)', () => {
+  it('getUrl should GET the sign in url', async () => {
+    const client = new ApiClient('');
+    const spy = jest.spyOn(client.http, 'get').mockResolvedValueOnce({});
+
+    await client.bots.signIn.getUrl({ state: 'test' });
+
+    expect(spy).toHaveBeenCalledWith(
+      'https://token.botframework.com/api/botsignin/GetSignInUrl?state=test'
+    );
+  });
+
+  it('getResource should GET the sign in resource', async () => {
+    const client = new ApiClient('');
+    const spy = jest.spyOn(client.http, 'get').mockResolvedValueOnce({});
+
+    await client.bots.signIn.getResource({ state: 'test' });
+
+    expect(spy).toHaveBeenCalledWith(
+      'https://token.botframework.com/api/botsignin/GetSignInResource?state=test'
     );
   });
 });

--- a/packages/api/src/clients/conversation/activity.ts
+++ b/packages/api/src/clients/conversation/activity.ts
@@ -35,6 +35,10 @@ export class ConversationActivityClient {
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
   }
 
+  /**
+   * @deprecated Use `conversations.createActivity(...)` instead. This will be
+   * removed in a future release.
+   */
   async create(conversationId: string, params: ActivityParams) {
     const res = await this.http.post<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities`,
@@ -43,6 +47,10 @@ export class ConversationActivityClient {
     return res.data;
   }
 
+  /**
+   * @deprecated Use `conversations.updateActivity(...)` instead. This will be
+   * removed in a future release.
+   */
   async update(conversationId: string, id: string, params: ActivityParams) {
     const res = await this.http.put<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`,
@@ -51,6 +59,10 @@ export class ConversationActivityClient {
     return res.data;
   }
 
+  /**
+   * @deprecated Use `conversations.replyToActivity(...)` instead. This will be
+   * removed in a future release.
+   */
   async reply(conversationId: string, id: string, params: ActivityParams) {
     params.replyToId = id;
     const res = await this.http.post<Resource>(
@@ -60,6 +72,10 @@ export class ConversationActivityClient {
     return res.data;
   }
 
+  /**
+   * @deprecated Use `conversations.deleteActivity(...)` instead. This will be
+   * removed in a future release.
+   */
   async delete(conversationId: string, id: string) {
     const res = await this.http.delete<void>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`
@@ -67,6 +83,10 @@ export class ConversationActivityClient {
     return res.data;
   }
 
+  /**
+   * @deprecated Use `conversations.getActivityMembers(...)` instead. This will
+   * be removed in a future release.
+   */
   async getMembers(conversationId: string, id: string): Promise<TeamsChannelAccount[]> {
     const res = await this.http.get<TeamsChannelAccount[]>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}/members`
@@ -74,6 +94,10 @@ export class ConversationActivityClient {
     return (res.data ?? []).map(resolveAadObjectId);
   }
 
+  /**
+   * @deprecated Use `conversations.createTargetedActivity(...)` instead. This
+   * will be removed in a future release.
+   */
   async createTargeted(conversationId: string, params: ActivityParams) {
     const res = await this.http.post<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities?isTargetedActivity=true`,
@@ -82,6 +106,10 @@ export class ConversationActivityClient {
     return res.data;
   }
 
+  /**
+   * @deprecated Use `conversations.updateTargetedActivity(...)` instead. This
+   * will be removed in a future release.
+   */
   async updateTargeted(conversationId: string, id: string, params: ActivityParams) {
     const res = await this.http.put<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}?isTargetedActivity=true`,
@@ -90,6 +118,10 @@ export class ConversationActivityClient {
     return res.data;
   }
 
+  /**
+   * @deprecated Use `conversations.deleteTargetedActivity(...)` instead. This
+   * will be removed in a future release.
+   */
   async deleteTargeted(conversationId: string, id: string) {
     const res = await this.http.delete<void>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}?isTargetedActivity=true`

--- a/packages/api/src/clients/conversation/activity.ts
+++ b/packages/api/src/clients/conversation/activity.ts
@@ -35,10 +35,6 @@ export class ConversationActivityClient {
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
   }
 
-  /**
-   * @deprecated Use `conversations.createActivity(...)` instead. This will be
-   * removed in a future release.
-   */
   async create(conversationId: string, params: ActivityParams) {
     const res = await this.http.post<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities`,
@@ -47,10 +43,6 @@ export class ConversationActivityClient {
     return res.data;
   }
 
-  /**
-   * @deprecated Use `conversations.updateActivity(...)` instead. This will be
-   * removed in a future release.
-   */
   async update(conversationId: string, id: string, params: ActivityParams) {
     const res = await this.http.put<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`,
@@ -59,10 +51,6 @@ export class ConversationActivityClient {
     return res.data;
   }
 
-  /**
-   * @deprecated Use `conversations.replyToActivity(...)` instead. This will be
-   * removed in a future release.
-   */
   async reply(conversationId: string, id: string, params: ActivityParams) {
     params.replyToId = id;
     const res = await this.http.post<Resource>(
@@ -72,10 +60,6 @@ export class ConversationActivityClient {
     return res.data;
   }
 
-  /**
-   * @deprecated Use `conversations.deleteActivity(...)` instead. This will be
-   * removed in a future release.
-   */
   async delete(conversationId: string, id: string) {
     const res = await this.http.delete<void>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`
@@ -83,10 +67,6 @@ export class ConversationActivityClient {
     return res.data;
   }
 
-  /**
-   * @deprecated Use `conversations.getActivityMembers(...)` instead. This will
-   * be removed in a future release.
-   */
   async getMembers(conversationId: string, id: string): Promise<TeamsChannelAccount[]> {
     const res = await this.http.get<TeamsChannelAccount[]>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}/members`
@@ -94,10 +74,6 @@ export class ConversationActivityClient {
     return (res.data ?? []).map(resolveAadObjectId);
   }
 
-  /**
-   * @deprecated Use `conversations.createTargetedActivity(...)` instead. This
-   * will be removed in a future release.
-   */
   async createTargeted(conversationId: string, params: ActivityParams) {
     const res = await this.http.post<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities?isTargetedActivity=true`,
@@ -106,10 +82,6 @@ export class ConversationActivityClient {
     return res.data;
   }
 
-  /**
-   * @deprecated Use `conversations.updateTargetedActivity(...)` instead. This
-   * will be removed in a future release.
-   */
   async updateTargeted(conversationId: string, id: string, params: ActivityParams) {
     const res = await this.http.put<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}?isTargetedActivity=true`,
@@ -118,10 +90,6 @@ export class ConversationActivityClient {
     return res.data;
   }
 
-  /**
-   * @deprecated Use `conversations.deleteTargetedActivity(...)` instead. This
-   * will be removed in a future release.
-   */
   async deleteTargeted(conversationId: string, id: string) {
     const res = await this.http.delete<void>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}?isTargetedActivity=true`

--- a/packages/api/src/clients/conversation/activity.ts
+++ b/packages/api/src/clients/conversation/activity.ts
@@ -36,6 +36,7 @@ export class ConversationActivityClient {
   }
 
   async create(conversationId: string, params: ActivityParams) {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     const res = await this.http.post<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities`,
       params
@@ -44,6 +45,7 @@ export class ConversationActivityClient {
   }
 
   async update(conversationId: string, id: string, params: ActivityParams) {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     const res = await this.http.put<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`,
       params
@@ -52,6 +54,7 @@ export class ConversationActivityClient {
   }
 
   async reply(conversationId: string, id: string, params: ActivityParams) {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     params.replyToId = id;
     const res = await this.http.post<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`,
@@ -61,6 +64,7 @@ export class ConversationActivityClient {
   }
 
   async delete(conversationId: string, id: string) {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     const res = await this.http.delete<void>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`
     );
@@ -68,6 +72,7 @@ export class ConversationActivityClient {
   }
 
   async getMembers(conversationId: string, id: string): Promise<TeamsChannelAccount[]> {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     const res = await this.http.get<TeamsChannelAccount[]>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}/members`
     );
@@ -75,6 +80,7 @@ export class ConversationActivityClient {
   }
 
   async createTargeted(conversationId: string, params: ActivityParams) {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     const res = await this.http.post<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities?isTargetedActivity=true`,
       params
@@ -83,6 +89,7 @@ export class ConversationActivityClient {
   }
 
   async updateTargeted(conversationId: string, id: string, params: ActivityParams) {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     const res = await this.http.put<Resource>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}?isTargetedActivity=true`,
       params
@@ -91,6 +98,7 @@ export class ConversationActivityClient {
   }
 
   async deleteTargeted(conversationId: string, id: string) {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     const res = await this.http.delete<void>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}?isTargetedActivity=true`
     );

--- a/packages/api/src/clients/conversation/index.spec.ts
+++ b/packages/api/src/clients/conversation/index.spec.ts
@@ -1,0 +1,300 @@
+import { ConversationClient } from './index';
+
+describe('ConversationClient', () => {
+  describe('activities', () => {
+    it('createActivity should POST an activity', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+      await client.createActivity('1', { type: 'message', text: 'hi' });
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities', {
+        type: 'message',
+        text: 'hi',
+      });
+    });
+
+    it('updateActivity should PUT an activity', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'put').mockResolvedValueOnce({});
+
+      await client.updateActivity('1', '2', { type: 'message', text: 'hi' });
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2', {
+        type: 'message',
+        text: 'hi',
+      });
+    });
+
+    it('replyToActivity should POST a reply', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+      await client.replyToActivity('1', '2', { type: 'message', text: 'hi' });
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2', {
+        type: 'message',
+        text: 'hi',
+        replyToId: '2',
+      });
+    });
+
+    it('deleteActivity should DELETE an activity', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
+
+      await client.deleteActivity('1', '2');
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2');
+    });
+
+    it('getActivityMembers should GET activity members', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'get').mockResolvedValueOnce({ data: [] });
+
+      await client.getActivityMembers('1', '2');
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2/members');
+    });
+
+    it('createTargetedActivity should POST a targeted activity', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+      await client.createTargetedActivity('1', { type: 'message', text: 'hi' });
+
+      expect(spy).toHaveBeenCalledWith(
+        '/v3/conversations/1/activities?isTargetedActivity=true',
+        { type: 'message', text: 'hi' }
+      );
+    });
+
+    it('updateTargetedActivity should PUT a targeted activity', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'put').mockResolvedValueOnce({});
+
+      await client.updateTargetedActivity('1', '2', { type: 'message', text: 'hi' });
+
+      expect(spy).toHaveBeenCalledWith(
+        '/v3/conversations/1/activities/2?isTargetedActivity=true',
+        { type: 'message', text: 'hi' }
+      );
+    });
+
+    it('deleteTargetedActivity should DELETE a targeted activity', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
+
+      await client.deleteTargetedActivity('1', '2');
+
+      expect(spy).toHaveBeenCalledWith(
+        '/v3/conversations/1/activities/2?isTargetedActivity=true'
+      );
+    });
+  });
+
+  describe('members', () => {
+    it('getMembers should GET members', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'get').mockResolvedValueOnce({ data: [] });
+
+      await client.getMembers('1');
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/members');
+    });
+
+    it('getMemberById should GET a member by id', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'get').mockResolvedValueOnce({ data: {} });
+
+      await client.getMemberById('1', '2');
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/members/2');
+    });
+
+    it('getPagedMembers should GET paged members', async () => {
+      const client = new ConversationClient('');
+      const spy = jest
+        .spyOn(client.http, 'get')
+        .mockResolvedValueOnce({ data: { members: [] } });
+
+      await client.getPagedMembers('1', 50, 'some-token');
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/pagedMembers', {
+        params: { pageSize: 50, continuationToken: 'some-token' },
+      });
+    });
+
+    it('deleteMember should DELETE a member', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
+
+      await client.deleteMember('1', '2');
+
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/members/2');
+    });
+  });
+
+  describe('reactions', () => {
+    it('addReaction should PUT a reaction on an activity', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'put').mockResolvedValueOnce({});
+
+      await client.addReaction('1', '2', 'like');
+
+      expect(spy).toHaveBeenCalledWith(
+        '/v3/conversations/1/activities/2/reactions/like'
+      );
+    });
+
+    it('deleteReaction should DELETE a reaction from an activity', async () => {
+      const client = new ConversationClient('');
+      const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
+
+      await client.deleteReaction('1', '2', 'like');
+
+      expect(spy).toHaveBeenCalledWith(
+        '/v3/conversations/1/activities/2/reactions/like'
+      );
+    });
+  });
+
+  // The pre-flattening chained API is still supported until officially removed;
+  // keep full coverage of the deprecated grouped accessors alongside the
+  // flattened methods above.
+  describe('deprecated chained aliases', () => {
+    describe('activities(id)', () => {
+      it('create should POST an activity', async () => {
+        const client = new ConversationClient('');
+        const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+        await client.activities('1').create({ type: 'message', text: 'hi' });
+
+        expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities', {
+          type: 'message',
+          text: 'hi',
+        });
+      });
+
+      it('update should PUT an activity', async () => {
+        const client = new ConversationClient('');
+        const spy = jest.spyOn(client.http, 'put').mockResolvedValueOnce({});
+
+        await client.activities('1').update('2', { type: 'message', text: 'hi' });
+
+        expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2', {
+          type: 'message',
+          text: 'hi',
+        });
+      });
+
+      it('reply should POST a reply', async () => {
+        const client = new ConversationClient('');
+        const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+        await client.activities('1').reply('2', { type: 'message', text: 'hi' });
+
+        expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2', {
+          type: 'message',
+          text: 'hi',
+          replyToId: '2',
+        });
+      });
+
+      it('delete should DELETE an activity', async () => {
+        const client = new ConversationClient('');
+        const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
+
+        await client.activities('1').delete('2');
+
+        expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2');
+      });
+
+      it('members should GET activity members', async () => {
+        const client = new ConversationClient('');
+        const spy = jest.spyOn(client.http, 'get').mockResolvedValueOnce({ data: [] });
+
+        await client.activities('1').members('2');
+
+        expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2/members');
+      });
+
+      it('createTargeted should POST a targeted activity', async () => {
+        const client = new ConversationClient('');
+        const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+        await client.activities('1').createTargeted({ type: 'message', text: 'hi' });
+
+        expect(spy).toHaveBeenCalledWith(
+          '/v3/conversations/1/activities?isTargetedActivity=true',
+          { type: 'message', text: 'hi' }
+        );
+      });
+
+      it('updateTargeted should PUT a targeted activity', async () => {
+        const client = new ConversationClient('');
+        const spy = jest.spyOn(client.http, 'put').mockResolvedValueOnce({});
+
+        await client.activities('1').updateTargeted('2', { type: 'message', text: 'hi' });
+
+        expect(spy).toHaveBeenCalledWith(
+          '/v3/conversations/1/activities/2?isTargetedActivity=true',
+          { type: 'message', text: 'hi' }
+        );
+      });
+
+      it('deleteTargeted should DELETE a targeted activity', async () => {
+        const client = new ConversationClient('');
+        const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
+
+        await client.activities('1').deleteTargeted('2');
+
+        expect(spy).toHaveBeenCalledWith(
+          '/v3/conversations/1/activities/2?isTargetedActivity=true'
+        );
+      });
+    });
+
+    describe('members(id)', () => {
+      it('get should GET members', async () => {
+        const client = new ConversationClient('');
+        const spy = jest.spyOn(client.http, 'get').mockResolvedValueOnce({ data: [] });
+
+        await client.members('1').get();
+
+        expect(spy).toHaveBeenCalledWith('/v3/conversations/1/members');
+      });
+
+      it('getById should GET a member by id', async () => {
+        const client = new ConversationClient('');
+        const spy = jest.spyOn(client.http, 'get').mockResolvedValueOnce({ data: {} });
+
+        await client.members('1').getById('2');
+
+        expect(spy).toHaveBeenCalledWith('/v3/conversations/1/members/2');
+      });
+
+      it('getPaged should GET paged members', async () => {
+        const client = new ConversationClient('');
+        const spy = jest
+          .spyOn(client.http, 'get')
+          .mockResolvedValueOnce({ data: { members: [] } });
+
+        await client.members('1').getPaged(50, 'some-token');
+
+        expect(spy).toHaveBeenCalledWith('/v3/conversations/1/pagedMembers', {
+          params: { pageSize: 50, continuationToken: 'some-token' },
+        });
+      });
+
+      it('delete should DELETE a member', async () => {
+        const client = new ConversationClient('');
+        const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
+
+        await client.members('1').delete('2');
+
+        expect(spy).toHaveBeenCalledWith('/v3/conversations/1/members/2');
+      });
+    });
+  });
+});

--- a/packages/api/src/clients/conversation/index.spec.ts
+++ b/packages/api/src/clients/conversation/index.spec.ts
@@ -124,15 +124,6 @@ describe('ConversationClient', () => {
         params: { pageSize: 50, continuationToken: 'some-token' },
       });
     });
-
-    it('deleteMember should DELETE a member', async () => {
-      const client = new ConversationClient('');
-      const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
-
-      await client.deleteMember('1', '2');
-
-      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/members/2');
-    });
   });
 
   describe('reactions', () => {

--- a/packages/api/src/clients/conversation/index.ts
+++ b/packages/api/src/clients/conversation/index.ts
@@ -5,9 +5,10 @@ import {
   type ClientOptions as HttpClientOptions
 } from '@microsoft/teams.common';
 
-import { Account, Conversation, ConversationResource } from '../../models';
+import { Account, Conversation, ConversationResource, MessageReactionType } from '../../models';
 
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
+import { ReactionClient } from '../reaction';
 
 import { ActivityParams, ConversationActivityClient } from './activity';
 import { ConversationMemberClient } from './member';
@@ -65,6 +66,7 @@ export class ConversationClient {
   protected _http: HttpClient;
   protected _activities: ConversationActivityClient;
   protected _members: ConversationMemberClient;
+  protected _reactions: ReactionClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
   constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
@@ -81,8 +83,14 @@ export class ConversationClient {
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
     this._activities = new ConversationActivityClient(serviceUrl, this.http, this._apiClientSettings);
     this._members = new ConversationMemberClient(serviceUrl, this.http, this._apiClientSettings);
+    this._reactions = new ReactionClient(serviceUrl, this.http, this._apiClientSettings);
   }
 
+  /**
+   * @deprecated Use the flattened activity methods on `ConversationClient`
+   * instead (e.g. `conversations.createActivity(conversationId, ...)`). This
+   * grouped accessor will be removed in a future release.
+   */
   activities(conversationId: string) {
     return {
       create: (params: ActivityParams) => this._activities.create(conversationId, params),
@@ -99,6 +107,11 @@ export class ConversationClient {
     };
   }
 
+  /**
+   * @deprecated Use the flattened member methods on `ConversationClient`
+   * instead (e.g. `conversations.getMembers(conversationId)`). This grouped
+   * accessor will be removed in a future release.
+   */
   members(conversationId: string) {
     return {
       get: () => this._members.get(conversationId),
@@ -110,6 +123,104 @@ export class ConversationClient {
        */
       delete: (id: string) => this._members.delete(conversationId, id),
     };
+  }
+
+  /**
+   * Create an activity in a conversation.
+   */
+  createActivity(conversationId: string, params: ActivityParams) {
+    return this._activities.create(conversationId, params);
+  }
+
+  /**
+   * Update an activity in a conversation.
+   */
+  updateActivity(conversationId: string, id: string, params: ActivityParams) {
+    return this._activities.update(conversationId, id, params);
+  }
+
+  /**
+   * Reply to an activity in a conversation.
+   */
+  replyToActivity(conversationId: string, id: string, params: ActivityParams) {
+    return this._activities.reply(conversationId, id, params);
+  }
+
+  /**
+   * Delete an activity in a conversation.
+   */
+  deleteActivity(conversationId: string, id: string) {
+    return this._activities.delete(conversationId, id);
+  }
+
+  /**
+   * Get the members of an activity in a conversation.
+   */
+  getActivityMembers(conversationId: string, id: string) {
+    return this._activities.getMembers(conversationId, id);
+  }
+
+  /**
+   * Create a targeted activity in a conversation.
+   */
+  createTargetedActivity(conversationId: string, params: ActivityParams) {
+    return this._activities.createTargeted(conversationId, params);
+  }
+
+  /**
+   * Update a targeted activity in a conversation.
+   */
+  updateTargetedActivity(conversationId: string, id: string, params: ActivityParams) {
+    return this._activities.updateTargeted(conversationId, id, params);
+  }
+
+  /**
+   * Delete a targeted activity in a conversation.
+   */
+  deleteTargetedActivity(conversationId: string, id: string) {
+    return this._activities.deleteTargeted(conversationId, id);
+  }
+
+  /**
+   * Get the members of a conversation.
+   */
+  getMembers(conversationId: string) {
+    return this._members.get(conversationId);
+  }
+
+  /**
+   * Get a member of a conversation by id.
+   */
+  getMemberById(conversationId: string, id: string) {
+    return this._members.getById(conversationId, id);
+  }
+
+  /**
+   * Get paged members of a conversation.
+   */
+  getPagedMembers(conversationId: string, pageSize?: number, continuationToken?: string) {
+    return this._members.getPaged(conversationId, pageSize, continuationToken);
+  }
+
+  /**
+   * @deprecated This will be removed in a future release.
+   */
+  deleteMember(conversationId: string, id: string) {
+    return this._members.delete(conversationId, id);
+  }
+
+  /**
+   * Add a reaction to an activity in a conversation.
+   */
+  addReaction(conversationId: string, activityId: string, reactionType: MessageReactionType) {
+    return this._reactions.add(conversationId, activityId, reactionType);
+  }
+
+  /**
+   * Delete a reaction from an activity in a conversation.
+   */
+  deleteReaction(conversationId: string, activityId: string, reactionType: MessageReactionType) {
+    return this._reactions.delete(conversationId, activityId, reactionType);
   }
 
   /**

--- a/packages/api/src/clients/conversation/index.ts
+++ b/packages/api/src/clients/conversation/index.ts
@@ -63,11 +63,11 @@ export class ConversationClient {
   set http(v) {
     this._http = v;
   }
-  protected _http: HttpClient;
-  protected _activities: ConversationActivityClient;
-  protected _members: ConversationMemberClient;
-  protected _reactions: ReactionClient;
-  protected _apiClientSettings: Partial<ApiClientSettings>;
+  private _http: HttpClient;
+  private _activities: ConversationActivityClient;
+  private _members: ConversationMemberClient;
+  private _reactions: ReactionClient;
+  private _apiClientSettings: Partial<ApiClientSettings>;
 
   constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;
@@ -200,13 +200,6 @@ export class ConversationClient {
    */
   getPagedMembers(conversationId: string, pageSize?: number, continuationToken?: string) {
     return this._members.getPaged(conversationId, pageSize, continuationToken);
-  }
-
-  /**
-   * @deprecated This will be removed in a future release.
-   */
-  deleteMember(conversationId: string, id: string) {
-    return this._members.delete(conversationId, id);
   }
 
   /**

--- a/packages/api/src/clients/conversation/index.ts
+++ b/packages/api/src/clients/conversation/index.ts
@@ -60,14 +60,17 @@ export class ConversationClient {
   get http() {
     return this._http;
   }
-  set http(v) {
-    this._http = v;
-  }
-  private _http: HttpClient;
-  private _activities: ConversationActivityClient;
-  private _members: ConversationMemberClient;
-  private _reactions: ReactionClient;
-  private _apiClientSettings: Partial<ApiClientSettings>;
+set http(v) {
+  this._activities.http = v;
+  this._members.http = v;
+  this._reactions.http = v;
+  this._http = v;
+}
+protected _http: HttpClient;
+protected _activities: ConversationActivityClient;
+protected _members: ConversationMemberClient;
+protected _reactions: ReactionClient;
+protected _apiClientSettings: Partial<ApiClientSettings>;
 
   constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
     this.serviceUrl = serviceUrl;

--- a/packages/api/src/clients/conversation/member.ts
+++ b/packages/api/src/clients/conversation/member.ts
@@ -32,6 +32,7 @@ export class ConversationMemberClient {
   }
 
   async get(conversationId: string): Promise<TeamsChannelAccount[]> {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     const res = await this.http.get<TeamsChannelAccount[]>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/members`
     );
@@ -39,6 +40,7 @@ export class ConversationMemberClient {
   }
 
   async getById(conversationId: string, id: string): Promise<TeamsChannelAccount> {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     const res = await this.http.get<TeamsChannelAccount>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/members/${id}`
     );
@@ -53,6 +55,7 @@ export class ConversationMemberClient {
    * @returns PagedMembersResult containing members and an optional continuation token.
    */
   async getPaged(conversationId: string, pageSize?: number, continuationToken?: string): Promise<PagedMembersResult> {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     const params: Record<string, string | number> = {};
     if (pageSize !== undefined) params['pageSize'] = pageSize;
     if (continuationToken !== undefined) params['continuationToken'] = continuationToken;

--- a/packages/api/src/clients/conversation/member.ts
+++ b/packages/api/src/clients/conversation/member.ts
@@ -31,6 +31,10 @@ export class ConversationMemberClient {
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
   }
 
+  /**
+   * @deprecated Use `conversations.getMembers(...)` instead. This will be
+   * removed in a future release.
+   */
   async get(conversationId: string): Promise<TeamsChannelAccount[]> {
     const res = await this.http.get<TeamsChannelAccount[]>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/members`
@@ -38,6 +42,10 @@ export class ConversationMemberClient {
     return res.data.map(resolveAadObjectId);
   }
 
+  /**
+   * @deprecated Use `conversations.getMemberById(...)` instead. This will be
+   * removed in a future release.
+   */
   async getById(conversationId: string, id: string): Promise<TeamsChannelAccount> {
     const res = await this.http.get<TeamsChannelAccount>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/members/${id}`
@@ -47,6 +55,8 @@ export class ConversationMemberClient {
 
   /**
    * Get paged members in a conversation.
+   * @deprecated Use `conversations.getPagedMembers(...)` instead. This will be
+   * removed in a future release.
    * @param conversationId - The ID of the conversation.
    * @param pageSize - Optional maximum number of members per page (min 50, default 200, max 500).
    * @param continuationToken - Optional token from a previous call to fetch the next page.

--- a/packages/api/src/clients/conversation/member.ts
+++ b/packages/api/src/clients/conversation/member.ts
@@ -31,10 +31,6 @@ export class ConversationMemberClient {
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
   }
 
-  /**
-   * @deprecated Use `conversations.getMembers(...)` instead. This will be
-   * removed in a future release.
-   */
   async get(conversationId: string): Promise<TeamsChannelAccount[]> {
     const res = await this.http.get<TeamsChannelAccount[]>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/members`
@@ -42,10 +38,6 @@ export class ConversationMemberClient {
     return res.data.map(resolveAadObjectId);
   }
 
-  /**
-   * @deprecated Use `conversations.getMemberById(...)` instead. This will be
-   * removed in a future release.
-   */
   async getById(conversationId: string, id: string): Promise<TeamsChannelAccount> {
     const res = await this.http.get<TeamsChannelAccount>(
       `${this.serviceUrl}/v3/conversations/${conversationId}/members/${id}`
@@ -55,8 +47,6 @@ export class ConversationMemberClient {
 
   /**
    * Get paged members in a conversation.
-   * @deprecated Use `conversations.getPagedMembers(...)` instead. This will be
-   * removed in a future release.
    * @param conversationId - The ID of the conversation.
    * @param pageSize - Optional maximum number of members per page (min 50, default 200, max 500).
    * @param continuationToken - Optional token from a previous call to fetch the next page.

--- a/packages/api/src/clients/index.ts
+++ b/packages/api/src/clients/index.ts
@@ -15,26 +15,41 @@ import { UserClient } from './user';
 
 export class Client {
   readonly serviceUrl: string;
-  readonly bots: BotClient;
   readonly users: UserClient;
   readonly conversations: ConversationClient;
   readonly teams: TeamClient;
   readonly meetings: MeetingClient;
-  readonly reactions: ReactionClient;
 
   get http() {
     return this._http;
   }
   set http(v) {
-    this.bots.http = v;
+    this._bots.http = v;
     this.conversations.http = v;
     this.users.http = v;
     this.teams.http = v;
     this.meetings.http = v;
-    this.reactions.http = v;
+    this._reactions.http = v;
     this._http = v;
   }
+  /**
+   * @deprecated The bot client is no longer used and will be removed in a
+   * future release.
+   */
+  get bots() {
+    return this._bots;
+  }
+  /**
+   * @deprecated Use `conversations.addReaction(...)` and
+   * `conversations.deleteReaction(...)` instead. This will be removed in a
+   * future release.
+   */
+  get reactions() {
+    return this._reactions;
+  }
   protected _http: HttpClient;
+  protected _bots: BotClient;
+  protected _reactions: ReactionClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
   constructor(serviceUrl: string, options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>, cloud?: CloudEnvironment) {
@@ -56,12 +71,12 @@ export class Client {
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings, cloud);
 
-    this.bots = new BotClient(this.http, this._apiClientSettings);
+    this._bots = new BotClient(this.http, this._apiClientSettings);
     this.users = new UserClient(this.http, this._apiClientSettings);
     this.conversations = new ConversationClient(serviceUrl, this.http, this._apiClientSettings);
     this.teams = new TeamClient(serviceUrl, this.http, this._apiClientSettings);
     this.meetings = new MeetingClient(serviceUrl, this.http, this._apiClientSettings);
-    this.reactions = new ReactionClient(serviceUrl, this.http, this._apiClientSettings);
+    this._reactions = new ReactionClient(serviceUrl, this.http, this._apiClientSettings);
   }
 }
 

--- a/packages/api/src/clients/reaction/reaction.spec.ts
+++ b/packages/api/src/clients/reaction/reaction.spec.ts
@@ -1,5 +1,7 @@
 import { Client } from '@microsoft/teams.common';
 
+import { Client as ApiClient } from '../index';
+
 import { ReactionClient } from './reaction';
 
 describe('ReactionClient', () => {
@@ -69,5 +71,24 @@ describe('ReactionClient', () => {
     const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
     await client.delete('conv+1/test=', 'act+1/test=', 'heart');
     expect(spy).toHaveBeenCalledWith('/v3/conversations/conv%2B1%2Ftest%3D/activities/act%2B1%2Ftest%3D/reactions/heart');
+  });
+});
+
+// The reaction verbs now live on `ConversationClient`; the deprecated top-level
+// `client.reactions` accessor (the old chained path) is still supported until
+// officially removed.
+describe('client.reactions (deprecated accessor)', () => {
+  it('add should PUT a reaction', async () => {
+    const client = new ApiClient('');
+    const spy = jest.spyOn(client.http, 'put').mockResolvedValueOnce({});
+    await client.reactions.add('conv1', 'act1', 'like');
+    expect(spy).toHaveBeenCalledWith('/v3/conversations/conv1/activities/act1/reactions/like');
+  });
+
+  it('delete should DELETE a reaction', async () => {
+    const client = new ApiClient('');
+    const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
+    await client.reactions.delete('conv1', 'act1', 'like');
+    expect(spy).toHaveBeenCalledWith('/v3/conversations/conv1/activities/act1/reactions/like');
   });
 });

--- a/packages/api/src/clients/reaction/reaction.ts
+++ b/packages/api/src/clients/reaction/reaction.ts
@@ -38,8 +38,6 @@ export class ReactionClient {
 
   /**
    * Add a reaction to a message.
-   * @deprecated Use `conversations.addReaction(...)` instead. This will be
-   * removed in a future release.
    */
   async add(conversationId: string, activityId: string, reactionType: MessageReactionType) {
     const res = await this.http.put<void>(
@@ -50,8 +48,6 @@ export class ReactionClient {
 
   /**
    * Delete a reaction from a message.
-   * @deprecated Use `conversations.deleteReaction(...)` instead. This will be
-   * removed in a future release.
    */
   async delete(conversationId: string, activityId: string, reactionType: MessageReactionType) {
     const res = await this.http.delete<void>(

--- a/packages/api/src/clients/reaction/reaction.ts
+++ b/packages/api/src/clients/reaction/reaction.ts
@@ -38,6 +38,8 @@ export class ReactionClient {
 
   /**
    * Add a reaction to a message.
+   * @deprecated Use `conversations.addReaction(...)` instead. This will be
+   * removed in a future release.
    */
   async add(conversationId: string, activityId: string, reactionType: MessageReactionType) {
     const res = await this.http.put<void>(
@@ -48,6 +50,8 @@ export class ReactionClient {
 
   /**
    * Delete a reaction from a message.
+   * @deprecated Use `conversations.deleteReaction(...)` instead. This will be
+   * removed in a future release.
    */
   async delete(conversationId: string, activityId: string, reactionType: MessageReactionType) {
     const res = await this.http.delete<void>(

--- a/packages/api/src/clients/reaction/reaction.ts
+++ b/packages/api/src/clients/reaction/reaction.ts
@@ -40,6 +40,7 @@ export class ReactionClient {
    * Add a reaction to a message.
    */
   async add(conversationId: string, activityId: string, reactionType: MessageReactionType) {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     const res = await this.http.put<void>(
       `${this.serviceUrl}/v3/conversations/${encodeURIComponent(conversationId)}/activities/${encodeURIComponent(activityId)}/reactions/${encodeURIComponent(reactionType)}`
     );
@@ -50,6 +51,7 @@ export class ReactionClient {
    * Delete a reaction from a message.
    */
   async delete(conversationId: string, activityId: string, reactionType: MessageReactionType) {
+    // TODO: Will be deprecated alongside accessor in ConversationClient
     const res = await this.http.delete<void>(
       `${this.serviceUrl}/v3/conversations/${encodeURIComponent(conversationId)}/activities/${encodeURIComponent(activityId)}/reactions/${encodeURIComponent(reactionType)}`
     );

--- a/packages/api/src/clients/user/index.spec.ts
+++ b/packages/api/src/clients/user/index.spec.ts
@@ -1,0 +1,204 @@
+import { UserClient } from './index';
+
+describe('UserClient', () => {
+  it('getToken should GET the user token', async () => {
+    const client = new UserClient();
+    const spy = jest.spyOn(client.http, 'get').mockResolvedValueOnce({});
+
+    await client.getToken({
+      connectionName: 'graph',
+      userId: '1',
+      channelId: 'msteams',
+      code: '123',
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      'https://token.botframework.com/api/usertoken/GetToken?connectionName=graph&userId=1&channelId=msteams&code=123'
+    );
+  });
+
+  it('getAadTokens should POST for AAD tokens', async () => {
+    const client = new UserClient();
+    const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+    await client.getAadTokens({
+      connectionName: 'graph',
+      userId: '1',
+      channelId: 'msteams',
+      resourceUrls: [],
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      'https://token.botframework.com/api/usertoken/GetAadTokens?connectionName=graph&userId=1&channelId=msteams',
+      {
+        connectionName: 'graph',
+        userId: '1',
+        channelId: 'msteams',
+        resourceUrls: [],
+      }
+    );
+  });
+
+  it('getTokenStatus should GET the token status', async () => {
+    const client = new UserClient();
+    const spy = jest.spyOn(client.http, 'get').mockResolvedValueOnce({});
+
+    await client.getTokenStatus({
+      userId: '1',
+      channelId: 'msteams',
+      includeFilter: '',
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      'https://token.botframework.com/api/usertoken/GetTokenStatus?userId=1&channelId=msteams&includeFilter='
+    );
+  });
+
+  it('signOut should DELETE the user token', async () => {
+    const client = new UserClient();
+    const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
+
+    await client.signOut({
+      channelId: 'msteams',
+      connectionName: 'graph',
+      userId: '1',
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      'https://token.botframework.com/api/usertoken/SignOut?channelId=msteams&connectionName=graph&userId=1',
+      {
+        data: {
+          channelId: 'msteams',
+          connectionName: 'graph',
+          userId: '1',
+        },
+      }
+    );
+  });
+
+  it('exchangeToken should POST to exchange', async () => {
+    const client = new UserClient();
+    const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+    await client.exchangeToken({
+      channelId: 'msteams',
+      connectionName: 'graph',
+      userId: '1',
+      exchangeRequest: {
+        uri: 'http://localhost',
+        token: 'test',
+      },
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      'https://token.botframework.com/api/usertoken/exchange?userId=1&connectionName=graph&channelId=msteams',
+      {
+        uri: 'http://localhost',
+        token: 'test',
+      }
+    );
+  });
+
+  // The pre-flattening `token` sub-client accessor is still supported until
+  // officially removed; keep full coverage of it alongside the flattened
+  // methods above.
+  describe('deprecated token sub-client', () => {
+    it('token.get should GET the user token', async () => {
+      const client = new UserClient();
+      const spy = jest.spyOn(client.http, 'get').mockResolvedValueOnce({});
+
+      await client.token.get({
+        connectionName: 'graph',
+        userId: '1',
+        channelId: 'msteams',
+        code: '123',
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        'https://token.botframework.com/api/usertoken/GetToken?connectionName=graph&userId=1&channelId=msteams&code=123'
+      );
+    });
+
+    it('token.getAad should POST for AAD tokens', async () => {
+      const client = new UserClient();
+      const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+      await client.token.getAad({
+        connectionName: 'graph',
+        userId: '1',
+        channelId: 'msteams',
+        resourceUrls: [],
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        'https://token.botframework.com/api/usertoken/GetAadTokens?connectionName=graph&userId=1&channelId=msteams',
+        {
+          connectionName: 'graph',
+          userId: '1',
+          channelId: 'msteams',
+          resourceUrls: [],
+        }
+      );
+    });
+
+    it('token.getStatus should GET the token status', async () => {
+      const client = new UserClient();
+      const spy = jest.spyOn(client.http, 'get').mockResolvedValueOnce({});
+
+      await client.token.getStatus({
+        userId: '1',
+        channelId: 'msteams',
+        includeFilter: '',
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        'https://token.botframework.com/api/usertoken/GetTokenStatus?userId=1&channelId=msteams&includeFilter='
+      );
+    });
+
+    it('token.signOut should DELETE the user token', async () => {
+      const client = new UserClient();
+      const spy = jest.spyOn(client.http, 'delete').mockResolvedValueOnce({});
+
+      await client.token.signOut({
+        channelId: 'msteams',
+        connectionName: 'graph',
+        userId: '1',
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        'https://token.botframework.com/api/usertoken/SignOut?channelId=msteams&connectionName=graph&userId=1',
+        {
+          data: {
+            channelId: 'msteams',
+            connectionName: 'graph',
+            userId: '1',
+          },
+        }
+      );
+    });
+
+    it('token.exchange should POST to exchange', async () => {
+      const client = new UserClient();
+      const spy = jest.spyOn(client.http, 'post').mockResolvedValueOnce({});
+
+      await client.token.exchange({
+        channelId: 'msteams',
+        connectionName: 'graph',
+        userId: '1',
+        exchangeRequest: {
+          uri: 'http://localhost',
+          token: 'test',
+        },
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        'https://token.botframework.com/api/usertoken/exchange?userId=1&connectionName=graph&channelId=msteams',
+        {
+          uri: 'http://localhost',
+          token: 'test',
+        }
+      );
+    });
+  });
+});

--- a/packages/api/src/clients/user/index.ts
+++ b/packages/api/src/clients/user/index.ts
@@ -5,18 +5,32 @@ import {
 
 import { ApiClientSettings, mergeApiClientSettings } from '../api-client-settings';
 
-import { UserTokenClient } from './token';
+import {
+  ExchangeUserTokenParams,
+  GetUserAADTokenParams,
+  GetUserTokenParams,
+  GetUserTokenStatusParams,
+  SignOutUserParams,
+  UserTokenClient,
+} from './token';
 
 export class UserClient {
-  readonly token: UserTokenClient;
-
   get http() {
     return this._http;
   }
   set http(v) {
     this._http = v;
   }
+  /**
+   * @deprecated Use the flattened methods on `UserClient` instead
+   * (e.g. `users.getToken(...)`). This grouped accessor will be removed
+   * in a future release.
+   */
+  get token() {
+    return this._token;
+  }
   protected _http: HttpClient;
+  protected _token: UserTokenClient;
   protected _apiClientSettings: Partial<ApiClientSettings>;
 
   constructor(options?: HttpClient | HttpClientOptions, apiClientSettings?: Partial<ApiClientSettings>) {
@@ -29,7 +43,42 @@ export class UserClient {
     }
 
     this._apiClientSettings = mergeApiClientSettings(apiClientSettings);
-    this.token = new UserTokenClient(this.http, this._apiClientSettings);
+    this._token = new UserTokenClient(this.http, this._apiClientSettings);
+  }
+
+  /**
+   * Get a user token for the given connection.
+   */
+  getToken(params: GetUserTokenParams) {
+    return this._token.get(params);
+  }
+
+  /**
+   * Get AAD tokens for the given connection and resource urls.
+   */
+  getAadTokens(params: GetUserAADTokenParams) {
+    return this._token.getAad(params);
+  }
+
+  /**
+   * Get the token status for a user.
+   */
+  getTokenStatus(params: GetUserTokenStatusParams) {
+    return this._token.getStatus(params);
+  }
+
+  /**
+   * Sign a user out of the given connection.
+   */
+  signOut(params: SignOutUserParams) {
+    return this._token.signOut(params);
+  }
+
+  /**
+   * Exchange a user token for the given connection.
+   */
+  exchangeToken(params: ExchangeUserTokenParams) {
+    return this._token.exchange(params);
   }
 }
 

--- a/packages/api/src/clients/user/index.ts
+++ b/packages/api/src/clients/user/index.ts
@@ -18,9 +18,10 @@ export class UserClient {
   get http() {
     return this._http;
   }
-  set http(v) {
-    this._http = v;
-  }
+set http(v) {
+  this._token.http = v;
+  this._http = v;
+}
   /**
    * @deprecated Use the flattened methods on `UserClient` instead
    * (e.g. `users.getToken(...)`). This grouped accessor will be removed

--- a/packages/apps/src/activity-sender.ts
+++ b/packages/apps/src/activity-sender.ts
@@ -35,14 +35,14 @@ export class ActivitySender implements IActivitySender {
     // Decide create vs update, with targeted variants
     if (activity.id) {
       const res = isTargeted
-        ? await api.conversations.activities(ref.conversation.id).updateTargeted(activity.id, activity)
-        : await api.conversations.activities(ref.conversation.id).update(activity.id, activity);
+        ? await api.conversations.updateTargetedActivity(ref.conversation.id, activity.id, activity)
+        : await api.conversations.updateActivity(ref.conversation.id, activity.id, activity);
       return { ...activity, ...res };
     }
 
     const res = isTargeted
-      ? await api.conversations.activities(ref.conversation.id).createTargeted(activity)
-      : await api.conversations.activities(ref.conversation.id).create(activity);
+      ? await api.conversations.createTargetedActivity(ref.conversation.id, activity)
+      : await api.conversations.createActivity(ref.conversation.id, activity);
     return { ...activity, ...res };
   }
 

--- a/packages/apps/src/app.oauth.ts
+++ b/packages/apps/src/app.oauth.ts
@@ -42,7 +42,7 @@ export class OauthHandlers<TPlugin extends IPlugin = IPlugin> {
     }
 
     try {
-      const token = await api.users.token.exchange({
+      const token = await api.users.exchangeToken({
         channelId: activity.channelId,
         userId: activity.from.id,
         connectionName: activity.value.connectionName,
@@ -95,7 +95,7 @@ export class OauthHandlers<TPlugin extends IPlugin = IPlugin> {
         return { status: 404 };
       }
 
-      const token = await api.users.token.get({
+      const token = await api.users.getToken({
         channelId: activity.channelId,
         userId: activity.from.id,
         connectionName: this.getConnectionName(),

--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -243,7 +243,7 @@ export class ActivityProcessor<TPlugin extends IPlugin = IPlugin> {
    * fetch the user's token for the given channel/user, if signed in
    */
   private async getUserToken(channelId: ChannelID, userId: string) {
-    const res = await this.options.api.users.token.get({
+    const res = await this.options.api.users.getToken({
       channelId,
       userId,
       connectionName: this.options.getConnectionName(),

--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -30,10 +30,8 @@ describe('ActivityContext', () => {
 
     mockApiClient = {
       users: {
-        token: {
-          get: jest.fn(),
-          signOut: jest.fn(),
-        },
+        getToken: jest.fn(),
+        signOut: jest.fn(),
       },
       conversations: {
         create: jest.fn(),
@@ -529,7 +527,7 @@ describe('ActivityContext', () => {
 
     it('returns existing token if available', async () => {
       const expectedToken = 'test-token';
-      mockApiClient.users.token.get.mockResolvedValueOnce({
+      mockApiClient.users.getToken.mockResolvedValueOnce({
         token: expectedToken,
         connectionName: 'test-connection',
         channelId: 'test-channel',
@@ -539,7 +537,7 @@ describe('ActivityContext', () => {
       const result = await context.signin();
 
       expect(result).toBe(expectedToken);
-      expect(mockApiClient.users.token.get).toHaveBeenCalledWith({
+      expect(mockApiClient.users.getToken).toHaveBeenCalledWith({
         channelId: 'test-channel',
         userId: 'test-user',
         connectionName: 'test-connection',
@@ -547,7 +545,7 @@ describe('ActivityContext', () => {
     });
 
     it('creates oauth card for new signin in 1:1 chat', async () => {
-      mockApiClient.users.token.get.mockRejectedValueOnce(
+      mockApiClient.users.getToken.mockRejectedValueOnce(
         new Error('No token')
       );
       const mockResource = {
@@ -607,7 +605,7 @@ describe('ActivityContext', () => {
         activitySender: mockSender,
       });
 
-      mockApiClient.users.token.get.mockRejectedValueOnce(
+      mockApiClient.users.getToken.mockRejectedValueOnce(
         new Error('No token')
       );
       mockApiClient.conversations.create.mockResolvedValueOnce({
@@ -634,7 +632,7 @@ describe('ActivityContext', () => {
     it('forwards signout request to api client', async () => {
       await context.signout();
 
-      expect(mockApiClient.users.token.signOut).toHaveBeenCalledWith({
+      expect(mockApiClient.users.signOut).toHaveBeenCalledWith({
         channelId: 'test-channel',
         userId: 'test-user',
         connectionName: 'test-connection',

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -333,7 +333,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     const convo = { ...this.ref };
 
     try {
-      const res = await this.api.users.token.get({
+      const res = await this.api.users.getToken({
         channelId: this.activity.channelId,
         userId: this.activity.from.id,
         connectionName: connectionName || this.connectionName,
@@ -398,7 +398,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
   }
 
   async signout(connectionName?: string) {
-    await this.api.users.token.signOut({
+    await this.api.users.signOut({
       channelId: this.activity.channelId,
       userId: this.activity.from.id,
       connectionName: connectionName || this.connectionName,

--- a/packages/apps/src/http/http-stream.spec.ts
+++ b/packages/apps/src/http/http-stream.spec.ts
@@ -12,10 +12,8 @@ describe('HttpStream', () => {
   beforeEach(() => {
     client = {
       conversations: {
-        activities: jest.fn().mockReturnValue({
-          create: jest.fn(),
-          update: jest.fn(),
-        }),
+        createActivity: jest.fn(),
+        updateActivity: jest.fn(),
       },
     };
 
@@ -36,7 +34,7 @@ describe('HttpStream', () => {
 
   function mockCreate(successAfter = 0) {
     let calls = 0;
-    client.conversations.activities().create.mockImplementation(
+    client.conversations.createActivity.mockImplementation(
       async (_activity: any) => {
         calls++;
         if (calls <= successAfter) {
@@ -58,26 +56,26 @@ describe('HttpStream', () => {
     }
 
     // Initial emit triggers immediate flush
-    expect(client.conversations.activities().create).toHaveBeenCalledTimes(1);
+    expect(client.conversations.createActivity).toHaveBeenCalledTimes(1);
 
     await jest.advanceTimersByTimeAsync(200);
     // next flush will be after 500ms, so no new calls yet
-    expect(client.conversations.activities().create).toHaveBeenCalledTimes(1);
+    expect(client.conversations.createActivity).toHaveBeenCalledTimes(1);
     stream.emit('Message 13');
 
     await jest.advanceTimersByTimeAsync(300);
     // 500ms passed since first emit, second flush drains entire queue
-    expect(client.conversations.activities().create).toHaveBeenCalledTimes(2);
+    expect(client.conversations.createActivity).toHaveBeenCalledTimes(2);
     stream.emit('Message 14');
 
     await jest.advanceTimersByTimeAsync(500);
     // another 500ms passed, third flush picks up Message 14
-    expect(client.conversations.activities().create).toHaveBeenCalledTimes(3);
+    expect(client.conversations.createActivity).toHaveBeenCalledTimes(3);
 
-    const calls = client.conversations.activities().create.mock.calls;
-    expect(calls[0][0].text).toBe('Message 1');
-    expect(calls[1][0].text).toBe('Message 1Message 2Message 3Message 4Message 5Message 6Message 7Message 8Message 9Message 10Message 11Message 12Message 13');
-    expect(calls[2][0].text).toBe('Message 1Message 2Message 3Message 4Message 5Message 6Message 7Message 8Message 9Message 10Message 11Message 12Message 13Message 14');
+    const calls = client.conversations.createActivity.mock.calls;
+    expect(calls[0][1].text).toBe('Message 1');
+    expect(calls[1][1].text).toBe('Message 1Message 2Message 3Message 4Message 5Message 6Message 7Message 8Message 9Message 10Message 11Message 12Message 13');
+    expect(calls[2][1].text).toBe('Message 1Message 2Message 3Message 4Message 5Message 6Message 7Message 8Message 9Message 10Message 11Message 12Message 13Message 14');
   });
 
 
@@ -86,15 +84,15 @@ describe('HttpStream', () => {
     const stream = new HttpStream(client, ref, logger);
 
     stream.emit('Test message');
-    expect(client.conversations.activities().create).toHaveBeenCalledTimes(1);
+    expect(client.conversations.createActivity).toHaveBeenCalledTimes(1);
 
     // retry after 500ms
     await jest.advanceTimersByTimeAsync(500);
 
-    expect(client.conversations.activities().create).toHaveBeenCalledTimes(2);
-    const calls = client.conversations.activities().create.mock.calls;
-    expect(calls[0][0].text).toBe('Test message');
-    expect(calls[1][0].text).toBe('Test message');
+    expect(client.conversations.createActivity).toHaveBeenCalledTimes(2);
+    const calls = client.conversations.createActivity.mock.calls;
+    expect(calls[0][1].text).toBe('Test message');
+    expect(calls[1][1].text).toBe('Test message');
     const res = await stream.close();
     expect(res).toBeDefined();
   });
@@ -108,10 +106,10 @@ describe('HttpStream', () => {
     // resolve promise microtask queue
     await jest.runAllTicks();
 
-    const calls = client.conversations.activities().create.mock.calls;
-    expect(calls[0][0].type).toBe('typing');
-    expect(calls[0][0].text).toBe('Thinking...');
-    expect(calls[0][0].channelData?.streamType).toBe('informative');
+    const calls = client.conversations.createActivity.mock.calls;
+    expect(calls[0][1].type).toBe('typing');
+    expect(calls[0][1].text).toBe('Thinking...');
+    expect(calls[0][1].channelData?.streamType).toBe('informative');
     expect(stream['index']).toBe(0);
   });
 
@@ -139,10 +137,10 @@ describe('HttpStream', () => {
 
     await jest.advanceTimersByTimeAsync(500);
 
-    const calls = client.conversations.activities().create.mock.calls;
+    const calls = client.conversations.createActivity.mock.calls;
     expect(calls.length).toBe(2);
-    expect(calls[0][0].type).toBe('typing');
-    expect(calls[1][0].text).toContain('Final message');
+    expect(calls[0][1].type).toBe('typing');
+    expect(calls[1][1].text).toContain('Final message');
 
   });
 
@@ -172,7 +170,7 @@ describe('HttpStream', () => {
       statusText: 'Forbidden',
       config: {} as any,
     });
-    client.conversations.activities().create.mockRejectedValue(axiosError);
+    client.conversations.createActivity.mockRejectedValue(axiosError);
 
     stream.emit('Test message');
     await jest.runAllTimersAsync();
@@ -218,7 +216,7 @@ describe('HttpStream', () => {
       config: {} as any,
     });
 
-    client.conversations.activities().create.mockImplementation(async (_activity: any) => {
+    client.conversations.createActivity.mockImplementation(async (_activity: any) => {
       callCount++;
       if (callCount === 1) {
         return { _activity, id: 'activity-1' };
@@ -253,7 +251,8 @@ describe('HttpStream', () => {
     await jest.runAllTimersAsync();
     await closePromise;
 
-    expect(client.conversations.activities().create).toHaveBeenLastCalledWith(
+    expect(client.conversations.createActivity).toHaveBeenLastCalledWith(
+      expect.any(String),
       expect.objectContaining({
         type: 'message',
         text: 'first messagelast message',
@@ -279,7 +278,7 @@ describe('HttpStream', () => {
     await jest.advanceTimersByTimeAsync(100);
 
     // Verify close() is still waiting
-    const callsBeforeFlush = client.conversations.activities().create.mock.calls.length;
+    const callsBeforeFlush = client.conversations.createActivity.mock.calls.length;
     expect(callsBeforeFlush).toBe(0);
 
     // Simulate flush completing
@@ -289,7 +288,7 @@ describe('HttpStream', () => {
     await closePromise;
 
     // Now create() should have been called
-    const createCalls = client.conversations.activities().create.mock.calls.length;
+    const createCalls = client.conversations.createActivity.mock.calls.length;
     expect(createCalls).toBe(1);
   });
 
@@ -355,11 +354,11 @@ describe('HttpStream', () => {
     await jest.runAllTimersAsync();
     await closePromise;
 
-    const createCalls = client.conversations.activities().create.mock.calls;
+    const createCalls = client.conversations.createActivity.mock.calls;
     const finalCall = createCalls[createCalls.length - 1];
-    expect(finalCall[0].type).toBe('message');
-    expect(finalCall[0].text).toBe('');
-    expect(finalCall[0].attachments).toEqual([cardAttachment]);
-    expect(finalCall[0].channelData?.streamType).toBe('final');
+    expect(finalCall[1].type).toBe('message');
+    expect(finalCall[1].text).toBe('');
+    expect(finalCall[1].attachments).toEqual([cardAttachment]);
+    expect(finalCall[1].channelData?.streamType).toBe('final');
   });
 });

--- a/packages/apps/src/http/http-stream.spec.ts
+++ b/packages/apps/src/http/http-stream.spec.ts
@@ -35,13 +35,13 @@ describe('HttpStream', () => {
   function mockCreate(successAfter = 0) {
     let calls = 0;
     client.conversations.createActivity.mockImplementation(
-      async (_activity: any) => {
+      async (_conversationId: any, activity: any) => {
         calls++;
         if (calls <= successAfter) {
           throw new Error('timeout');
         }
 
-        return { _activity, id: `activity-${calls}` };
+        return { ...activity, id: `activity-${calls}` };
       }
     );
     return () => calls;
@@ -216,10 +216,10 @@ describe('HttpStream', () => {
       config: {} as any,
     });
 
-    client.conversations.createActivity.mockImplementation(async (_activity: any) => {
+    client.conversations.createActivity.mockImplementation(async (_conversationId: any, activity: any) => {
       callCount++;
       if (callCount === 1) {
-        return { _activity, id: 'activity-1' };
+        return { ...activity, id: 'activity-1' };
       }
       throw axiosError;
     });

--- a/packages/apps/src/http/http-stream.ts
+++ b/packages/apps/src/http/http-stream.ts
@@ -303,16 +303,19 @@ export class HttpStream implements IStreamer {
 
     try {
       if (activity.id && !(activity.entities?.some((e) => e.type === 'streaminfo') || false)) {
-        const res = await this.client.conversations
-          .activities(this.ref.conversation.id)
-          .update(activity.id, activity);
+        const res = await this.client.conversations.updateActivity(
+          this.ref.conversation.id,
+          activity.id,
+          activity
+        );
 
         return { ...activity, ...res };
       }
 
-      const res = await this.client.conversations
-        .activities(this.ref.conversation.id)
-        .create(activity);
+      const res = await this.client.conversations.createActivity(
+        this.ref.conversation.id,
+        activity
+      );
 
       return { ...activity, ...res };
     } catch (err: any) {

--- a/packages/apps/src/utils/function-context.spec.ts
+++ b/packages/apps/src/utils/function-context.spec.ts
@@ -9,8 +9,7 @@ const mockApp = (overrides: any = {}) => ({
   id: 'bot-id',
   api: {
     conversations: {
-      members: jest.fn().mockReturnThis(),
-      getById: jest.fn(),
+      getMemberById: jest.fn(),
       create: jest.fn(),
     },
   },
@@ -24,7 +23,7 @@ describe('getConversationIdResolver', () => {
 
   it('returns conversationId if user is a member', async () => {
     const app = mockApp();
-    app.api.conversations.getById = jest
+    app.api.conversations.getMemberById = jest
       .fn()
       .mockResolvedValue({ id: 'user-id' });
     const context = { userId: 'user-id', channelId: 'conv-123' };
@@ -35,13 +34,12 @@ describe('getConversationIdResolver', () => {
     );
     const id = await resolver();
     expect(id).toBe('conv-123');
-    expect(app.api.conversations.members).toHaveBeenCalledWith('conv-123');
-    expect(app.api.conversations.getById).toHaveBeenCalledWith('user-id');
+    expect(app.api.conversations.getMemberById).toHaveBeenCalledWith('conv-123', 'user-id');
   });
 
   it('returns undefined if member lookup fails', async () => {
     const app = mockApp();
-    app.api.conversations.getById = jest
+    app.api.conversations.getMemberById = jest
       .fn()
       .mockRejectedValue(new Error('not found'));
     const context = { userId: 'user-id', channelId: 'conv-123' };
@@ -60,7 +58,7 @@ describe('getConversationIdResolver', () => {
 
   it('returns undefined if user is not a member', async () => {
     const app = mockApp();
-    app.api.conversations.getById = jest.fn().mockReturnValue(null);
+    app.api.conversations.getMemberById = jest.fn().mockReturnValue(null);
     const context = { userId: 'user-id', channelId: 'conv-123' };
     const resolver = getConversationIdResolver(
       app.api as any,
@@ -123,7 +121,7 @@ describe('getConversationIdResolver', () => {
 
   it('caches the resolved conversation id', async () => {
     const app = mockApp();
-    app.api.conversations.getById = jest
+    app.api.conversations.getMemberById = jest
       .fn()
       .mockResolvedValue({ id: 'user-id' });
     const context = { userId: 'user-id', channelId: 'conv-123' };
@@ -136,6 +134,6 @@ describe('getConversationIdResolver', () => {
     const id2 = await resolver();
     expect(id1).toBe('conv-123');
     expect(id2).toBe('conv-123');
-    expect(app.api.conversations.getById).toHaveBeenCalledTimes(1);
+    expect(app.api.conversations.getMemberById).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/apps/src/utils/function-context.ts
+++ b/packages/apps/src/utils/function-context.ts
@@ -41,9 +41,7 @@ export function getConversationIdResolver(
     } else {
       // Validate that the bot and user are both members of the conversation.
       try {
-        const member = await api.conversations
-          .members(conversationId)
-          .getById(userId);
+        const member = await api.conversations.getMemberById(conversationId, userId);
         state = { id: !member ? undefined : conversationId };
       } catch {
         state = { id: undefined };


### PR DESCRIPTION
## Summary

Reduces the number of chained member accesses ("hops") needed to call the API by promoting grouped sub-client methods onto their parent clients. Common calls drop from **3 hops to 2**. The change is **additive and backward compatible** — the existing chained accessors remain as `@deprecated` aliases until officially removed.

## Flattening

| Old (deprecated, kept) | New |
| --- | --- |
| `users.token.{get,getAad,getStatus,signOut,exchange}` | `users.{getToken,getAadTokens,getTokenStatus,signOut,exchangeToken}` |
| `conversations.activities(id).{create,update,reply,delete,members,createTargeted,updateTargeted,deleteTargeted}` | `conversations.{createActivity,updateActivity,replyToActivity,deleteActivity,getActivityMembers,createTargetedActivity,updateTargetedActivity,deleteTargetedActivity}` |
| `conversations.members(id).{get,getById,getPaged,delete}` | `conversations.{getMembers,getMemberById,getPagedMembers}` |
| `client.reactions.{add,delete}` | `conversations.{addReaction,deleteReaction}` |

`teams.*` and `meetings.*` were already 2 hops — unchanged.

## Other changes

- **BotClient deprecated** — no longer used; the whole class and the `client.bots` accessor are marked `@deprecated` (not flattened).
- **Reactions moved** into the conversation/activity context (`conversations.addReaction(conversationId, activityId, type)`); `client.reactions` kept as a deprecated alias.
- **No internal use of deprecated members** — deprecated sub-client instances are held privately (`protected _token`/`_bots`/`_reactions`) and exposed via deprecated public accessors, so the flattened code and `Client.set http` never touch a deprecated member.
- **Internal callers migrated** — `@microsoft/teams.apps` now uses the flattened API.

## Tests

- New specs for the flattened methods on `UserClient` and `ConversationClient`.
- Full coverage of the deprecated chained aliases, co-located with the relevant sub-client specs.

## Verification

- `@microsoft/teams.api`: 20 suites / 194 tests ✓, lint ✓
- `@microsoft/teams.apps`: 19 suites / 284 tests ✓
- All essential (non-graph) packages build ✓

## Notes

- Deprecation notices intentionally omit a specific removal date ("in a future release"). Pre-existing deprecations elsewhere were left untouched.