### PR TITLE
feat: enforce 7-day package-age gate for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7

--- a/.github/scripts/dependabot-pr-age-check.mjs
+++ b/.github/scripts/dependabot-pr-age-check.mjs
@@ -38,11 +38,18 @@ async function main() {
   const pullRequests = await getTargetPullRequests(context);
 
   for (const pullRequest of pullRequests) {
-    if (!isDependabotPullRequest(pullRequest)) {
-      continue;
-    }
-
     try {
+      if (!isDependabotPullRequest(pullRequest)) {
+        // The gate only applies to Dependabot PRs, but when `package-age/7-day`
+        // is a required status check GitHub blocks any PR that never reports it.
+        // Publish a passing "not applicable" status so human PRs are never gated.
+        await setCommitStatus(context, pullRequest, {
+          state: 'success',
+          description: 'Not a Dependabot PR; package-age gate not applicable.',
+        });
+        continue;
+      }
+
       const assessment = await assessPullRequest(context, pullRequest);
       await setCommitStatus(context, pullRequest, assessment);
     } catch (error) {
@@ -232,6 +239,10 @@ async function getChangedVersionsFromLockfiles(context, pullRequest) {
   return [...changed.values()];
 }
 
+/**
+ * Returns all files changed by the PR (paginated), used to locate changed
+ * lockfiles.
+ */
 async function listPullRequestFiles(context, pullRequest) {
   const files = [];
   let page = 1;
@@ -275,7 +286,7 @@ async function readLockfileVersions(context, path, ref) {
   try {
     raw = await githubRequestRaw(
       context,
-      `/repos/${context.owner}/${context.repo}/contents/${encodeURIComponent(path)}?ref=${ref}`,
+      `/repos/${context.owner}/${context.repo}/contents/${encodePath(path)}?ref=${ref}`,
     );
   } catch (error) {
     console.warn(`Could not fetch ${path} at ${ref}:`, error.message);
@@ -308,6 +319,20 @@ async function readLockfileVersions(context, path, ref) {
   return versions;
 }
 
+/**
+ * Encodes a repository file path for the GitHub Contents API, escaping each
+ * segment individually so that directory separators are preserved (nested
+ * lockfiles such as `packages/foo/package-lock.json` resolve correctly).
+ */
+function encodePath(path) {
+  return path.split('/').map(encodeURIComponent).join('/');
+}
+
+/**
+ * Extracts the package name from an npm v2/v3 lockfile install path (the text
+ * after the final `node_modules/` segment), or null if the path is not a
+ * dependency install path.
+ */
 function installPathToName(installPath) {
   const marker = 'node_modules/';
   const index = installPath.lastIndexOf(marker);
@@ -317,6 +342,10 @@ function installPathToName(installPath) {
   return installPath.slice(index + marker.length);
 }
 
+/**
+ * Recursively collects `name@version` entries from the nested `dependencies`
+ * tree of an npm v1 lockfile into the provided map.
+ */
 function collectV1Dependencies(dependencies, versions) {
   if (!dependencies) {
     return;
@@ -467,7 +496,7 @@ async function githubRequest(context, path, options = {}) {
 async function githubRequestRaw(context, path) {
   const response = await fetch(`https://api.github.com${path}`, {
     headers: {
-      Accept: 'application/vnd.github.raw+json',
+      Accept: 'application/vnd.github.raw',
       Authorization: `Bearer ${context.token}`,
       'User-Agent': `${context.owner}-${context.repo}-package-age-gate`,
     },

--- a/.github/scripts/dependabot-pr-age-check.mjs
+++ b/.github/scripts/dependabot-pr-age-check.mjs
@@ -1,0 +1,486 @@
+// @ts-check
+import { readFileSync } from 'node:fs';
+
+/**
+ * Enforced 7-day package-age gate for Dependabot pull requests.
+ *
+ * Microsoft Central Feed Services (CFS) quarantines newly-published npm
+ * versions for 7 days (measured from the public npm publish timestamp). During
+ * quarantine the version "appears not to exist" on the Azure Artifacts feed, so
+ * `npm ci` hard-fails (E404) if a PR merges a version younger than 7 days. This
+ * script protects `main` by publishing a *required commit status*
+ * (`package-age/7-day`) on each Dependabot PR head. When any changed package
+ * version (including transitive lockfile changes) is younger than 7 days, or its
+ * age cannot be confirmed, the status is set to `failure`/`pending` so branch
+ * protection blocks the merge. It flips to `success` only once every changed
+ * version has cleared the 7-day window.
+ *
+ * The gate deliberately fails safe: an un-verifiable age blocks the merge rather
+ * than allowing a potentially-quarantined package through.
+ */
+
+const AGE_THRESHOLD_DAYS = 7;
+const STATUS_CONTEXT = 'package-age/7-day';
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org';
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+const LOCKFILE_SUFFIX = 'package-lock.json';
+const STATUS_DESCRIPTION_LIMIT = 140;
+
+/**
+ * Fallback parser for Dependabot PR prose when no lockfile diff is available.
+ * Handles both single ("Bumps `X` from A to B") and grouped ("Updates `X` from
+ * A to B") update wording.
+ */
+const DEPENDENCY_UPDATE_PATTERN = /(?:Bumps|Updates)\s+(?:\[(?<linked>[^\]]+)\]\([^)]+\)|`(?<code>[^`]+)`|(?<plain>[^\s]+))\s+from\s+(?<from>[^\s]+)\s+to\s+(?<to>[^\s]+)/gi;
+
+async function main() {
+  const context = loadContext();
+  const pullRequests = await getTargetPullRequests(context);
+
+  for (const pullRequest of pullRequests) {
+    if (!isDependabotPullRequest(pullRequest)) {
+      continue;
+    }
+
+    try {
+      const assessment = await assessPullRequest(context, pullRequest);
+      await setCommitStatus(context, pullRequest, assessment);
+    } catch (error) {
+      console.error(`Failed to evaluate PR #${pullRequest.number}:`, error);
+      // Fail safe: never leave a Dependabot PR mergeable because our own
+      // evaluation crashed.
+      await setCommitStatus(context, pullRequest, {
+        state: 'failure',
+        description: 'Package-age check failed to run; blocking merge until it can be re-evaluated.',
+      }).catch((statusError) => console.error('Failed to set failure status:', statusError));
+    }
+  }
+}
+
+/**
+ * Reads the required environment configuration provided by the GitHub Actions
+ * runtime.
+ */
+function loadContext() {
+  const repository = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN;
+
+  if (!repository || !token) {
+    throw new Error('GITHUB_REPOSITORY and GITHUB_TOKEN are required.');
+  }
+
+  const [owner, repo] = repository.split('/');
+  if (!owner || !repo) {
+    throw new Error(`Invalid GITHUB_REPOSITORY value: ${repository}`);
+  }
+
+  return {
+    eventName: process.env.GITHUB_EVENT_NAME ?? '',
+    eventPath: process.env.GITHUB_EVENT_PATH ?? '',
+    owner,
+    repo,
+    token,
+  };
+}
+
+function readEventPayload(eventPath) {
+  if (!eventPath) {
+    return {};
+  }
+
+  return JSON.parse(readFileSync(eventPath, 'utf8'));
+}
+
+/**
+ * Returns the pull requests to evaluate. On a `pull_request*` event this is the
+ * single triggering PR; on a scheduled/dispatch run it is every open PR (so
+ * that pending PRs auto-clear once their packages age past the threshold).
+ */
+async function getTargetPullRequests(context) {
+  const payload = readEventPayload(context.eventPath);
+  if (payload.pull_request) {
+    return [payload.pull_request];
+  }
+
+  return await listOpenPullRequests(context);
+}
+
+async function listOpenPullRequests(context) {
+  const pullRequests = [];
+  let page = 1;
+
+  while (true) {
+    const response = await githubRequest(
+      context,
+      `/repos/${context.owner}/${context.repo}/pulls?state=open&per_page=100&page=${page}`,
+    );
+
+    if (response.length === 0) {
+      break;
+    }
+
+    pullRequests.push(...response);
+
+    if (response.length < 100) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return pullRequests;
+}
+
+function isDependabotPullRequest(pullRequest) {
+  return pullRequest.user?.login === 'dependabot[bot]';
+}
+
+/**
+ * Determines the age-eligibility of a PR by inspecting every package version it
+ * changes. Prefers the lockfile diff (captures transitive changes CFS also
+ * quarantines) and falls back to parsing the PR body when no lockfile changed.
+ *
+ * @returns {Promise<{state: 'success'|'failure'|'pending', description: string}>}
+ */
+async function assessPullRequest(context, pullRequest) {
+  let changedVersions = await getChangedVersionsFromLockfiles(context, pullRequest);
+  let source = 'lockfile';
+
+  if (changedVersions.length === 0) {
+    changedVersions = extractDependencyUpdatesFromBody(pullRequest);
+    source = 'pr-body';
+  }
+
+  if (changedVersions.length === 0) {
+    return {
+      state: 'failure',
+      description: 'Could not determine changed package versions; blocking merge (fail-safe).',
+    };
+  }
+
+  const ages = await Promise.allSettled(
+    changedVersions.map((dependency) => getDependencyAge(dependency)),
+  );
+
+  const resolved = ages.map((result, index) =>
+    result.status === 'fulfilled'
+      ? result.value
+      : { ...changedVersions[index], ageDays: null, publishedAt: null },
+  );
+
+  const unverifiable = resolved.filter((dependency) => dependency.ageDays === null);
+  if (unverifiable.length > 0) {
+    const names = unverifiable.map((d) => `${d.name}@${d.version}`).slice(0, 3).join(', ');
+    return {
+      state: 'failure',
+      description: truncate(
+        `Could not confirm npm age for ${unverifiable.length} package(s) (${names}); blocking merge (fail-safe).`,
+      ),
+    };
+  }
+
+  const tooYoung = resolved
+    .filter((dependency) => dependency.ageDays < AGE_THRESHOLD_DAYS)
+    .sort((a, b) => a.ageDays - b.ageDays);
+
+  if (tooYoung.length > 0) {
+    const youngest = tooYoung[0];
+    const readyAt = new Date(youngest.publishedAt.getTime() + AGE_THRESHOLD_DAYS * MILLISECONDS_PER_DAY);
+    return {
+      state: 'pending',
+      description: truncate(
+        `${youngest.name}@${youngest.version} is ${youngest.ageDays}d old (<${AGE_THRESHOLD_DAYS}d CFS quarantine). Eligible ${formatDate(readyAt)} UTC.`,
+      ),
+    };
+  }
+
+  return {
+    state: 'success',
+    description: truncate(
+      `All ${resolved.length} changed package version(s) are >= ${AGE_THRESHOLD_DAYS} days old [${source}].`,
+    ),
+  };
+}
+
+/**
+ * Collects the set of package versions newly introduced by the PR across every
+ * changed `package-lock.json`, including transitive dependencies.
+ *
+ * @returns {Promise<Array<{name: string, version: string}>>}
+ */
+async function getChangedVersionsFromLockfiles(context, pullRequest) {
+  const files = await listPullRequestFiles(context, pullRequest);
+  const lockfilePaths = files
+    .filter((file) => file.filename.endsWith(LOCKFILE_SUFFIX) && file.status !== 'removed')
+    .map((file) => file.filename);
+
+  const changed = new Map();
+
+  for (const path of lockfilePaths) {
+    const [baseVersions, headVersions] = await Promise.all([
+      readLockfileVersions(context, path, pullRequest.base?.sha),
+      readLockfileVersions(context, path, pullRequest.head?.sha),
+    ]);
+
+    for (const [key, dependency] of headVersions) {
+      if (!baseVersions.has(key)) {
+        changed.set(key, dependency);
+      }
+    }
+  }
+
+  return [...changed.values()];
+}
+
+async function listPullRequestFiles(context, pullRequest) {
+  const files = [];
+  let page = 1;
+
+  while (true) {
+    const response = await githubRequest(
+      context,
+      `/repos/${context.owner}/${context.repo}/pulls/${pullRequest.number}/files?per_page=100&page=${page}`,
+    );
+
+    if (response.length === 0) {
+      break;
+    }
+
+    files.push(...response);
+
+    if (response.length < 100) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return files;
+}
+
+/**
+ * Reads a lockfile at a specific ref and returns a map of `name@version` to
+ * `{ name, version }`. Returns an empty map if the file is missing or
+ * unparseable at that ref.
+ *
+ * @returns {Promise<Map<string, {name: string, version: string}>>}
+ */
+async function readLockfileVersions(context, path, ref) {
+  const versions = new Map();
+  if (!ref) {
+    return versions;
+  }
+
+  let raw;
+  try {
+    raw = await githubRequestRaw(
+      context,
+      `/repos/${context.owner}/${context.repo}/contents/${encodeURIComponent(path)}?ref=${ref}`,
+    );
+  } catch (error) {
+    console.warn(`Could not fetch ${path} at ${ref}:`, error.message);
+    return versions;
+  }
+
+  let lockfile;
+  try {
+    lockfile = JSON.parse(raw);
+  } catch (error) {
+    console.warn(`Could not parse ${path} at ${ref}:`, error.message);
+    return versions;
+  }
+
+  // npm lockfile v2/v3: `packages` keyed by install path.
+  for (const [installPath, entry] of Object.entries(lockfile.packages ?? {})) {
+    if (installPath === '' || !entry?.version) {
+      continue; // root project entry has no meaningful published version
+    }
+    const name = entry.name ?? installPathToName(installPath);
+    if (!name) {
+      continue;
+    }
+    versions.set(`${name}@${entry.version}`, { name, version: entry.version });
+  }
+
+  // npm lockfile v1 fallback: nested `dependencies`.
+  collectV1Dependencies(lockfile.dependencies, versions);
+
+  return versions;
+}
+
+function installPathToName(installPath) {
+  const marker = 'node_modules/';
+  const index = installPath.lastIndexOf(marker);
+  if (index === -1) {
+    return null;
+  }
+  return installPath.slice(index + marker.length);
+}
+
+function collectV1Dependencies(dependencies, versions) {
+  if (!dependencies) {
+    return;
+  }
+  for (const [name, entry] of Object.entries(dependencies)) {
+    if (entry?.version) {
+      versions.set(`${name}@${entry.version}`, { name, version: entry.version });
+    }
+    collectV1Dependencies(entry?.dependencies, versions);
+  }
+}
+
+/**
+ * Fallback: parse changed dependency versions from the Dependabot PR body when
+ * no lockfile diff is available.
+ *
+ * @returns {Array<{name: string, version: string}>}
+ */
+function extractDependencyUpdatesFromBody(pullRequest) {
+  const text = `${pullRequest.title ?? ''}\n${pullRequest.body ?? ''}`;
+  const updates = new Map();
+
+  for (const match of text.matchAll(DEPENDENCY_UPDATE_PATTERN)) {
+    const name = sanitizeToken(match.groups?.linked ?? match.groups?.code ?? match.groups?.plain ?? '');
+    const version = sanitizeToken(match.groups?.to ?? '');
+
+    if (!name || !version) {
+      continue;
+    }
+
+    updates.set(`${name}@${version}`, { name, version });
+  }
+
+  return [...updates.values()];
+}
+
+function sanitizeToken(value) {
+  return value.replace(/[),.;]+$/u, '').trim();
+}
+
+/**
+ * Looks up the npm publish timestamp for a specific version and computes its
+ * age in days. `ageDays`/`publishedAt` are null when the version is unpublished,
+ * missing from metadata, or the registry request fails (treated as
+ * unverifiable => merge-blocking upstream).
+ */
+async function getDependencyAge(dependency) {
+  let response;
+  try {
+    response = await fetch(`${NPM_REGISTRY_URL}/${encodeURIComponent(dependency.name)}`, {
+      headers: { Accept: 'application/json' },
+    });
+  } catch (error) {
+    console.warn(`npm registry request failed for ${dependency.name}:`, error.message);
+    return { ...dependency, ageDays: null, publishedAt: null };
+  }
+
+  if (!response.ok) {
+    console.warn(`npm registry returned ${response.status} for ${dependency.name}`);
+    return { ...dependency, ageDays: null, publishedAt: null };
+  }
+
+  let metadata;
+  try {
+    metadata = await response.json();
+  } catch (error) {
+    console.warn(`Could not parse npm metadata for ${dependency.name}:`, error.message);
+    return { ...dependency, ageDays: null, publishedAt: null };
+  }
+
+  const publishedAtValue = metadata.time?.[dependency.version] ?? null;
+  if (!publishedAtValue) {
+    return { ...dependency, ageDays: null, publishedAt: null };
+  }
+
+  const publishedAt = new Date(publishedAtValue);
+  return {
+    ...dependency,
+    ageDays: Math.floor((Date.now() - publishedAt.getTime()) / MILLISECONDS_PER_DAY),
+    publishedAt,
+  };
+}
+
+/**
+ * Publishes the age-gate result as a commit status on the PR head SHA. The
+ * Commit Status API replaces any prior status for the same context, so repeated
+ * runs update in place without spamming.
+ */
+async function setCommitStatus(context, pullRequest, assessment) {
+  const sha = pullRequest.head?.sha;
+  if (!sha) {
+    throw new Error(`PR #${pullRequest.number} has no head SHA.`);
+  }
+
+  await githubRequest(
+    context,
+    `/repos/${context.owner}/${context.repo}/statuses/${sha}`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        state: assessment.state,
+        context: STATUS_CONTEXT,
+        description: truncate(assessment.description),
+      }),
+    },
+  );
+
+  console.log(`PR #${pullRequest.number} [${sha.slice(0, 7)}] -> ${assessment.state}: ${assessment.description}`);
+}
+
+function truncate(value) {
+  if (value.length <= STATUS_DESCRIPTION_LIMIT) {
+    return value;
+  }
+  return `${value.slice(0, STATUS_DESCRIPTION_LIMIT - 1)}\u2026`;
+}
+
+function formatDate(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+async function githubRequest(context, path, options = {}) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...options,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${context.token}`,
+      'User-Agent': `${context.owner}-${context.repo}-package-age-gate`,
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed (${response.status}) for ${path}: ${await response.text()}`);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return await response.json();
+}
+
+/**
+ * Fetches file contents as raw text (handles files larger than the 1MB inline
+ * base64 limit of the Contents API).
+ */
+async function githubRequestRaw(context, path) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Accept: 'application/vnd.github.raw+json',
+      Authorization: `Bearer ${context.token}`,
+      'User-Agent': `${context.owner}-${context.repo}-package-age-gate`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub raw request failed (${response.status}) for ${path}`);
+  }
+
+  return await response.text();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/.github/workflows/dependabot-package-age-gate.yml
+++ b/.github/workflows/dependabot-package-age-gate.yml
@@ -1,0 +1,35 @@
+name: Dependabot Package Age Gate
+
+# Publishes a required commit status ("package-age/7-day") on every Dependabot
+# PR. The status is `success` only when all changed package versions (including
+# transitive lockfile changes) are at least 7 days old, matching the Microsoft
+# Central Feed Services (CFS) npm quarantine window. Configure this status as a
+# required check in branch protection so a `failure`/`pending` state blocks the
+# merge and prevents `npm ci` from breaking on quarantined packages.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  schedule:
+    # Daily re-check so PRs that were too new auto-clear once packages age past
+    # the 7-day window.
+    - cron: '17 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  age-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+      - name: Evaluate Dependabot package age
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/dependabot-pr-age-check.mjs


### PR DESCRIPTION
## Summary

Enforces a 7-day minimum package-age policy on Dependabot PRs so we never merge an npm version that is still inside the Microsoft **Central Feed Services (CFS)** quarantine window. CFS defers newly-published npm versions for 7 days (measured from the public npm publish time); during quarantine the version is not served by the Azure Artifacts feed, so merging a fresh package breaks `npm ci` (E404) for the whole repo.

## What changed

- **`.github/dependabot.yml`** — enables npm version updates with a 7-day `cooldown` (major/minor/patch), delaying version-update PRs until the target release is ≥7 days old.
- **`.github/workflows/dependabot-package-age-gate.yml`** — publishes a `package-age/7-day` commit status on every Dependabot PR. Runs on `pull_request_target` (opened/synchronize/reopened), a daily schedule (so PRs that were too new auto-clear once packages age out), and `workflow_dispatch`.
- **`.github/scripts/dependabot-pr-age-check.mjs`** — computes eligibility from the `package-lock.json` diff (every added version, including transitive) and sets the status: `success` when all changed versions are ≥7 days old, `pending` when a version is <7 days old (description shows the eligible date), and `failure` when age can't be confirmed (fail-safe: blocks merge).

## Why `cooldown` alone isn't enough

`dependabot.yml` `cooldown` only applies to version updates. Dependabot security updates ignore cooldown and open immediately with the fixed version — which may be <7 days old and break `npm ci`. The gate covers all Dependabot PRs (security + version), closing that hole.

## ⚠️ Required follow-up

Enforcement is inert until `package-age/7-day` is added as a required status check in branch protection for `main`. Until then the status posts but does not block merges.

## Testing

Validated the script end-to-end against mocked GitHub + npm responses: all-old→success, young top-level→pending (+eligible date), young transitive dep→pending, missing npm timestamp→failure, registry 404→failure.
