### PR TITLE
Add App info to ChannelData

### DIFF
--- a/packages/api/src/models/channel-data/app-info.ts
+++ b/packages/api/src/models/channel-data/app-info.ts
@@ -1,0 +1,17 @@
+/**
+ *
+ * An interface representing AppInfo.
+ * Describes an app.
+ *
+ */
+export type AppInfo = {
+  /**
+   * @member {string} [id] Unique identifier representing an app
+   */
+  id: string;
+
+  /**
+   * @member {string} [version] Version of the app
+   */
+  version?: string;
+};

--- a/packages/api/src/models/channel-data/index.ts
+++ b/packages/api/src/models/channel-data/index.ts
@@ -1,6 +1,7 @@
 import { MeetingInfo } from '../meeting';
 import { MembershipSource } from '../membership-source';
 
+import { AppInfo } from './app-info';
 import { ChannelInfo } from './channel-info';
 import { FeedbackLoop } from './feedback-loop';
 import { NotificationInfo } from './notification-info';
@@ -21,6 +22,11 @@ export type ChannelData = {
    * message was sent.
    */
   channel?: ChannelInfo;
+
+  /**
+   * @member {AppInfo} [app] Information about the app that sent the message.
+   */
+  app?: AppInfo;
 
   /**
    * @member {string} [eventType] Type of event.
@@ -114,6 +120,7 @@ export type ChannelData = {
   membershipSource?: MembershipSource;
 };
 
+export * from './app-info';
 export * from './channel-info';
 export * from './notification-info';
 export * from './on-behalf-of';


### PR DESCRIPTION
This pull request introduces support for including app-related metadata in channel data models. The main changes involve defining a new `AppInfo` type and integrating it with the existing `ChannelData` structure.

**App metadata integration:**

* Added a new `AppInfo` type in `app-info.ts` to represent app details such as `id` and optional `version`.
* Updated `ChannelData` in `index.ts` to include an optional `app` property of type `AppInfo`, allowing messages to carry information about the originating app.
* Imported the new `AppInfo` type into `index.ts` for use in the `ChannelData` type.
* Re-exported `AppInfo` from `index.ts` for easier access throughout the codebase.