### PR TITLE
chore(examples): migrate examples to the flattened conversation API

### DIFF
--- a/examples/message-extensions/src/index.ts
+++ b/examples/message-extensions/src/index.ts
@@ -81,7 +81,7 @@ app.on('message.ext.submit', async ({ activity }) => {
 
 app.on('message.ext.open', async ({ activity, api }) => {
   const conversationId = activity.conversation.id;
-  const members = await api.conversations.members(conversationId).get();
+  const members = await api.conversations.getMembers(conversationId);
   const card = createConversationMembersCard(members);
 
   return {

--- a/examples/reactions/README.md
+++ b/examples/reactions/README.md
@@ -1,12 +1,12 @@
 # Example: Reactions
 
-A bot that demonstrates how to use the ReactionClient to add and remove reactions on messages.
+A bot that demonstrates how to use the conversation reaction methods to add and remove reactions on messages.
 
 ## Features
 
 - Responds to user messages and adds reactions
 - Handles `messageReaction` activities to detect when users add/remove reactions
-- Demonstrates using the `ReactionClient` API to programmatically manage reactions
+- Demonstrates using the `conversations.addReaction` / `deleteReaction` API to programmatically manage reactions
 
 ## Usage
 
@@ -38,7 +38,7 @@ The CLI writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` to your `.env` file
 $: npm run dev
 ```
 
-## ReactionClient API
+## Reaction API
 
 ```typescript
 import { Client } from '@microsoft/teams.api';
@@ -46,10 +46,10 @@ import { Client } from '@microsoft/teams.api';
 const client = new Client(serviceUrl);
 
 // Add a reaction
-await client.reactions.add(conversationId, activityId, 'like');
+await client.conversations.addReaction(conversationId, activityId, 'like');
 
 // Delete a reaction
-await client.reactions.delete(conversationId, activityId, 'like');
+await client.conversations.deleteReaction(conversationId, activityId, 'like');
 ```
 
 ## Supported Reaction Types

--- a/examples/reactions/appPackage/manifest.json
+++ b/examples/reactions/appPackage/manifest.json
@@ -15,8 +15,8 @@
     "termsOfUseUrl": "https://www.microsoft.com/legal/terms-of-use"
   },
   "description": {
-    "short": "Demo bot showing how to use ReactionClient",
-    "full": "Sample bot that demonstrates how to use the ReactionClient API to add, remove, and respond to message reactions"
+    "short": "Demo bot showing how to use the reaction API",
+    "full": "Sample bot that demonstrates how to use the conversation reaction API to add, remove, and respond to message reactions"
   },
   "icons": {
     "outline": "outline.png",

--- a/examples/reactions/src/index.ts
+++ b/examples/reactions/src/index.ts
@@ -6,9 +6,9 @@ const app = new App({
   logger: new ConsoleLogger('@examples/reactions', { level: 'debug' })
 });
 
-// Store the service URL and conversation reference to use with ReactionClient
+// Reaction verbs live on the conversation client: conversations.addReaction / deleteReaction
 
-type ReactionParameter = Parameters<Client['reactions']['add']>[2];
+type ReactionParameter = Parameters<Client['conversations']['addReaction']>[2];
 
 // Handle incoming messages
 app.on('message', async ({ reply, activity, log, api }) => {
@@ -20,7 +20,7 @@ app.on('message', async ({ reply, activity, log, api }) => {
     await reply({
       type: 'message',
       text: '**Reactions Bot Help**\n\n' +
-        'I demonstrate how to use the ReactionClient API!\n\n' +
+        'I demonstrate how to use the reaction API!\n\n' +
         '**Commands:**\n' +
         '- Type "add [reaction]" - I\'ll add that reaction to your message\n' +
         '- Type "remove [reaction]" - I\'ll add that reaction and then remove it 2s later\n' +
@@ -34,7 +34,7 @@ app.on('message', async ({ reply, activity, log, api }) => {
   if (addMatch && api) {
     const reactionType = addMatch[1] as ReactionParameter;
     try {
-      await api.reactions.add(
+      await api.conversations.addReaction(
         activity.conversation.id,
         activity.id,
         reactionType
@@ -55,14 +55,14 @@ app.on('message', async ({ reply, activity, log, api }) => {
   if (removeMatch && api) {
     const reactionType = removeMatch[1] as ReactionParameter;
     try {
-      await api.reactions.add(
+      await api.conversations.addReaction(
         activity.conversation.id,
         activity.id,
         reactionType
       );
       await reply(`Added a ${reactionType} reaction, removing in 2s...`);
       await new Promise((resolve) => setTimeout(resolve, 2000));
-      await api.reactions.delete(
+      await api.conversations.deleteReaction(
         activity.conversation.id,
         activity.id,
         reactionType
@@ -115,7 +115,7 @@ app.on('install.add', async ({ send }) => {
   await send({
     type: 'message',
     text: '👋 **Welcome to the Reactions Bot!**\n\n' +
-      'I demonstrate how to use the ReactionClient to manage message reactions.\n\n' +
+      'I demonstrate how to use the reaction API to manage message reactions.\n\n' +
       'Type "help" to see what I can do!',
   });
 });

--- a/examples/targeted-messages/src/index.ts
+++ b/examples/targeted-messages/src/index.ts
@@ -21,9 +21,11 @@ app.on('message', async ({ send, activity, api }) => {
         const updatedMessage = new MessageActivity(
           `✏️ **Updated!** This message was modified at ${new Date().toISOString().slice(11, 19)}`
         );
-        await api.conversations
-          .activities(conversationId)
-          .updateTargeted(result.id, updatedMessage);
+        await api.conversations.updateTargetedActivity(
+          conversationId,
+          result.id,
+          updatedMessage
+        );
       } catch (err: any) {
         console.error('[UPDATE] Error:', err?.message || err);
       }
@@ -37,9 +39,7 @@ app.on('message', async ({ send, activity, api }) => {
 
     setTimeout(async () => {
       try {
-        await api.conversations
-          .activities(conversationId)
-          .deleteTargeted(result.id);
+        await api.conversations.deleteTargetedActivity(conversationId, result.id);
       } catch (err: any) {
         console.error('[DELETE] Error:', err?.message || err);
       }


### PR DESCRIPTION
Update the reactions, targeted-messages, and message-extensions examples to use the flattened conversations.* methods instead of the deprecated chained accessors.