### PR TITLE
feat(api/apps): add application/search invoke support

### DIFF
--- a/examples/cards/src/index.ts
+++ b/examples/cards/src/index.ts
@@ -209,6 +209,43 @@ function createProfileCardInputValidation() {
   return card;
 }
 
+// A dynamic typeahead ChoiceSet: instead of static `choices`, it declares a
+// `choices.data` Data.Query with a `dataset`. As the user types, Teams sends an
+// `application/search` invoke, handled by `app.on('search', ...)` below.
+function createDynamicSearchCard(): IAdaptiveCard {
+  return {
+    type: 'AdaptiveCard',
+    version: '1.5',
+    body: [
+      {
+        type: 'TextBlock',
+        text: 'Pick a Nintendo game (type to search):',
+        wrap: true,
+        style: 'heading',
+      },
+      {
+        type: 'Input.ChoiceSet',
+        id: 'game',
+        label: 'Game',
+        placeholder: 'Search for a game',
+        style: 'filtered',
+        choices: [],
+        'choices.data': {
+          type: 'Data.Query',
+          dataset: 'nintendoGames',
+        },
+      },
+    ],
+    actions: [
+      {
+        type: 'Action.Execute',
+        title: 'Submit',
+        data: { action: 'submit_game' },
+      },
+    ],
+  };
+}
+
 const app = new App({
 });
 
@@ -240,6 +277,10 @@ const cardGeneratorByName: Record<
   'profile-input-validation': {
     generator: createProfileCardInputValidation,
     description: 'Show card with input validation',
+  },
+  search: {
+    generator: createDynamicSearchCard,
+    description: 'Show card with dynamic typeahead search (application/search)',
   },
 };
 
@@ -348,6 +389,40 @@ app.on('card.action.save_profile', async ({ activity, send }) => {
   await send(
     `Profile saved!\nName: ${data.name}\nEmail: ${data.email}\nSubscribed: ${data.subscribe}`
   );
+  return OK_RESPONSE;
+});
+
+// The full catalog the typeahead searches over. In a real app this would be a
+// database or API call.
+const NINTENDO_GAMES = [
+  'The Legend of Zelda: Tears of the Kingdom',
+  'Super Mario Odyssey',
+  'Animal Crossing: New Horizons',
+  'Metroid Dread',
+  'Splatoon 3',
+  'Mario Kart 8 Deluxe',
+  'Super Smash Bros. Ultimate',
+  'Pikmin 4',
+];
+
+// Fired when the user types in the dynamic typeahead ChoiceSet above. Return the
+// matching results as `{ title, value }` pairs.
+app.on('search', async ({ activity }) => {
+  const query = activity.value.queryText?.toLowerCase() ?? '';
+  const results = NINTENDO_GAMES.filter((game) =>
+    game.toLowerCase().includes(query)
+  ).map((game) => ({ title: game, value: game }));
+
+  return {
+    statusCode: 200,
+    type: 'application/vnd.microsoft.search.searchResponse',
+    value: { results },
+  };
+});
+
+app.on('card.action.submit_game', async ({ activity, send }) => {
+  const data = activity.value.action.data;
+  await send(`You picked: ${data.game}`);
   return OK_RESPONSE;
 });
 

