### PR TITLE
fix(api): the final streamed message carries no streamSequence

### DIFF
--- a/packages/api/src/activities/message/message.spec.ts
+++ b/packages/api/src/activities/message/message.spec.ts
@@ -2,7 +2,7 @@ import { AdaptiveCard, TextBlock } from '@microsoft/teams.cards';
 
 import { Account, cardAttachment } from '../../models';
 
-import { MessageActivity } from './message';
+import { MessageActivity, MessageActivityInput } from './message';
 
 describe('MessageActivity', () => {
   const user: Account = {
@@ -467,6 +467,30 @@ describe('MessageActivity', () => {
         .addQuote('msg-1')
         .addText(' manual text');
       expect(activity.text).toEqual('<quoted messageId="msg-1"/> manual text');
+    });
+  });
+
+  describe('addStreamFinal', () => {
+    // Teams documents `streamSequence` as required on every streaming request except this one:
+    // "For the final message, `streamSequence` must not be set."
+    it('should not put a streamSequence on the final', () => {
+      const activity = new MessageActivityInput('done').withId('stream-1').addStreamFinal();
+
+      const streamInfo = (activity.entities ?? []).find((e) => e.type === 'streaminfo');
+      expect(streamInfo).toMatchObject({ streamId: 'stream-1', streamType: 'final' });
+      expect(streamInfo).not.toHaveProperty('streamSequence');
+      expect(activity.channelData).not.toHaveProperty('streamSequence');
+    });
+
+    it('should drop a streamSequence carried over from the chunks', () => {
+      const activity = new MessageActivityInput('done')
+        .withChannelData({ streamId: 'stream-1', streamType: 'streaming', streamSequence: 4 })
+        .addStreamFinal();
+
+      const streamInfo = (activity.entities ?? []).find((e) => e.type === 'streaminfo');
+      expect(streamInfo).not.toHaveProperty('streamSequence');
+      expect(activity.channelData).not.toHaveProperty('streamSequence');
+      expect(activity.channelData?.streamType).toEqual('final');
     });
   });
 });

--- a/packages/api/src/activities/message/message.ts
+++ b/packages/api/src/activities/message/message.ts
@@ -315,6 +315,10 @@ export class MessageActivityInput extends ActivityInput<'message'> implements IM
 
   /**
    * Mark the message as the final activity in a stream.
+   *
+   * The final carries no `streamSequence`. Teams documents the sequence as required on every streaming
+   * request except this one: "For the final message, `streamSequence` must not be set."
+   * https://learn.microsoft.com/en-us/microsoftteams/platform/bots/streaming-ux#stream-message-through-rest-api
    */
   addStreamFinal() {
     if (!this.channelData) {
@@ -322,17 +326,15 @@ export class MessageActivityInput extends ActivityInput<'message'> implements IM
     }
 
     const streamId = this.channelData.streamId || this.id || '';
-    const streamSequence = this.channelData.streamSequence ?? 1;
 
     this.channelData.streamId = streamId;
     this.channelData.streamType = 'final';
-    this.channelData.streamSequence = streamSequence;
+    delete this.channelData.streamSequence;
 
     this.addEntity({
       type: 'streaminfo',
       streamId,
       streamType: 'final',
-      streamSequence,
     });
 
     return this;


### PR DESCRIPTION
Fixes #687.

`MessageActivityInput.addStreamFinal()` puts `streamSequence: this.channelData.streamSequence ?? 1` on the final's `streaminfo` entity and on its `channelData`. Teams documents the sequence as required on every streaming request *except* this one:

> Here are the requirements for using `streamSequence` for REST APIs:
> - First one must be number '1'.
> - Subsequent numbers (except final) must be a monotonic increasing integer (for example, 1->2->3).
> - **For the final message, `streamSequence` must not be set.**

— [Stream agent messages](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/streaming-ux#stream-message-through-rest-api)

`HttpStream.close()` builds its final with `MessageActivityInput`, so every final the streamer sends carries the field. `MessageActivity.addStreamFinal()` — the sibling implementation in the same file — already omits it, so this brings the two in line rather than inventing a shape.

The sequence is also deleted from `channelData`, so one carried over from the chunks doesn't reach the wire either.

### Tests
Two added in `message.spec.ts`: the final's entity and channelData have no `streamSequence`, and a sequence carried over from the chunks is dropped while `streamType` still becomes `final`.

- `packages/api` — 205 passed, 21 suites
- `packages/apps` — `src/http` 63 passed, `http-stream.spec.ts` included

### Note on impact
The service accepts a final carrying `streamSequence` with `202 {}`, so nothing surfaces in logs. On a real tenant we saw finals not consistently terminating the stream in the client — the bubble keeping its Stop button while the message was delivered — but we could not make that deterministic, and a stale web client muddied our own investigation. So this PR is offered as "the SDK sends a field the contract forbids there", not as a proven fix for that symptom.