### PR TITLE
Prepare main for 2.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,21 +2,29 @@
 
 This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) for automatic version management.
 
+Each maintained release line uses a versioned branch named `release/v<major>.<minor>` (for example, `release/v2.0`). Set `RELEASE_BRANCH` to the line you are releasing before running the commands below:
+
+```bash
+RELEASE_BRANCH=release/v2.0
+```
+
 ## Creating a Release
 
-1. **Create a branch from `release`** and merge `main` into it:
+1. **Create a preparation branch from the matching release branch**:
    ```bash
-   git checkout -b prep-release/<next-version> release
-   git merge origin/main
+   git fetch origin
+   git checkout -b prep-release/<next-version> "origin/$RELEASE_BRANCH"
    ```
+   - If `main` is still on the same major/minor development line, merge `origin/main`
+   - For an older maintained line, include only the intended backports; do not merge a newer development line
    - Set `version.json` to the stable version being released (e.g. remove the `-preview.{height}` suffix)
    - Commit and push
 
-2. **Create a PR to `release`** (base: `release`, compare: `prep-release/<next-version>`):
-   - The PR will include all changes from main plus the version bump
+2. **Create a PR to `$RELEASE_BRANCH`** (compare: `prep-release/<next-version>`):
+   - The PR will include the intended changes for that release line plus the version bump
    - Get teammate approval and merge
 
-3. **Trigger the [release pipeline](https://dev.azure.com/DomoreexpGithub/Github_Pipelines/_build?definitionId=52&_a=summary)** for the `release` branch with **Public** publish type
+3. **Trigger the [release pipeline](https://dev.azure.com/DomoreexpGithub/Github_Pipelines/_build?definitionId=52&_a=summary)** for `$RELEASE_BRANCH` with **Public** publish type
 
 4. **Bump the version on main** for the next release cycle:
    - Edit `version.json` on main
@@ -26,10 +34,10 @@ This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.Gi
 5. **Create the git tag and GitHub Release page** after packages land on npm:
    ```bash
    gh release create v<version> -R microsoft/teams.ts \
-     --target release --title "v<version>" --draft \
+     --target "$RELEASE_BRANCH" --title "v<version>" --draft \
      --generate-notes --notes-start-tag v<previous-version>
    ```
-   The auto-generated notes walk back from `release`, which is squash-merged — so the list will only show the release PR. To get the real PR delta from `main`, query by date:
+   The auto-generated notes walk back from the versioned release branch, which is squash-merged — so the list will only show the release PR. To get the real PR delta from `main`, query by date:
    ```bash
    gh api -X GET search/issues \
      -f q='repo:microsoft/teams.ts is:pr is:merged base:main merged:>=<previous-release-publish-date>' \
@@ -41,17 +49,17 @@ This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.Gi
 
 To fix a bug in a released version without including new preview changes:
 
-1. **Consider if a normal release would work instead** - merging main to release includes all updates and is simpler. Only use a hotfix if you need to exclude preview changes from main.
+1. **Consider if a normal release would work instead** - when `main` is on the same development line, merging it into the matching release branch includes all updates and is simpler. Only use a hotfix if you need to exclude newer changes from main.
 
-2. **Create a branch from `release`**:
+2. **Create a branch from the matching versioned release branch**:
    ```bash
-   git checkout release
-   git checkout -b hotfix/fix-description
+   git fetch origin
+   git checkout -b hotfix/fix-description "origin/$RELEASE_BRANCH"
    ```
 
 3. **Make your fix and commit**
 
-4. **Create a PR to `release`**, get approval, and merge
+4. **Create a PR to `$RELEASE_BRANCH`**, get approval, and merge
 
 5. **Trigger the release pipeline**
 
@@ -85,15 +93,16 @@ To publish experimental versions from a feature branch:
 
 To bump from `2.0.x` to `2.1.x` or `3.0.x`:
 
-1. Edit `version.json` on main branch
-2. Update the version (e.g. `"2.0.x-preview.{height}"` → `"2.1.0-preview.{height}"` or `"3.0.0-preview.{height}"`)
-3. Commit and push
+1. Ensure the current line is preserved in its versioned release branch (for example, `release/v2.0`)
+2. Edit `version.json` on main branch
+3. Update the version (e.g. `"2.0.x-preview.{height}"` → `"2.1.0-preview.{height}"` or `"3.0.0-preview.{height}"`)
+4. Commit and push
 
 ## How Versioning Works
 
 - Versions are computed automatically from git history based on `version.json`
 - **Main branch**: `X.Y.Z-preview.1`, `X.Y.Z-preview.2`, etc. (prerelease, published with `next` npm tag)
-- **Release branch**: `X.Y.Z`, etc. (stable, published with `latest` npm tag)
+- **Versioned release branches** (`release/v<major>.<minor>`): `X.Y.Z`, etc. (stable, published with `latest` npm tag)
 
 ## Publishing
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.1.0",
+  "version": "2.1.0-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+$"

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.15-preview.{height}",
+  "version": "2.1.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
-    "^refs/heads/release$"
+    "^refs/heads/release/v\\d+\\.\\d+$"
   ]
 }


### PR DESCRIPTION
## Summary

Starts the 2.1 development line with preview builds while preserving the 2.0 train at `release/v2.0`—old line safe, new line ready for mischief. Release matching and guidance now support future `release/v<major>.<minor>` maintenance branches.

## Decisions

- **Let NBGV reset preview height naturally.** The version change emits `2.1.0-preview.1` from its first committed build, matching prior version bumps; no `versionHeightOffset` is needed.
- **Keep release handling future-safe.** `main` and exact versioned release lines remain public-release refs, and the repository ruleset protects `release/v*`.

## Deferred

Stable `2.1.0` and the `release/v2.1` branch are intentionally deferred until 2.1 is ready to ship.