--- a/examples/cards/src/index.ts
+++ b/examples/cards/src/index.ts
@@ -211,7 +211,7 @@ function createProfileCardInputValidation() {
 
 // A dynamic typeahead ChoiceSet: instead of static `choices`, it declares a
 // `choices.data` Data.Query with a `dataset`. As the user types, Teams sends an
-// `application/search` invoke, handled by `app.on('search', ...)` below.
+// `application/search` invoke, handled by `app.on('card.search', ...)` below.
 function createDynamicSearchCard(): IAdaptiveCard {
   return {
     type: 'AdaptiveCard',
@@ -407,7 +407,7 @@ const NINTENDO_GAMES = [
 
 // Fired when the user types in the dynamic typeahead ChoiceSet above. Return the
 // matching results as `{ title, value }` pairs.
-app.on('search', async ({ activity }) => {
+app.on('card.search', async ({ activity }) => {
   const query = activity.value.queryText?.toLowerCase() ?? '';
   const results = NINTENDO_GAMES.filter((game) =>
     game.toLowerCase().includes(query)

--- a/packages/api/src/activities/invoke/index.ts
+++ b/packages/api/src/activities/invoke/index.ts
@@ -5,6 +5,7 @@ import { IFileConsentInvokeActivity } from './file-consent';
 import { IHandoffActionInvokeActivity } from './handoff-action';
 import { MessageInvokeActivity } from './message';
 import { MessageExtensionInvokeActivity } from './message-extension';
+import { ISearchInvokeActivity } from './search';
 import { SignInInvokeActivity } from './sign-in';
 import { ISuggestedActionSubmitInvokeActivity } from './suggested-action-submit';
 import { TabInvokeActivity } from './tab';
@@ -21,7 +22,8 @@ export type InvokeActivity =
   | IHandoffActionInvokeActivity
   | SignInInvokeActivity
   | AdaptiveCardInvokeActivity
-  | ISuggestedActionSubmitInvokeActivity;
+  | ISuggestedActionSubmitInvokeActivity
+  | ISearchInvokeActivity;
 
 export * from './file-consent';
 export * from './execute-action';
@@ -33,4 +35,5 @@ export * from './message';
 export * from './handoff-action';
 export * from './sign-in';
 export * from './suggested-action-submit';
+export * from './search';
 export * from './adaptive-card';

--- a/packages/api/src/activities/invoke/search.spec.ts
+++ b/packages/api/src/activities/invoke/search.spec.ts
@@ -1,0 +1,30 @@
+import { SearchInvokeValue } from '../../models';
+
+import { ISearchInvokeActivity } from './search';
+
+describe('SearchInvokeActivity', () => {
+  it('should match the expected wire format', () => {
+    const activity: ISearchInvokeActivity = {
+      type: 'invoke',
+      name: 'application/search',
+      value: { kind: 'search', queryText: 'hello', dataset: 'cities' },
+    } as ISearchInvokeActivity;
+
+    expect(activity.type).toEqual('invoke');
+    expect(activity.name).toEqual('application/search');
+    expect(activity.value.queryText).toEqual('hello');
+    expect(activity.value.dataset).toEqual('cities');
+  });
+
+  it('should accept a value without kind (Adaptive Card dynamic typeahead payload)', () => {
+    const value: SearchInvokeValue = {
+      queryText: 'mario',
+      queryOptions: { skip: 0, top: 5 },
+      dataset: 'nintendoGames',
+    };
+
+    expect(value.kind).toBeUndefined();
+    expect(value.queryText).toEqual('mario');
+    expect(value.dataset).toEqual('nintendoGames');
+  });
+});

--- a/packages/api/src/activities/invoke/search.ts
+++ b/packages/api/src/activities/invoke/search.ts
@@ -1,0 +1,18 @@
+import { SearchInvokeValue } from '../../models';
+import { IActivity } from '../activity';
+
+/**
+ * Sent when an Adaptive Card dynamic typeahead `Input.ChoiceSet` (via `choices.data` /
+ * `Data.Query`) requests choices. The bot responds with a `SearchInvokeResponse`.
+ */
+export interface ISearchInvokeActivity extends IActivity<'invoke'> {
+  /**
+   * The name of the operation associated with an invoke or event activity.
+   */
+  name: 'application/search';
+
+  /**
+   * A value that is associated with the activity.
+   */
+  value: SearchInvokeValue;
+}

--- a/packages/api/src/models/index.ts
+++ b/packages/api/src/models/index.ts
@@ -30,6 +30,7 @@ export * from './membership-source-types';
 export * from './membership-source';
 export * from './membership-types';
 export * from './adaptive-card';
+export * from './search';
 export * from './channel-data';
 export * from './team-details';
 export * from './meeting';

--- a/packages/api/src/models/invoke-response.ts
+++ b/packages/api/src/models/invoke-response.ts
@@ -3,6 +3,7 @@ import {
   ConfigResponse,
   MessagingExtensionActionResponse,
   MessagingExtensionResponse,
+  SearchInvokeResponse,
   TabResponse,
   TaskModuleResponse,
   TokenExchangeInvokeResponse,
@@ -63,4 +64,5 @@ type InvokeResponseBody = {
   'signin/verifyState': void;
   'signin/failure': void;
   'adaptiveCard/action': AdaptiveCardActionResponse;
+  'application/search': SearchInvokeResponse;
 };

--- a/packages/api/src/models/search/index.ts
+++ b/packages/api/src/models/search/index.ts
@@ -1,0 +1,2 @@
+export * from './search-invoke-value';
+export * from './search-response';

--- a/packages/api/src/models/search/search-invoke-value.ts
+++ b/packages/api/src/models/search/search-invoke-value.ts
@@ -1,0 +1,56 @@
+/**
+ * The kind of search invoke value. Must be either `search`, `searchAnswer`, or `typeahead`.
+ */
+export type SearchInvokeType = 'search' | 'searchAnswer' | 'typeahead';
+
+/**
+ * Defines the query options for an Invoke activity with Name of 'application/search'.
+ */
+export type SearchInvokeOptions = {
+  /**
+   * The starting reference number from which ordered search results should be returned.
+   */
+  skip?: number;
+
+  /**
+   * The number of search results that should be returned.
+   */
+  top?: number;
+};
+
+/**
+ * Defines the structure that arrives in the Activity.Value for an Invoke activity with
+ * Name of 'application/search'. Sent by Adaptive Card dynamic typeahead `Input.ChoiceSet`
+ * inputs (via `choices.data` / `Data.Query`).
+ */
+export type SearchInvokeValue = {
+  /**
+   * The kind for this search invoke value. Must be either `search`, `searchAnswer`, or
+   * `typeahead`. Omitted by Adaptive Card dynamic typeahead `Input.ChoiceSet` inputs, so this
+   * may be `undefined`.
+   */
+  kind?: SearchInvokeType;
+
+  /**
+   * The query text of this search invoke value.
+   */
+  queryText: string;
+
+  /**
+   * The query options for this search invoke.
+   */
+  queryOptions?: SearchInvokeOptions;
+
+  /**
+   * Context information about the query, such as the UI control that issued the query.
+   * The type is dependent on the `kind` field. For `search` and `searchAnswer` there is
+   * no defined context value.
+   */
+  context?: any;
+
+  /**
+   * The identifier of the dataset from which to fetch the choices, as authored on the
+   * Adaptive Card `Data.Query`.
+   */
+  dataset?: string;
+};

--- a/packages/api/src/models/search/search-response.ts
+++ b/packages/api/src/models/search/search-response.ts
@@ -1,0 +1,46 @@
+/**
+ * A single result returned in a `SearchInvokeResponse`. For Adaptive Card dynamic typeahead
+ * `Input.ChoiceSet`, `title` is the display text and `value` is the submitted value.
+ */
+export type SearchInvokeResult = {
+  /**
+   * The display text of the result.
+   */
+  title: string;
+
+  /**
+   * The value submitted when the result is selected.
+   */
+  value: string;
+};
+
+/**
+ * The value payload of a `SearchInvokeResponse`.
+ */
+export type SearchInvokeResponseValue = {
+  /**
+   * The list of search results.
+   */
+  results: SearchInvokeResult[];
+};
+
+/**
+ * Defines the structure returned as the result of an Invoke activity with Name of
+ * 'application/search'.
+ */
+export type SearchInvokeResponse = {
+  /**
+   * The response status code.
+   */
+  statusCode: number;
+
+  /**
+   * The type of this response.
+   */
+  type: 'application/vnd.microsoft.search.searchResponse';
+
+  /**
+   * The response value.
+   */
+  value: SearchInvokeResponseValue;
+};

--- a/packages/apps/src/router/router.spec.ts
+++ b/packages/apps/src/router/router.spec.ts
@@ -40,6 +40,24 @@ describe('Router', () => {
     expect(router.select({ type: 'invoke', name: 'signin/tokenExchange' } as any)).toHaveLength(1);
   });
 
+  it('should select "search" alias for application/search invoke', () => {
+    const router = new Router();
+    const handler = jest.fn();
+
+    router.on('search', handler);
+
+    expect(router.select({
+      type: 'invoke',
+      name: 'application/search',
+      value: { kind: 'search', queryText: 'hello' },
+    } as any)).toHaveLength(1);
+
+    expect(router.select({
+      type: 'invoke',
+      name: 'adaptiveCard/action',
+    } as any)).toHaveLength(0);
+  });
+
   describe('type', () => {
     it('should select type filtered routes', () => {
       const router = new Router();

--- a/packages/apps/src/router/router.spec.ts
+++ b/packages/apps/src/router/router.spec.ts
@@ -40,11 +40,11 @@ describe('Router', () => {
     expect(router.select({ type: 'invoke', name: 'signin/tokenExchange' } as any)).toHaveLength(1);
   });
 
-  it('should select "search" alias for application/search invoke', () => {
+  it('should select "card.search" alias for application/search invoke', () => {
     const router = new Router();
     const handler = jest.fn();
 
-    router.on('search', handler);
+    router.on('card.search', handler);
 
     expect(router.select({
       type: 'invoke',

--- a/packages/apps/src/routes/invoke/index.ts
+++ b/packages/apps/src/routes/invoke/index.ts
@@ -48,6 +48,7 @@ type InvokeAliases = {
   'signin/verifyState': 'signin.verify-state';
   'signin/failure': 'signin.failure';
   'adaptiveCard/action': 'card.action';
+  'application/search': 'search';
 };
 
 export const INVOKE_ALIASES: InvokeAliases = {
@@ -76,6 +77,7 @@ export const INVOKE_ALIASES: InvokeAliases = {
   'signin/verifyState': 'signin.verify-state',
   'signin/failure': 'signin.failure',
   'adaptiveCard/action': 'card.action',
+  'application/search': 'search',
 };
 
 export * from './card-action';

--- a/packages/apps/src/routes/invoke/index.ts
+++ b/packages/apps/src/routes/invoke/index.ts
@@ -48,7 +48,7 @@ type InvokeAliases = {
   'signin/verifyState': 'signin.verify-state';
   'signin/failure': 'signin.failure';
   'adaptiveCard/action': 'card.action';
-  'application/search': 'search';
+  'application/search': 'card.search';
 };
 
 export const INVOKE_ALIASES: InvokeAliases = {
@@ -77,7 +77,7 @@ export const INVOKE_ALIASES: InvokeAliases = {
   'signin/verifyState': 'signin.verify-state',
   'signin/failure': 'signin.failure',
   'adaptiveCard/action': 'card.action',
-  'application/search': 'search',
+  'application/search': 'card.search',
 };
 
 export * from './card-action';


### PR DESCRIPTION
## Summary

Adds support for the `application/search` invoke activity, sent by Adaptive Card dynamic typeahead `Input.ChoiceSet` inputs (`choices.data` `Data.Query`). Introduces the search value/response models, a typed `SearchInvokeActivity`, and routes the invoke to an `app.on('search', ...)` handler.

## Changes
- New `SearchInvokeValue` / `SearchInvokeResponse` models (`kind` optional to match the real Teams payload).
- `SearchInvokeActivity` added to the invoke activity union + invoke routing alias.
- Unit tests: wire-format serialization + no-`kind` handling.
- Cards example (`examples/cards`) demonstrates a dynamic typeahead card + search handler.

## Testing
- `npx turbo test --filter=@microsoft/teams.api`
- Live e2e on Teams web.

Closes #252
