### PR TITLE
fix(apps): add opt-out for per-activity user token lookup

### DIFF
--- a/packages/apps/src/app.process.spec.ts
+++ b/packages/apps/src/app.process.spec.ts
@@ -349,4 +349,62 @@ describe('App', () => {
       expect(errors[0].activity).toBeDefined();
     });
   });
+
+  describe('user token lookup', () => {
+    const userActivity = new MessageActivity('hi', {
+      id: 'a1',
+      channelId: 'msteams',
+      from: { id: 'user-1', name: 'User' },
+      conversation: { id: 'c1' },
+      recipient: { id: 'bot' },
+    } as Partial<IMessageActivity>);
+
+    it('does not fetch the user token when no OAuth connection is configured', async () => {
+      const testApp = createTestApp();
+      testApp.start();
+      const spy = jest.spyOn(testApp.api.users, 'getToken');
+
+      await testApp.process({ token, body: userActivity });
+
+      expect(spy).not.toHaveBeenCalled();
+      testApp.stop();
+    });
+
+    it('fetches the user token when an OAuth connection is configured', async () => {
+      const testApp = createTestApp({ oauth: { defaultConnectionName: 'graph' } });
+      testApp.start();
+      const spy = jest
+        .spyOn(testApp.api.users, 'getToken')
+        .mockResolvedValue({ token: 'user-token' } as any);
+
+      await testApp.process({ token, body: userActivity });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      testApp.stop();
+    });
+
+    it('honors an explicit fetchUserToken=false override even when OAuth is configured', async () => {
+      const testApp = createTestApp({ oauth: { defaultConnectionName: 'graph', fetchUserToken: false } });
+      testApp.start();
+      const spy = jest.spyOn(testApp.api.users, 'getToken');
+
+      await testApp.process({ token, body: userActivity });
+
+      expect(spy).not.toHaveBeenCalled();
+      testApp.stop();
+    });
+
+    it('honors an explicit fetchUserToken=true override when no OAuth connection is configured', async () => {
+      const testApp = createTestApp({ oauth: { fetchUserToken: true } });
+      testApp.start();
+      const spy = jest
+        .spyOn(testApp.api.users, 'getToken')
+        .mockResolvedValue({ token: 'user-token' } as any);
+
+      await testApp.process({ token, body: userActivity });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      testApp.stop();
+    });
+  });
 });

