### PR TITLE
fix(apps): preserve activity instance so channelData accessors resolve

### DIFF
--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -111,6 +111,49 @@ describe('ActivityContext', () => {
     });
   };
 
+  describe('activity channelData accessors', () => {
+    // Inbound activities arrive as plain JSON objects off the wire, so the
+    // computed `channelData` getters (channel/team/meeting/notification/tenant)
+    // are not present on them. The ActivityContext must rehydrate the payload
+    // into an activity instance so those accessors resolve. A regression where
+    // the payload was flattened via `toInterface()` silently dropped these
+    // prototype getters, making them return `undefined`.
+    const buildInboundPayload = (): Activity => {
+      return {
+        type: 'message',
+        id: 'test-activity-id',
+        channelId: 'test-channel',
+        from: { id: 'test-user', name: 'Test User', role: 'user' },
+        recipient: { id: 'bot-id', name: 'Bot', role: 'bot' },
+        conversation: {
+          id: 'test-conversation',
+          conversationType: 'channel',
+          isGroup: false,
+        },
+        text: 'Hello world',
+        channelData: {
+          tenant: { id: 'tenant-id' },
+          channel: { id: 'channel-id' },
+          team: { id: 'team-id' },
+          meeting: { id: 'meeting-id' },
+          notification: { alert: true },
+        },
+      } as unknown as Activity;
+    };
+
+    it('resolves computed channelData accessors on a flattened inbound payload', () => {
+      const ctx = buildActivityContext(buildInboundPayload());
+
+      expect(ctx.activity.channel?.id).toEqual('channel-id');
+      expect(ctx.activity.team?.id).toEqual('team-id');
+      expect(ctx.activity.meeting?.id).toEqual('meeting-id');
+      expect(ctx.activity.notification?.alert).toEqual(true);
+      // `tenant` is a class-only getter (not declared on the public interface),
+      // so read it through the concrete instance shape.
+      expect((ctx.activity as { tenant?: { id: string } }).tenant?.id).toEqual('tenant-id');
+    });
+  });
+
   describe('reply', () => {
     it('stamps quotedReply entity with activity id', async () => {
       const activity = buildIncomingMessageActivity('Hello world');

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -235,20 +235,25 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     // Extract activitySender and next before Object.assign to avoid overwriting methods
     const { activitySender, next, ...rest } = value;
 
+    // Rehydrate the inbound payload into its activity instance so computed
+    // accessors (channel/team/meeting/notification/tenant) resolve. Do NOT
+    // call `toInterface()` here: it flattens the instance to a plain object via
+    // `Object.assign`, which drops the prototype getters and makes those
+    // accessors silently return `undefined`.
     if (rest.activity.type === 'message') {
-      rest.activity = MessageActivity.from(rest.activity).toInterface();
+      rest.activity = MessageActivity.from(rest.activity);
     }
 
     if (rest.activity.type === 'messageUpdate') {
-      rest.activity = MessageUpdateActivity.from(rest.activity).toInterface();
+      rest.activity = MessageUpdateActivity.from(rest.activity);
     }
 
     if (rest.activity.type === 'messageDelete') {
-      rest.activity = MessageDeleteActivity.from(rest.activity).toInterface();
+      rest.activity = MessageDeleteActivity.from(rest.activity);
     }
 
     if (rest.activity.type === 'typing') {
-      rest.activity = TypingActivity.from(rest.activity).toInterface();
+      rest.activity = TypingActivity.from(rest.activity);
     }
 
     // SECURITY: drop any keys in `rest` that would shadow prototype methods.


### PR DESCRIPTION
## Problem

`ctx.activity`'s computed accessors — `channel`, `team`, `meeting`, `notification`, `tenant` — silently return `undefined` at runtime, even though TypeScript types them as present (no compile error).

The `ActivityContext` constructor rehydrated the inbound payload with `MessageActivity.from(rest.activity).toInterface()`. `toInterface()` flattens the instance to a plain object via `Object.assign({}, this)`, which copies own-enumerable data props but **not** prototype getters. So every computed accessor was dropped. Raw `channelData.*` reads still worked, which is why it went unnoticed.

The getters (`channel`/`team`/`meeting`/`notification` are on the public `IActivity`) and the flattening were introduced together, so these accessors have never worked.

## Fix

Drop `.toInterface()` from the four rehydration branches (`message` / `messageUpdate` / `messageDelete` / `typing`) so the constructor keeps the live class instance and its prototype getters. Added an explanatory comment warning against re-adding it.

`toInterface()` itself is left untouched — it's an intentional POJO-snapshot producer used by `clone()` and when passing plain contexts to plugins. (Materializing the getters *inside* `toInterface()` instead breaks `clone()`: getter-only props throw `TypeError` under the constructor's `Object.assign`.)

## Test

Added a regression test (`activity channelData accessors`) that feeds a representative inbound payload through `ActivityContext` and asserts `channel`/`team`/`meeting`/`notification`/`tenant` all resolve. Fails on `main`, passes with this change.

## Blast radius

- Outbound `{...activity}` spreads (`activity-sender.ts`, `http-stream.ts`) operate on outbound `ActivityParams`, not `ctx.activity` — unaffected (getters were never enumerable, so spreads were never carrying them anyway).
- `ctx.activity` isn't persisted to storage (only `activity.conversation.id` is read for state keys) — no serialization round-trip.
- Full `@microsoft/teams.api` (201) and `@microsoft/teams.apps` (297) suites pass; lint clean.

**Note:** only the 4 message/typing types have concrete classes today; the other ~40 activity types are interface-only and remain plain objects. Restoring their getters is a larger follow-up.
