### PR TITLE
Port CI pipeline fixes to main and bump to 2.0.15-preview

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -74,14 +74,33 @@ extends:
             version: '8.x'
           target:
             container: host
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to Azure Artifacts'
+          target:
+            container: host
 
         - powershell: |
-            # Install nbgv
-            dotnet tool install -g nbgv
-            Write-Host "##vso[task.prependpath]$env:USERPROFILE\.dotnet\tools"
-            nbgv --version
+            $nugetConfig = "$(Agent.TempDirectory)\NuGet.TeamsSDKPreviews.config"
 
-            # Set cloud build number and variables (resolves detached HEAD in ADO)
+            @'
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="TeamsSDKPreviews" value="https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json" />
+              </packageSources>
+            </configuration>
+            '@ | Set-Content -Path $nugetConfig -Encoding UTF8
+
+            dotnet nuget list source --configfile $nugetConfig
+
+            dotnet tool install -g nbgv --configfile $nugetConfig
+
+            $toolsPath = Join-Path $env:USERPROFILE ".dotnet\tools"
+            $env:PATH = "$toolsPath;$env:PATH"
+            Write-Host "##vso[task.prependpath]$env:USERPROFILE\.dotnet\tools"
+
+            nbgv --version
             nbgv cloud
           displayName: 'Install nbgv and set cloud build version'
           target:

--- a/examples/mcp-server/turbo.json
+++ b/examples/mcp-server/turbo.json
@@ -9,7 +9,9 @@
         "@microsoft/teams.api#build",
         "@microsoft/teams.apps#build",
         "@microsoft/teams.cards#build",
-        "@microsoft/teams.common#build"
+        "@microsoft/teams.common#build",
+        "@microsoft/teams.graph#build",
+        "@microsoft/teams.graph-endpoints#build"
       ]
     }
   }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.14-preview.{height}",
+  "version": "2.0.15-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release$"


### PR DESCRIPTION
## What

Backports the pipeline fixes from #649 (merged to `release`) to `main`, and bumps `main` to the next preview version per RELEASE.md step 4.

### Commit 1 — port CI fixes
`main`'s publish pipeline has the same two bugs that #649 fixed on `release`:

- **`publish.yml`** — `nbgv` failed to install (`'nbgv' is not recognized`) because the private feed wasn't authenticated. Now installs from the `TeamsSDKPreviews` feed via a dedicated `NuGet.config` + `NuGetAuthenticate`.
- **`examples/mcp-server/turbo.json`** — the sample built before `@microsoft/teams.graph-endpoints` finished emitting its `.d.ts`, causing intermittent `TS7016`. Added `graph` and `graph-endpoints` to the build `dependsOn` so ordering is guaranteed (matches the `tab`/`graph` examples).

Both files are byte-identical to what's on `release`.

### Commit 2 — version bump
`2.0.14-preview.{height}` → `2.0.15-preview.{height}`. 2.0.14 is being published from `release`; move `main` to the next cycle.

## Verification
- Ported files match `release` exactly; `turbo.json` valid JSON.
- Full clean `npm run build` (all build outputs wiped) passes 35/35 tasks with no TS7016 — `graph-endpoints` builds before `mcp-server`.

Refs #649