--- a/packages/apps/src/app.process.spec.ts
+++ b/packages/apps/src/app.process.spec.ts
@@ -351,6 +351,7 @@ describe('App', () => {
   });
 
   describe('user token lookup', () => {
+    let testApp: App;
     const userActivity = new MessageActivity('hi', {
       id: 'a1',
       channelId: 'msteams',
@@ -359,19 +360,22 @@ describe('App', () => {
       recipient: { id: 'bot' },
     } as Partial<IMessageActivity>);
 
+    afterEach(() => {
+      testApp?.stop();
+    });
+
     it('does not fetch the user token when no OAuth connection is configured', async () => {
-      const testApp = createTestApp();
+      testApp = createTestApp();
       testApp.start();
       const spy = jest.spyOn(testApp.api.users, 'getToken');
 
       await testApp.process({ token, body: userActivity });
 
       expect(spy).not.toHaveBeenCalled();
-      testApp.stop();
     });
 
     it('fetches the user token when an OAuth connection is configured', async () => {
-      const testApp = createTestApp({ oauth: { defaultConnectionName: 'graph' } });
+      testApp = createTestApp({ oauth: { defaultConnectionName: 'graph' } });
       testApp.start();
       const spy = jest
         .spyOn(testApp.api.users, 'getToken')
@@ -380,22 +384,20 @@ describe('App', () => {
       await testApp.process({ token, body: userActivity });
 
       expect(spy).toHaveBeenCalledTimes(1);
-      testApp.stop();
     });
 
     it('honors an explicit fetchUserToken=false override even when OAuth is configured', async () => {
-      const testApp = createTestApp({ oauth: { defaultConnectionName: 'graph', fetchUserToken: false } });
+      testApp = createTestApp({ oauth: { defaultConnectionName: 'graph', fetchUserToken: false } });
       testApp.start();
       const spy = jest.spyOn(testApp.api.users, 'getToken');
 
       await testApp.process({ token, body: userActivity });
 
       expect(spy).not.toHaveBeenCalled();
-      testApp.stop();
     });
 
     it('honors an explicit fetchUserToken=true override when no OAuth connection is configured', async () => {
-      const testApp = createTestApp({ oauth: { fetchUserToken: true } });
+      testApp = createTestApp({ oauth: { fetchUserToken: true } });
       testApp.start();
       const spy = jest
         .spyOn(testApp.api.users, 'getToken')
@@ -404,7 +406,6 @@ describe('App', () => {
       await testApp.process({ token, body: userActivity });
 
       expect(spy).toHaveBeenCalledTimes(1);
-      testApp.stop();
     });
   });
 });

--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -39,8 +39,9 @@ export interface IActivityProcessorOptions<TPlugin extends IPlugin = IPlugin> {
   readonly getId: () => string | undefined;
   readonly getConnectionName: () => string;
   /**
-   * whether to eagerly fetch the user's OAuth token on the inbound activity to
-   * populate `ctx.isSignedIn` / `ctx.userToken` / `ctx.userGraph`.
+   * whether to eagerly look up the user's OAuth token on the inbound activity.
+   * the token is used to compute `ctx.isSignedIn` and `ctx.userToken`, and to authenticate
+   * `ctx.userGraph` (which is always constructed regardless of this setting).
    */
   readonly shouldFetchUserToken: () => boolean;
   readonly apiClientSettings?: ApiClientSettings;

--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -38,6 +38,11 @@ export interface IActivityProcessorOptions<TPlugin extends IPlugin = IPlugin> {
   readonly log: ILogger;
   readonly getId: () => string | undefined;
   readonly getConnectionName: () => string;
+  /**
+   * whether to eagerly fetch the user's OAuth token on the inbound activity to
+   * populate `ctx.isSignedIn` / `ctx.userToken` / `ctx.userGraph`.
+   */
+  readonly shouldFetchUserToken: () => boolean;
   readonly apiClientSettings?: ApiClientSettings;
   readonly graphBaseUrl?: string;
 }
@@ -81,10 +86,14 @@ export class ActivityProcessor<TPlugin extends IPlugin = IPlugin> {
 
     let userToken: string | undefined;
 
-    try {
-      userToken = await this.getUserToken(activity.channelId, activity.from.id);
-    } catch (err) {
-      // noop
+    // Skipped unless configured (see OAuthSettings.fetchUserToken / auto-detection) to avoid
+    // a wasted user-token request on every activity when the app never reads ctx.userGraph.
+    if (this.options.shouldFetchUserToken()) {
+      try {
+        userToken = await this.getUserToken(activity.channelId, activity.from.id);
+      } catch (err) {
+        // noop
+      }
     }
 
     const client = this.options.client.clone();

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -349,6 +349,7 @@ export class App<TPlugin extends IPlugin = IPlugin> {
       log: this.log,
       getId: () => this.id,
       getConnectionName: () => this.oauth.defaultConnectionName,
+      shouldFetchUserToken: () => this.shouldFetchUserToken(),
       apiClientSettings: this.options.apiClientSettings,
       graphBaseUrl: this.graphBaseUrl,
     });
@@ -787,5 +788,19 @@ export class App<TPlugin extends IPlugin = IPlugin> {
   protected async getAppGraphToken(tenantId?: string) {
     if (!this.tokenManager) return;
     return await this.tokenManager.getGraphToken(tenantId);
+  }
+
+  /**
+   * whether to eagerly look up the user's OAuth token on every inbound activity.
+   * an explicit `oauth.fetchUserToken` wins; otherwise it is auto-detected, enabled
+   * only when an OAuth connection is explicitly configured, so apps that never use
+   * user OAuth do not pay for a wasted token request on every turn.
+   */
+  protected shouldFetchUserToken(): boolean {
+    const explicit = this.options.oauth?.fetchUserToken;
+    if (explicit !== undefined) {
+      return explicit;
+    }
+    return this.options.oauth?.defaultConnectionName !== undefined;
   }
 }

--- a/packages/apps/src/oauth.ts
+++ b/packages/apps/src/oauth.ts
@@ -7,8 +7,9 @@ export type OAuthSettings = {
   readonly defaultConnectionName?: string;
 
   /**
-   * whether to eagerly fetch the user's OAuth token on every inbound activity to
-   * populate `ctx.isSignedIn` / `ctx.userToken` / `ctx.userGraph`.
+   * whether to eagerly look up the user's OAuth token on every inbound activity.
+   * the token is used to compute `ctx.isSignedIn` and `ctx.userToken`, and to authenticate
+   * `ctx.userGraph` (which is always constructed regardless of this setting).
    * when left unset, this is auto-detected: enabled only when an OAuth connection is
    * explicitly configured via `defaultConnectionName`, so apps that never use user OAuth
    * do not pay for a wasted token request on every turn.

--- a/packages/apps/src/oauth.ts
+++ b/packages/apps/src/oauth.ts
@@ -5,8 +5,18 @@ export type OAuthSettings = {
    * @default `graph`
    */
   readonly defaultConnectionName?: string;
+
+  /**
+   * whether to eagerly fetch the user's OAuth token on every inbound activity to
+   * populate `ctx.isSignedIn` / `ctx.userToken` / `ctx.userGraph`.
+   * when left unset, this is auto-detected: enabled only when an OAuth connection is
+   * explicitly configured via `defaultConnectionName`, so apps that never use user OAuth
+   * do not pay for a wasted token request on every turn.
+   * set explicitly to `true` or `false` to override the auto-detection.
+   */
+  readonly fetchUserToken?: boolean;
 };
 
-export const DEFAULT_OAUTH_SETTINGS: Required<OAuthSettings> = {
+export const DEFAULT_OAUTH_SETTINGS: Required<Pick<OAuthSettings, 'defaultConnectionName'>> = {
   defaultConnectionName: 'graph'
 };


### PR DESCRIPTION
## Problem

Fixes #652

Every inbound activity triggers an eager Bot Framework `getUserToken` call, even when the app never uses `ctx.userGraph` / `ctx.isSignedIn`. For apps with no OAuth connection this adds latency per turn and emits ERROR spans (404s from the token service).

## Change (non-breaking)

Adds a `fetchUserToken` option to `OAuthSettings` that gates the eager token lookup.

- **Auto-detect default:** when unset, the lookup is skipped unless OAuth is explicitly configured (i.e. `oauth.defaultConnectionName` was provided by the user). Apps with no OAuth connection stop paying the cost with no config change.
- **Explicit override:** set `oauth.fetchUserToken: true` to force the lookup, or `false` to always skip it.

OAuth-configured apps are unchanged.

## Edge case

Apps that rely on the default `"graph"` connection *without* explicitly passing `oauth.defaultConnectionName`, and read `ctx.isSignedIn` / `ctx.userGraph`, will now see the fetch skipped. They must set `oauth.fetchUserToken: true`.

## Verification

- `eslint` clean; `tsc` build ok; all apps tests pass (added a `user token lookup` describe block).
- In-process transport check (no network): default app = **0** GetToken calls, OAuth app = **1** (unchanged), explicit opt-out = **0**.

The breaking full-laziness change (fetch on first access of `userGraph`, deprecate `isSignedIn`/`userToken`) is deferred to 2.1.