### PR TITLE
Sync main into 2.1 preview release

### DIFF
--- a/packages/api/src/activities/message/message.spec.ts
+++ b/packages/api/src/activities/message/message.spec.ts
@@ -2,7 +2,7 @@ import { AdaptiveCard, TextBlock } from '@microsoft/teams.cards';
 
 import { Account, cardAttachment } from '../../models';
 
-import { MessageActivity } from './message';
+import { MessageActivity, MessageActivityInput } from './message';
 
 describe('MessageActivity', () => {
   const user: Account = {
@@ -467,6 +467,30 @@ describe('MessageActivity', () => {
         .addQuote('msg-1')
         .addText(' manual text');
       expect(activity.text).toEqual('<quoted messageId="msg-1"/> manual text');
+    });
+  });
+
+  describe('addStreamFinal', () => {
+    // Teams documents `streamSequence` as required on every streaming request except this one:
+    // "For the final message, `streamSequence` must not be set."
+    it('should not put a streamSequence on the final', () => {
+      const activity = new MessageActivityInput('done').withId('stream-1').addStreamFinal();
+
+      const streamInfo = (activity.entities ?? []).find((e) => e.type === 'streaminfo');
+      expect(streamInfo).toMatchObject({ streamId: 'stream-1', streamType: 'final' });
+      expect(streamInfo).not.toHaveProperty('streamSequence');
+      expect(activity.channelData).not.toHaveProperty('streamSequence');
+    });
+
+    it('should drop a streamSequence carried over from the chunks', () => {
+      const activity = new MessageActivityInput('done')
+        .withChannelData({ streamId: 'stream-1', streamType: 'streaming', streamSequence: 4 })
+        .addStreamFinal();
+
+      const streamInfo = (activity.entities ?? []).find((e) => e.type === 'streaminfo');
+      expect(streamInfo).not.toHaveProperty('streamSequence');
+      expect(activity.channelData).not.toHaveProperty('streamSequence');
+      expect(activity.channelData?.streamType).toEqual('final');
     });
   });
 });

--- a/packages/api/src/activities/message/message.ts
+++ b/packages/api/src/activities/message/message.ts
@@ -315,6 +315,10 @@ export class MessageActivityInput extends ActivityInput<'message'> implements IM
 
   /**
    * Mark the message as the final activity in a stream.
+   *
+   * The final carries no `streamSequence`. Teams documents the sequence as required on every streaming
+   * request except this one: "For the final message, `streamSequence` must not be set."
+   * https://learn.microsoft.com/en-us/microsoftteams/platform/bots/streaming-ux#stream-message-through-rest-api
    */
   addStreamFinal() {
     if (!this.channelData) {
@@ -322,17 +326,15 @@ export class MessageActivityInput extends ActivityInput<'message'> implements IM
     }
 
     const streamId = this.channelData.streamId || this.id || '';
-    const streamSequence = this.channelData.streamSequence ?? 1;
 
     this.channelData.streamId = streamId;
     this.channelData.streamType = 'final';
-    this.channelData.streamSequence = streamSequence;
+    delete this.channelData.streamSequence;
 
     this.addEntity({
       type: 'streaminfo',
       streamId,
       streamType: 'final',
-      streamSequence,
     });
 
     return this;


### PR DESCRIPTION
## Summary

Bring the 2.1 preview release line forward to the latest `main` commit so PR #688 is included before the first public preview. This preserves the release branch as a strict fast-forward of `main`; no release metadata or publishing automation changes are included.

## Release behavior

With the pipeline's public-release semantics, this head remains a `2.1.0-preview` prerelease and will use npm dist-tag `next`. Publishing remains a separate, manual action and is not triggered by this PR.