### PR TITLE
Deprecate Attachment.id

### DIFF
--- a/packages/api/src/models/attachment/attachment.ts
+++ b/packages/api/src/models/attachment/attachment.ts
@@ -1,6 +1,7 @@
 export type Attachment = {
   /**
    * @member {string} [id] The id of the attachment.
+   * @deprecated This is a legacy Bot Framework field and will be removed in a future version of the SDK.
    */
   id?: string;
 


### PR DESCRIPTION
`Attachment.id` is a legacy Bot Framework field, and has already been removed from PY and C#. 

The field remains available for backward compatibility but is marked for removal in the future. 

- No unit tests use `Attachment.id`
- build & test pass