### PR TITLE
fix(api): add teamMemberAdded/Removed to conversationUpdate eventType union

### DIFF
--- a/packages/api/src/activities/conversation/conversation-update.ts
+++ b/packages/api/src/activities/conversation/conversation-update.ts
@@ -37,6 +37,8 @@ export interface IConversationUpdateActivity extends IActivity<'conversationUpda
       | 'teamHardDeleted'
       | 'teamRenamed'
       | 'teamRestored'
-      | 'teamUnarchived';
+      | 'teamUnarchived'
+      | 'teamMemberAdded'
+      | 'teamMemberRemoved';
   };
 }


### PR DESCRIPTION
## Summary

Type-completeness follow-up related to microsoft/teams.py#520.

The `conversationUpdate.channelData.eventType` union was missing `teamMemberAdded` and `teamMemberRemoved`, so consumers could not narrow to those events. This adds them for parity with the full set of Teams conversation event types (the union already includes the `channel*` and other `team*` variants).

### Note on scope

Unlike the Python SDK — where the equivalent gap caused a runtime `ValidationError` (see microsoft/teams.py#520) — TypeScript performs no runtime schema validation of activities, so an unknown `eventType` never throws at runtime. This change is therefore a **type-accuracy / DX improvement only**, not a runtime bug fix. Verified there are no exhaustive `switch` consumers of `eventType` that this would affect.

### Validation

- `turbo build --filter=@microsoft/teams.api` — succeeds (incl. DTS generation)
