### PR TITLE
docs(contributing): note npm CFS proxy for Microsoft-managed devices

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -19,3 +19,19 @@ Add an integration test when your change affects **what goes on the wire** — U
 Tests live in `test/integration/` — see the [README](test/integration/README.md) for setup and run instructions.
 
 👉 Full guidance: [INTEGRATION-TESTS.md](https://github.com/microsoft/teams-sdk/blob/main/INTEGRATION-TESTS.md#when-to-add-integration-tests)
+
+## npm Registry (Microsoft-managed devices)
+
+External contributors don't need extra setup; `npm ci` resolves from the public npm registry.
+
+On a **Microsoft-managed device**, direct access to `registry.npmjs.org` is blocked. Your machine should already be configured to route npm through the org's Central Feed Services (CFS) proxy, so installs reroute transparently. Verify with:
+
+```bash
+npm config get registry
+```
+
+If a tool fails or warns that it can't reach npm, follow the per-protocol setup instructions at [aka.ms/CFS](https://aka.ms/CFS) to point npm at the internal Azure Artifacts feed.
+
+> This is the device-level reroute that lets contributors install packages. Repo-level CFS onboarding (making the build itself consume through Azure Artifacts) is handled in the build pipeline, not configured here.
+
+> Newly published package versions are held in CFS for ~7 days. If a dependency bump can't be installed on a managed device, this quarantine hold is the likely cause.

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -34,4 +34,4 @@ If a tool fails or warns that it can't reach npm, follow the per-protocol setup 
 
 > This is the device-level reroute that lets contributors install packages. Repo-level CFS onboarding (making the build itself consume through Azure Artifacts) is handled in the build pipeline, not configured here.
 
-> Newly published package versions are held in CFS for ~7 days. If a dependency bump can't be installed on a managed device, this quarantine hold is the likely cause.
+> Newly published package versions are held in CFS for a short quarantine period before they become installable. If a recent dependency bump can't be installed on a managed device, this quarantine hold is the likely cause.


### PR DESCRIPTION
## What

Adds an "npm Registry (Microsoft-managed devices)" section to `CONTRIBUTING.MD`.

## Why

Direct access to `registry.npmjs.org` is now blocked on Microsoft-managed devices; npm/pnpm/yarn must resolve through the org's Central Feed Services (CFS) proxy. Contributors on managed devices hitting install failures had no guidance in-repo.

## Notes

- Points to [aka.ms/CFS](https://aka.ms/CFS) rather than hardcoding an internal feed URL — per CFS guidance, onboarding config stays private to the build and must not be committed to a public repo.
- Clarifies **external contributors are unaffected** (public npm still works for them).
- Distinguishes the device-level reroute (this note) from repo-level CFS onboarding (handled in the build pipeline, tracked separately).
