### PR TITLE
Send OAuth/SSO sign-in cards natively in group chats & channels (targeted); drop 1:1 fallback

### DIFF
--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -673,7 +673,8 @@ describe('ActivityContext', () => {
           conversation: {
             id: 'channel-conv',
             conversationType: 'channel',
-            isGroup: true,
+            // isGroup deliberately false: channels must still be targeted via conversationType.
+            isGroup: false,
           },
         },
         activitySender: mockSender,
@@ -699,6 +700,45 @@ describe('ActivityContext', () => {
       expect(sentActivity.recipient.isTargeted).toBe(true);
       // Channels cannot do silent SSO, so the token exchange resource is omitted.
       expect(sentActivity.attachments[0].content.tokenExchangeResource).toBeUndefined();
+    });
+
+    it('passes the channel-filtered token exchange resource to overrideSignInActivity', async () => {
+      context = new ActivityContext({
+        ...context,
+        activity: {
+          ...buildIncomingMessageActivity('Test message'),
+          conversation: {
+            id: 'channel-conv',
+            conversationType: 'channel',
+            isGroup: true,
+          },
+        },
+        activitySender: mockSender,
+      });
+
+      mockApiClient.users.getToken.mockRejectedValueOnce(new Error('No token'));
+      const mockResource = {
+        tokenExchangeResource: {
+          uri: 'my-token-exhcange-resource-uri',
+        } as TokenExchangeResource,
+        tokenPostResource: { sasUrl: 'sas' } as TokenPostResource,
+        signInLink: 'https://login.url',
+      };
+      mockApiClient.bots.signIn.getResource.mockResolvedValueOnce(mockResource);
+
+      const overrideSignInActivity = jest
+        .fn()
+        .mockReturnValue({ type: 'message', text: 'custom sign-in' });
+
+      await context.signin({ overrideSignInActivity });
+
+      // In channels the override callback receives no token exchange resource, so a
+      // custom override can't trigger a silent SSO exchange Teams can't complete.
+      expect(overrideSignInActivity).toHaveBeenCalledWith(
+        undefined,
+        mockResource.tokenPostResource,
+        mockResource.signInLink
+      );
     });
 
     it('forwards signout request to api client', async () => {

--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -673,8 +673,7 @@ describe('ActivityContext', () => {
           conversation: {
             id: 'channel-conv',
             conversationType: 'channel',
-            // isGroup deliberately false: channels must still be targeted via conversationType.
-            isGroup: false,
+            isGroup: true,
           },
         },
         activitySender: mockSender,

--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -588,6 +588,19 @@ describe('ActivityContext', () => {
     });
 
     it('creates oauth card for new signin in 1:1 chat', async () => {
+      context = new ActivityContext({
+        ...context,
+        activity: {
+          ...buildIncomingMessageActivity('Test message'),
+          conversation: {
+            id: 'personal-conv',
+            conversationType: 'personal',
+            isGroup: false,
+          },
+        },
+        activitySender: mockSender,
+      });
+
       mockApiClient.users.getToken.mockRejectedValueOnce(
         new Error('No token')
       );
@@ -604,44 +617,25 @@ describe('ActivityContext', () => {
 
       await context.signin();
 
-      expect(mockSender.send).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'message',
-          attachments: [
-            {
-              content: {
-                buttons: [
-                  {
-                    title: 'Sign In',
-                    type: 'signin',
-                    value: 'https://login.url',
-                  },
-                ],
-                connectionName: 'test-connection',
-                text: 'Please Sign In...',
-                tokenExchangeResource: {
-                  uri: 'my-token-exhcange-resource-uri',
-                },
-                tokenPostResource: { sasUrl: 'my-token-post-resource-sas-url' },
-              },
-              contentType: 'application/vnd.microsoft.card.oauth',
-            },
-          ],
-          recipient: { id: 'test-user', name: 'Test User', role: 'user' },
-        }),
-        mockRef
-      );
+      // No 1:1 fallback conversation is created.
+      expect(mockApiClient.conversations.create).not.toHaveBeenCalled();
+      const sentActivity = (mockSender.send as jest.Mock).mock.calls[0][0];
+      // 1:1 sign-in cards are not targeted and keep the token exchange resource (SSO possible).
+      expect(sentActivity.recipient.isTargeted).toBeUndefined();
+      expect(sentActivity.attachments[0].content.tokenExchangeResource).toEqual({
+        uri: 'my-token-exhcange-resource-uri',
+      });
     });
 
-    it('creates new 1:1 conversation for group chat signin', async () => {
+    it('sends a targeted oauth card in a group chat without creating a 1:1', async () => {
       context = new ActivityContext({
         ...context,
         activity: {
           ...buildIncomingMessageActivity('Test message'),
           conversation: {
             id: 'group-conv',
+            conversationType: 'groupChat',
             isGroup: true,
-            conversationType: 'group',
           },
         },
         activitySender: mockSender,
@@ -650,13 +644,10 @@ describe('ActivityContext', () => {
       mockApiClient.users.getToken.mockRejectedValueOnce(
         new Error('No token')
       );
-      mockApiClient.conversations.create.mockResolvedValueOnce({
-        id: 'new-conv-id',
-        activityId: 'new-activity-id',
-        serviceUrl: '',
-      });
       const mockResource = {
-        tokenExchangeResource: {} as TokenExchangeResource,
+        tokenExchangeResource: {
+          uri: 'my-token-exhcange-resource-uri',
+        } as TokenExchangeResource,
         tokenPostResource: {} as TokenPostResource,
         signInLink: 'https://login.url',
       };
@@ -664,11 +655,50 @@ describe('ActivityContext', () => {
 
       await context.signin();
 
-      expect(mockApiClient.conversations.create).toHaveBeenCalled();
-      expect(mockSender.send).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'message', text: 'Please Sign In...' }),
-        expect.any(Object)
+      // No 1:1 fallback; the card is sent directly in the group chat, targeted to the user.
+      expect(mockApiClient.conversations.create).not.toHaveBeenCalled();
+      const sentActivity = (mockSender.send as jest.Mock).mock.calls[0][0];
+      expect(sentActivity.recipient.isTargeted).toBe(true);
+      // SSO token exchange remains available in group chats.
+      expect(sentActivity.attachments[0].content.tokenExchangeResource).toEqual({
+        uri: 'my-token-exhcange-resource-uri',
+      });
+    });
+
+    it('sends a targeted oauth card and omits token exchange in a channel', async () => {
+      context = new ActivityContext({
+        ...context,
+        activity: {
+          ...buildIncomingMessageActivity('Test message'),
+          conversation: {
+            id: 'channel-conv',
+            conversationType: 'channel',
+            isGroup: true,
+          },
+        },
+        activitySender: mockSender,
+      });
+
+      mockApiClient.users.getToken.mockRejectedValueOnce(
+        new Error('No token')
       );
+      const mockResource = {
+        tokenExchangeResource: {
+          uri: 'my-token-exhcange-resource-uri',
+        } as TokenExchangeResource,
+        tokenPostResource: {} as TokenPostResource,
+        signInLink: 'https://login.url',
+      };
+      mockApiClient.bots.signIn.getResource.mockResolvedValueOnce(mockResource);
+
+      await context.signin();
+
+      // No 1:1 fallback; card sent directly in the channel, targeted to the user.
+      expect(mockApiClient.conversations.create).not.toHaveBeenCalled();
+      const sentActivity = (mockSender.send as jest.Mock).mock.calls[0][0];
+      expect(sentActivity.recipient.isTargeted).toBe(true);
+      // Channels cannot do silent SSO, so the token exchange resource is omitted.
+      expect(sentActivity.attachments[0].content.tokenExchangeResource).toBeUndefined();
     });
 
     it('forwards signout request to api client', async () => {

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -397,18 +397,26 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
 
     // In group conversations (group chats and channels) the OAuth card is sent as a
     // targeted message so it is visible only to the requesting user rather than the
-    // whole conversation. Channels cannot perform the silent SSO token exchange, so
-    // the token exchange resource is omitted there to render the sign-in button
-    // (OAuth card flow) instead of attempting an exchange that would fail.
-    const isGroup = this.activity.conversation.isGroup === true;
+    // whole conversation. Channels are always group contexts, but `isGroup` is
+    // optional on the conversation, so treat channels as group scope to ensure the
+    // card is always targeted.
     const isChannel = this.activity.conversation.conversationType === 'channel';
+    const isGroup = this.activity.conversation.isGroup === true || isChannel;
     const recipient = isGroup
       ? { ...this.activity.from, isTargeted: true }
       : this.activity.from;
 
+    // Channels cannot perform the silent SSO token exchange, so omit the token
+    // exchange resource there to render the sign-in button (OAuth card flow). This is
+    // applied to both the default card and any custom override so an override cannot
+    // accidentally trigger an exchange that Teams can't complete in a channel.
+    const tokenExchangeResource = isChannel
+      ? undefined
+      : resource.tokenExchangeResource;
+
     await this.send(
       overrideSignInActivity?.(
-        resource.tokenExchangeResource,
+        tokenExchangeResource,
         resource.tokenPostResource,
         resource.signInLink
       ) ?? {
@@ -418,7 +426,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
           cardAttachment('oauth', {
             text: oauthCardText,
             connectionName: connectionName || this.connectionName,
-            tokenExchangeResource: isChannel ? undefined : resource.tokenExchangeResource,
+            tokenExchangeResource,
             tokenPostResource: resource.tokenPostResource,
             buttons: [
               {

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -397,11 +397,9 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
 
     // In group conversations (group chats and channels) the OAuth card is sent as a
     // targeted message so it is visible only to the requesting user rather than the
-    // whole conversation. Channels are always group contexts, but `isGroup` is
-    // optional on the conversation, so treat channels as group scope to ensure the
-    // card is always targeted.
+    // whole conversation.
     const isChannel = this.activity.conversation.conversationType === 'channel';
-    const isGroup = this.activity.conversation.isGroup === true || isChannel;
+    const isGroup = this.activity.conversation.isGroup === true;
     const recipient = isGroup
       ? { ...this.activity.from, isTargeted: true }
       : this.activity.from;

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -3,7 +3,6 @@ import {
   ActivityLike,
   ActivityParams,
   cardAttachment,
-  ConversationAccount,
   ConversationReference,
   DeprecatedInputActivity,
   InvokeResponse,
@@ -391,22 +390,21 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
       msAppId: this.appId,
     };
 
-    if (this.activity.conversation.isGroup) {
-      // create new 1:1 conversation with user to do SSO
-      // because groupchats don't support it.
-      const res = await this.api.conversations.create({
-        tenantId: this.activity.conversation.tenantId,
-        members: [this.activity.from],
-      });
-
-      await this.send({ type: 'message', text: oauthCardText });
-      convo.conversation = { id: res.id } as ConversationAccount;
-    }
-
     const state = Buffer.from(JSON.stringify(tokenExchangeState)).toString(
       'base64'
     );
     const resource = await this.api.bots.signIn.getResource({ state });
+
+    // In group conversations (group chats and channels) the OAuth card is sent as a
+    // targeted message so it is visible only to the requesting user rather than the
+    // whole conversation. Channels cannot perform the silent SSO token exchange, so
+    // the token exchange resource is omitted there to render the sign-in button
+    // (OAuth card flow) instead of attempting an exchange that would fail.
+    const isGroup = this.activity.conversation.isGroup === true;
+    const isChannel = this.activity.conversation.conversationType === 'channel';
+    const recipient = isGroup
+      ? { ...this.activity.from, isTargeted: true }
+      : this.activity.from;
 
     await this.send(
       overrideSignInActivity?.(
@@ -415,12 +413,12 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
         resource.signInLink
       ) ?? {
         type: 'message',
-        recipient: this.activity.from,
+        recipient,
         attachments: [
           cardAttachment('oauth', {
             text: oauthCardText,
             connectionName: connectionName || this.connectionName,
-            tokenExchangeResource: resource.tokenExchangeResource,
+            tokenExchangeResource: isChannel ? undefined : resource.tokenExchangeResource,
             tokenPostResource: resource.tokenPostResource,
             buttons: [
               {


### PR DESCRIPTION
## Summary

Updates `ActivityContext.signin()` to deliver the OAuth/SSO sign-in card **directly in the conversation** (as a targeted message) instead of falling back to a 1:1 chat.

merged TS counterpart of microsoft/teams.py#510.