### PR TITLE
set replyToId for all streaming activities

### DIFF
--- a/packages/apps/src/http/http-stream.spec.ts
+++ b/packages/apps/src/http/http-stream.spec.ts
@@ -551,4 +551,37 @@ describe('HttpStream', () => {
     expect(firstResult!.id).not.toBe(secondResult!.id);
     expect(closeResults.map((r) => r.id)).toEqual([firstResult!.id, secondResult!.id]);
   });
+
+  describe('replyToId threading', () => {
+    test('threads every streamed activity under the inbound message when ref.activityId is set', async () => {
+      const threadedRef = { ...ref, activityId: 'inbound-activity-id' };
+      const stream = new HttpStream(client, threadedRef, logger);
+      mockCreate();
+
+      stream.update('Thinking...'); // informative update
+      stream.emit('hello '); // streaming chunk
+      stream.emit('world');
+      const closePromise = stream.close(); // final message
+      await jest.runAllTimersAsync();
+      await closePromise;
+
+      const calls = client.conversations.createActivity.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+
+      // informative, streaming, and final sends are all threaded to the inbound message
+      for (const call of calls) {
+        expect(call[1].replyToId).toBe('inbound-activity-id');
+      }
+
+      // and specifically the final message
+      expect(client.conversations.createActivity).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          type: 'message',
+          channelData: expect.objectContaining({ streamType: 'final' }),
+          replyToId: 'inbound-activity-id',
+        })
+      );
+    });
+  });
 });

--- a/packages/apps/src/http/http-stream.ts
+++ b/packages/apps/src/http/http-stream.ts
@@ -412,6 +412,7 @@ export class HttpStream implements IStreamer {
       ...activity,
       from: this.ref.bot,
       conversation: this.ref.conversation,
+      replyToId: this.ref.activityId,
     };
 
     try {


### PR DESCRIPTION
updated the `send` method to set the `replyToId` field on every streaming activity
- matches v1 implementation (was automatically done through BF previously)