### PR TITLE
Remove activityId from reply POST URL

### DIFF
--- a/packages/api/src/clients/conversation/activity.spec.ts
+++ b/packages/api/src/clients/conversation/activity.spec.ts
@@ -229,7 +229,7 @@ describe('ConversationActivityClient', () => {
       text: 'hi',
     });
 
-    expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2', {
+    expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities', {
       type: 'message',
       text: 'hi',
       replyToId: '2',

--- a/packages/api/src/clients/conversation/activity.ts
+++ b/packages/api/src/clients/conversation/activity.ts
@@ -89,7 +89,7 @@ export class ConversationActivityClient {
     const activity = toActivityParams(params);
     activity.replyToId = id;
     const res = await this.http.post<Resource>(
-      `${this.serviceUrl}/v3/conversations/${conversationId}/activities/${id}`,
+      `${this.serviceUrl}/v3/conversations/${conversationId}/activities`,
       activity
     );
     return res.data;

--- a/packages/api/src/clients/conversation/index.spec.ts
+++ b/packages/api/src/clients/conversation/index.spec.ts
@@ -32,7 +32,7 @@ describe('ConversationClient', () => {
 
       await client.replyToActivity('1', '2', { type: 'message', text: 'hi' });
 
-      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2', {
+      expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities', {
         type: 'message',
         text: 'hi',
         replyToId: '2',
@@ -185,7 +185,7 @@ describe('ConversationClient', () => {
 
         await client.activities('1').reply('2', { type: 'message', text: 'hi' });
 
-        expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities/2', {
+        expect(spy).toHaveBeenCalledWith('/v3/conversations/1/activities', {
           type: 'message',
           text: 'hi',
           replyToId: '2',


### PR DESCRIPTION
## What

Changes the connector `reply` POST to target the base activities collection instead of the activity-scoped path:

- Before: `POST /v3/conversations/{conversationId}/activities/{activityId}`
- After: `POST /v3/conversations/{conversationId}/activities`

`replyToId` continues to be set in the request body, so reply semantics are unchanged. The `{activityId}` in the path was redundant: the service uses `replyToId` (body) for encryption purposes, not routing or threading, and threading is addressed via the `;messageid=` suffix on `conversationId`.

## Why

The only POST that included `{activityId}` in the path was `reply`. Removing it aligns the wire shape with the other sends (`create`, `createTargeted`), which already POST to the base `.../activities`. This also matches what the .NET `core` client already does (`ActivityClient.ReplyAsync` posts to base activities with `ReplyToId` in the body).

## Scope

- `packages/api/src/clients/conversation/activity.ts` — `reply()` URL
- Updated unit tests: `activity.spec.ts`, `index.spec.ts` (incl. deprecated `replyToActivity` accessor)

Integration tests are behavior-based (assert the returned reply has an id) and need no change; they validate the new URL against the live service.

No observable behavior change for `app.reply` / `ctx.reply` callers.