### PR TITLE
Feature: Receive files in personal scope

### DIFF
--- a/packages/api/src/models/account.ts
+++ b/packages/api/src/models/account.ts
@@ -1,4 +1,5 @@
 import { AgenticIdentity } from './agentic-identity';
+import { ConversationType } from './conversation-type';
 import { MembershipSource } from './membership-source';
 import { Role } from './role';
 
@@ -147,7 +148,7 @@ export function resolveAadObjectId(data: any): TeamsChannelAccount {
 export type ConversationAccount = {
   readonly id: string;
   readonly tenantId?: string;
-  readonly conversationType: 'personal' | 'groupChat' | Omit<string, 'personal' | 'groupChat'>;
+  readonly conversationType: ConversationType;
   readonly name?: string;
   readonly isGroup?: boolean;
 };

--- a/packages/api/src/models/attachment/attachment-content-type.ts
+++ b/packages/api/src/models/attachment/attachment-content-type.ts
@@ -1,0 +1,5 @@
+/**
+ * Content type of an inbound uploaded-file attachment.
+ * Its `content` is a `FileDownloadInfo` describing a file that can be fetched from a short-lived, pre-authorized download URL.
+ */
+export const FILE_DOWNLOAD_INFO_CONTENT_TYPE = 'application/vnd.microsoft.teams.file.download.info';

--- a/packages/api/src/models/attachment/attachment.ts
+++ b/packages/api/src/models/attachment/attachment.ts
@@ -26,7 +26,8 @@ export type Attachment = {
   name?: string;
 
   /**
-   * (OPTIONAL) Thumbnail associated with attachment
+   * (OPTIONAL) Thumbnail associated with attachment.
+   * Not set by Teams when a bot receives an upload.
    */
   thumbnailUrl?: string;
 };

--- a/packages/api/src/models/attachment/index.ts
+++ b/packages/api/src/models/attachment/index.ts
@@ -1,3 +1,4 @@
 export * from './attachment';
+export * from './attachment-content-type';
 export * from './card-attachment';
 export * from './attachment-layout';

--- a/packages/api/src/models/conversation-type.ts
+++ b/packages/api/src/models/conversation-type.ts
@@ -1,0 +1,7 @@
+/**
+ * The type of conversation an activity was received in.
+ *
+ * Open union: the known values are enumerated for autocomplete and intent.
+ * `(string & {})` tail keeps forward-compatibility with values the service may introduce before the SDK enumerates them.
+ */
+export type ConversationType = 'personal' | 'groupChat' | 'channel' | (string & {});

--- a/packages/api/src/models/file/file-download-info.ts
+++ b/packages/api/src/models/file/file-download-info.ts
@@ -1,0 +1,28 @@
+/**
+ *
+ * An interface representing FileDownloadInfo.
+ * The content of a `file.download.info` attachment, describing an uploaded file received in a personal (1:1) chat.
+ * The file is fetched from the short-lived, pre-authorized `downloadUrl` with a plain GET (no bearer token).
+ *
+ */
+export type FileDownloadInfo = {
+  /**
+   * @member {string} [downloadUrl] Pre-authorized, short-lived URL the file can be fetched from with a plain GET (no bearer token).
+   */
+  downloadUrl?: string;
+
+  /**
+   * @member {string} [uniqueId] The OneDrive/ODSP drive-item id for the file. This is the storage-specific file identity a Graph fetch keys off.
+   */
+  uniqueId?: string;
+
+  /**
+   * @member {string} [fileType] Type of file (extension, e.g. `pdf`, `docx`).
+   */
+  fileType?: string;
+
+  /**
+   * @member {any} [etag] ETag for the file.
+   */
+  etag?: any;
+};

--- a/packages/api/src/models/file/file-download-info.ts
+++ b/packages/api/src/models/file/file-download-info.ts
@@ -22,7 +22,8 @@ export type FileDownloadInfo = {
   fileType?: string;
 
   /**
-   * @member {any} [etag] ETag for the file.
+   * @member {string} [etag] A server-assigned version tag identifying this version of the file's contents, for detecting whether the file changed between reads.
+   * Read-only; populated when Teams provides it with the file.
    */
-  etag?: any;
+  etag?: string;
 };

--- a/packages/api/src/models/file/file-info-card.ts
+++ b/packages/api/src/models/file/file-info-card.ts
@@ -16,7 +16,8 @@ export type FileInfoCard = {
   fileType?: string;
 
   /**
-   * @member {any} [etag] ETag for the file.
+   * @member {string} [etag] A server-assigned version tag identifying the uploaded file's contents.
+   * Populated from the storage service's upload response.
    */
-  etag?: any;
+  etag?: string;
 };

--- a/packages/api/src/models/file/index.ts
+++ b/packages/api/src/models/file/index.ts
@@ -1,3 +1,4 @@
 export * from './file-consent-card';
+export * from './file-download-info';
 export * from './file-info-card';
 export * from './file-upload-info';

--- a/packages/api/src/models/index.ts
+++ b/packages/api/src/models/index.ts
@@ -35,6 +35,7 @@ export * from './channel-data';
 export * from './team-details';
 export * from './meeting';
 export * from './channel-id';
+export * from './conversation-type';
 export * from './activity-like';
 export * from './html-widget';
 export * from './agentic-identity';

--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -240,6 +240,7 @@ export class ActivityProcessor<TPlugin extends IPlugin = IPlugin> {
         activity,
         next,
         api: apiClient,
+        client: this.options.client,
         userGraph,
         appGraph,
         appId: this.options.getId() || '',

--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -1,14 +1,17 @@
+import { Readable } from 'stream';
+
 import { type MockedObject } from 'jest-mock';
 
 import {
   Activity,
   ConversationReference,
+  FILE_DOWNLOAD_INFO_CONTENT_TYPE,
   IMessageActivity,
   MessageActivity,
   TokenExchangeResource,
   TokenPostResource,
 } from '@microsoft/teams.api';
-import { ILogger, IStorage } from '@microsoft/teams.common';
+import { Client as HttpClient, ILogger, IStorage } from '@microsoft/teams.common';
 
 import { ApiClient, GraphClient } from '../api';
 
@@ -827,6 +830,67 @@ describe('ActivityContext', () => {
 
       expect(maliciousSend).not.toHaveBeenCalled();
       expect(mockSender.send).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('files accessor', () => {
+    // `ctx.files` must receive the app's HTTP client so file downloads inherit its
+    // User-Agent, middleware, and user-supplied configuration. The download path
+    // falls back to a bare global `fetch` when no client is present, so dropping
+    // it here would silently bypass the SDK's outbound pipeline instead of
+    // failing loudly. This asserts the hand-off at the context boundary.
+    it('passes the app HTTP client through to ctx.files', async () => {
+      const seen: string[] = [];
+      const client = new HttpClient();
+      client.use({
+        async invoke(mwContext: any, next: any) {
+          mwContext.config.adapter = async (config: any) => {
+            seen.push(String(config.url));
+            return {
+              status: 200,
+              statusText: '',
+              headers: {},
+              config,
+              data: Readable.from([Buffer.from('bytes')]),
+            };
+          };
+          return next();
+        },
+      });
+
+      const activity = MessageActivity.from({
+        type: 'message',
+        conversation: { id: 'test-conversation', conversationType: 'personal' },
+        attachments: [
+          {
+            contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+            name: 'report.pdf',
+            content: { downloadUrl: 'https://download.example/report.pdf?tempauth=abc' },
+          },
+        ],
+      } as unknown as IMessageActivity);
+
+      const ctx = new ActivityContext({
+        appId: 'test-app',
+        activity,
+        ref: mockRef,
+        log: mockLogger,
+        api: mockApiClient,
+        client,
+        appGraph: {} as GraphClient,
+        userGraph: {} as GraphClient,
+        storage: mockStorage,
+        connectionName: 'test-connection',
+        next: jest.fn(),
+        activitySender: mockSender,
+      });
+
+      const file = await ctx.files.first();
+      expect(file).toBeDefined();
+
+      await file!.download();
+
+      expect(seen).toEqual(['https://download.example/report.pdf?tempauth=abc']);
     });
   });
 });

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -18,7 +18,7 @@ import {
   TokenPostResource,
   TypingActivity,
 } from '@microsoft/teams.api';
-import { ILogger, IStorage } from '@microsoft/teams.common';
+import { Client as HttpClient, ILogger, IStorage } from '@microsoft/teams.common';
 
 import { ApiClient, GraphClient } from '../api';
 import { FilesAccessor } from '../files/files-accessor';
@@ -73,6 +73,13 @@ export interface IBaseActivityContextOptions<T extends Activity = Activity> {
    * the api client
    */
   api: ApiClient;
+
+  /**
+   * the app's shared HTTP client, used for outbound calls that are not part of the Teams API surface
+   * (e.g. downloading an inbound file's bytes)
+   * They inherit the app's User-Agent, middleware, and configuration.
+   */
+  client?: HttpClient;
 
   /**
    * the app graph client
@@ -278,7 +285,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     this.next = next;
     this.stream = activitySender.createStream(value.ref);
     this.connectionName = value.connectionName;
-    this.files = new FilesAccessor(this.activity, this.log);
+    this.files = new FilesAccessor(this.activity, this.log, value.client);
   }
 
   /**

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -21,6 +21,8 @@ import {
 import { ILogger, IStorage } from '@microsoft/teams.common';
 
 import { ApiClient, GraphClient } from '../api';
+import { FilesAccessor } from '../files/files-accessor';
+import { IFilesAccessor } from '../files/types';
 import { IStreamer } from '../types';
 import { IActivitySender } from '../types/plugin/sender';
 
@@ -151,6 +153,11 @@ export interface IBaseActivityContext<T extends Activity = Activity, TExtraCtx e
   stream: IStreamer;
 
   /**
+   * the uploaded files on the current inbound activity, i.e. `contentType: file.download.info` subset of `activity.attachments`, mapped to `IncomingFile`. See {@link IFilesAccessor}.
+   */
+  files: IFilesAccessor;
+
+  /**
    * call the next event/middleware handler
    */
   next: (
@@ -221,6 +228,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
   userGraph!: GraphClient;
   storage!: IStorage;
   stream!: IStreamer;
+  files!: IFilesAccessor;
   isSignedIn?: boolean;
   connectionName: string;
   next!: (
@@ -270,6 +278,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
     this.next = next;
     this.stream = activitySender.createStream(value.ref);
     this.connectionName = value.connectionName;
+    this.files = new FilesAccessor(this.activity, this.log);
   }
 
   /**
@@ -459,6 +468,7 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
       ref: this.ref,
       storage: this.storage,
       stream: this.stream,
+      files: this.files,
       isSignedIn: this.isSignedIn,
       connectionName: this.connectionName,
       userToken: this.userToken,

--- a/packages/apps/src/files/download.http-client.spec.ts
+++ b/packages/apps/src/files/download.http-client.spec.ts
@@ -1,0 +1,173 @@
+import { Readable } from 'stream';
+
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
+import { FILE_DOWNLOAD_INFO_CONTENT_TYPE, type IMessageActivity, MessageActivity } from '@microsoft/teams.api';
+import {
+  Client as HttpClient,
+  ConsoleLogger,
+  type Middleware,
+  type MiddlewareContext,
+  type MiddlewareNext,
+  type RequestConfig,
+} from '@microsoft/teams.common';
+
+import { FileUrlExpiredError } from './errors';
+import { FilesAccessor } from './files-accessor';
+import { IncomingFile } from './incoming-file';
+
+/**
+ * Answers the request with a canned response instead of hitting the network, and records
+ * the merged config axios would have sent.
+ *
+ * It is a middleware that installs an adapter: running as middleware proves the download
+ * goes through the client's pipeline, and capturing at the adapter observes headers after
+ * instance defaults and per-request headers have been merged.
+ */
+class CapturingTransport implements Middleware {
+  readonly requests: InternalAxiosRequestConfig[] = [];
+
+  constructor(
+    private readonly status: number,
+    private readonly body: string,
+    private readonly headers: Record<string, string> = {}
+  ) { }
+
+  async invoke<R = AxiosResponse, D = any>(
+    context: MiddlewareContext<D>,
+    next: MiddlewareNext<R>
+  ): Promise<R> {
+    (context.config as RequestConfig).adapter = async (config: InternalAxiosRequestConfig) => {
+      this.requests.push(config);
+
+      return {
+        status: this.status,
+        statusText: '',
+        headers: this.headers,
+        config,
+        data: Readable.from([Buffer.from(this.body)]),
+      } as unknown as AxiosResponse;
+    };
+
+    return next();
+  }
+
+  get lastRequest(): InternalAxiosRequestConfig {
+    return this.requests[this.requests.length - 1];
+  }
+
+  /** Case-insensitive header lookup against the merged request axios would have sent. */
+  header(name: string): unknown {
+    return this.lastRequest?.headers?.get(name) ?? undefined;
+  }
+}
+
+function fileWith(client: HttpClient): IncomingFile {
+  return new IncomingFile({
+    name: 'notes.txt',
+    scope: 'personal',
+    source: 'botActivity',
+    downloadUrl: 'https://download.example/notes.txt?tempauth=abc',
+    httpClient: client,
+  });
+}
+
+describe('file download via HttpClient', () => {
+  it('downloads through the client and streams the bytes back', async () => {
+    const transport = new CapturingTransport(200, 'hello world', { 'content-type': 'text/plain' });
+    const client = new HttpClient({ middlewares: [transport] });
+
+    const downloaded = await fileWith(client).download();
+
+    expect(downloaded.text()).toBe('hello world');
+    expect(downloaded.contentType).toBe('text/plain');
+    expect(transport.lastRequest.url).toBe('https://download.example/notes.txt?tempauth=abc');
+    expect(transport.lastRequest.method).toBe('get');
+    expect(transport.lastRequest.responseType).toBe('stream');
+  });
+
+  // The URL carries its own `tempauth` credential; a bearer token on top can get it rejected.
+  it('does not attach an Authorization header even when the client has a token', async () => {
+    const transport = new CapturingTransport(200, 'hi');
+    const client = new HttpClient({
+      token: 'super-secret-app-token',
+      middlewares: [transport],
+    });
+
+    await fileWith(client).download();
+
+    expect(transport.header('Authorization')).toBeUndefined();
+  });
+
+  // Dropping the token must not cost us the rest of the client's configuration.
+  it('preserves the client User-Agent and registered middleware', async () => {
+    const transport = new CapturingTransport(200, 'hi');
+    const client = new HttpClient({
+      token: 'super-secret-app-token',
+      headers: { 'User-Agent': 'teams.ts-test/1.0' },
+      middlewares: [transport],
+    });
+
+    await fileWith(client).download();
+
+    expect(transport.requests).toHaveLength(1);
+    expect(transport.header('User-Agent')).toBe('teams.ts-test/1.0');
+  });
+
+  it('maps a 401 onto FileUrlExpiredError rather than throwing a transport error', async () => {
+    const transport = new CapturingTransport(401, '');
+    const client = new HttpClient({ middlewares: [transport] });
+
+    await expect(fileWith(client).download()).rejects.toThrow(FileUrlExpiredError);
+  });
+
+  it('surfaces other non-2xx statuses as a download failure', async () => {
+    const transport = new CapturingTransport(500, '');
+    const client = new HttpClient({ middlewares: [transport] });
+
+    await expect(fileWith(client).download()).rejects.toThrow(/failed to download file: 500/);
+  });
+
+  it('prefers an explicitly injected fetch over the client', async () => {
+    const transport = new CapturingTransport(200, 'from client');
+    const client = new HttpClient({ middlewares: [transport] });
+
+    const file = new IncomingFile({
+      name: 'notes.txt',
+      scope: 'personal',
+      source: 'botActivity',
+      downloadUrl: 'https://download.example/notes.txt?tempauth=abc',
+      httpClient: client,
+      fetch: async () => new Response(new TextEncoder().encode('from fetch')),
+    });
+
+    expect((await file.download()).text()).toBe('from fetch');
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  // Walks the real path (accessor -> IncomingFile -> request) so a dropped link fails here.
+  it('threads the client from FilesAccessor through to the request', async () => {
+    const transport = new CapturingTransport(200, 'threaded', { 'content-type': 'text/plain' });
+    const client = new HttpClient({ middlewares: [transport] });
+
+    const activity = MessageActivity.from({
+      type: 'message',
+      conversation: { conversationType: 'personal' },
+      attachments: [
+        {
+          contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+          name: 'report.pdf',
+          content: { downloadUrl: 'https://download.example/report.pdf?tempauth=abc' },
+        },
+      ],
+    } as unknown as IMessageActivity);
+
+    const accessor = new FilesAccessor(activity, new ConsoleLogger('threading.spec'), client);
+    const file = await accessor.first();
+
+    expect(file).toBeDefined();
+    expect((await file!.download()).text()).toBe('threaded');
+    expect(transport.requests).toHaveLength(1);
+    expect(transport.lastRequest.url).toBe('https://download.example/report.pdf?tempauth=abc');
+  });
+});

--- a/packages/apps/src/files/download.http-client.spec.ts
+++ b/packages/apps/src/files/download.http-client.spec.ts
@@ -99,6 +99,20 @@ describe('file download via HttpClient', () => {
     expect(transport.header('Authorization')).toBeUndefined();
   });
 
+  // A default `Authorization` header is merged in by `withConfig` independently of the token, so suppressing the
+  // token alone would still leak the bot's credential to the third-party storage host.
+  it('does not attach an Authorization header even when the client has one as a default header', async () => {
+    const transport = new CapturingTransport(200, 'hi');
+    const client = new HttpClient({
+      headers: { Authorization: 'Bearer super-secret-app-token' },
+      middlewares: [transport],
+    });
+
+    await fileWith(client).download();
+
+    expect(transport.header('Authorization')).toBeUndefined();
+  });
+
   // Dropping the token must not cost us the rest of the client's configuration.
   it('preserves the client User-Agent and registered middleware', async () => {
     const transport = new CapturingTransport(200, 'hi');

--- a/packages/apps/src/files/download.ts
+++ b/packages/apps/src/files/download.ts
@@ -59,6 +59,10 @@ async function openPersonalFileStream(
     throw new Error('cannot download personal file: no download URL is available');
   }
 
+  if (!/^https:\/\//i.test(url)) {
+    throw new Error('cannot download file: download URL must use https');
+  }
+
   const doFetch = options?.fetch ?? defaultFetch;
 
   // Plain GET with no bearer token: the download URL embeds its own `tempauth` credential, and attaching a credential can get the request rejected.

--- a/packages/apps/src/files/download.ts
+++ b/packages/apps/src/files/download.ts
@@ -1,0 +1,113 @@
+import { ConversationType } from '@microsoft/teams.api';
+
+import { FileScopeNotSupportedError, FileUrlExpiredError } from './errors';
+
+/**
+ * Pluggable fetch used to retrieve file bytes. Defaults to the global `fetch`; injectable so tests can supply a real `Response` without hitting the network.
+ */
+export type FileFetch = (url: string, init?: { signal?: AbortSignal }) => Promise<Response>;
+
+/**
+ * The minimal file description the download dispatcher needs to open a byte stream.
+ */
+export type FileFetchTarget = {
+  /** Conversation scope; the dispatcher is keyed on this. */
+  scope: ConversationType;
+  /** Short-lived, pre-authorized download URL (personal scope). */
+  downloadUrl?: string;
+  /** MIME type reported by the incoming file, used as a fallback when the response omits one. */
+  contentType?: string;
+};
+
+/**
+ * A freshly opened, single-consumption byte stream plus the metadata resolved while opening it.
+ */
+export type OpenedFileStream = {
+  /** The raw response body stream. Uncapped; the caller bounds it. */
+  stream: ReadableStream<Uint8Array>;
+  /** The URL the bytes were actually fetched from. */
+  sourceUrl: string;
+  /** MIME type resolved from the response, falling back to the incoming file's. */
+  contentType: string;
+};
+
+const defaultFetch: FileFetch = (url, init) => fetch(url, { method: 'GET', signal: init?.signal });
+
+/**
+ * Open a byte stream for an inbound file, keyed on its conversation scope so every scope's receive path extends this one place rather than branching in callers.
+ *
+ * Only `personal` is implemented; `groupChat`/`channel` (and any future scope) throw {@link FileScopeNotSupportedError} until their Graph receive path lands.
+ */
+export async function openFileStream(
+  target: FileFetchTarget,
+  options?: { priorFetchSucceeded?: boolean; fetch?: FileFetch; signal?: AbortSignal }
+): Promise<OpenedFileStream> {
+  if (target.scope === 'personal') {
+    return openPersonalFileStream(target, options);
+  }
+
+  throw new FileScopeNotSupportedError(String(target.scope));
+}
+
+async function openPersonalFileStream(
+  target: FileFetchTarget,
+  options?: { priorFetchSucceeded?: boolean; fetch?: FileFetch; signal?: AbortSignal }
+): Promise<OpenedFileStream> {
+  const url = target.downloadUrl;
+
+  if (!url) {
+    throw new Error('cannot download personal file: no download URL is available');
+  }
+
+  const doFetch = options?.fetch ?? defaultFetch;
+
+  // Plain GET with no bearer token: the download URL embeds its own `tempauth` credential, and attaching a credential can get the request rejected.
+  const response = await doFetch(url, { signal: options?.signal });
+
+  if (response.status === 401 || response.status === 403) {
+    throw new FileUrlExpiredError(options?.priorFetchSucceeded ? 'reread' : 'firstFetch');
+  }
+
+  if (!response.ok || !response.body) {
+    throw new Error(`failed to download file: ${response.status} ${response.statusText}`.trim());
+  }
+
+  const contentType = response.headers.get('content-type') ?? target.contentType ?? 'application/octet-stream';
+  return { stream: response.body, sourceUrl: url, contentType };
+}
+
+/**
+ * Read a byte stream to completion into a single `Uint8Array`.
+ */
+export async function collectStream(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        break;
+      }
+
+      if (value) {
+        total += value.byteLength;
+        chunks.push(value);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const out = new Uint8Array(total);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return out;
+}

--- a/packages/apps/src/files/download.ts
+++ b/packages/apps/src/files/download.ts
@@ -126,7 +126,10 @@ async function requestViaHttpClient(
     responseType: 'stream',
     signal,
     // The URL carries its own `tempauth` credential; a bearer token on top of it can get the request rejected.
+    // `token` only suppresses the token-derived header, so also override any default `Authorization` the client
+    // was configured with, which `withConfig` would otherwise merge in and send to a third-party storage host.
     token: () => undefined,
+    headers: { Authorization: undefined },
     // We map 401/403 onto FileUrlExpiredError ourselves, so keep axios from throwing first.
     validateStatus: () => true,
   });

--- a/packages/apps/src/files/download.ts
+++ b/packages/apps/src/files/download.ts
@@ -1,9 +1,12 @@
+import { Readable } from 'stream';
+
 import { ConversationType } from '@microsoft/teams.api';
+import { Client as HttpClient } from '@microsoft/teams.common';
 
 import { FileScopeNotSupportedError, FileUrlExpiredError } from './errors';
 
 /**
- * Pluggable fetch used to retrieve file bytes. Defaults to the global `fetch`; injectable so tests can supply a real `Response` without hitting the network.
+ * Pluggable fetch used to retrieve file bytes. Injectable so tests can supply a real `Response` without hitting the network; when omitted the app's {@link HttpClient} is used instead.
  */
 export type FileFetch = (url: string, init?: { signal?: AbortSignal }) => Promise<Response>;
 
@@ -31,7 +34,30 @@ export type OpenedFileStream = {
   contentType: string;
 };
 
-const defaultFetch: FileFetch = (url, init) => fetch(url, { method: 'GET', signal: init?.signal });
+/**
+ * Options shared by every scope's download path.
+ */
+export type OpenFileStreamOptions = {
+  priorFetchSucceeded?: boolean;
+  /** Test-only transport override. Takes precedence over `httpClient`. */
+  fetch?: FileFetch;
+  /** The app's HTTP client, so downloads inherit its User-Agent, middleware, interceptors, and any user-supplied configuration. */
+  httpClient?: HttpClient;
+  signal?: AbortSignal;
+};
+
+/**
+ * The transport-agnostic shape both the `fetch` and {@link HttpClient} paths normalize to.
+ */
+type TransportResponse = {
+  status: number;
+  statusText: string;
+  ok: boolean;
+  contentType?: string;
+  stream?: ReadableStream<Uint8Array>;
+  /** Releases the underlying socket for responses whose body we are not going to read. */
+  discard: () => void;
+};
 
 /**
  * Open a byte stream for an inbound file, keyed on its conversation scope so every scope's receive path extends this one place rather than branching in callers.
@@ -40,7 +66,7 @@ const defaultFetch: FileFetch = (url, init) => fetch(url, { method: 'GET', signa
  */
 export async function openFileStream(
   target: FileFetchTarget,
-  options?: { priorFetchSucceeded?: boolean; fetch?: FileFetch; signal?: AbortSignal }
+  options?: OpenFileStreamOptions
 ): Promise<OpenedFileStream> {
   if (target.scope === 'personal') {
     return openPersonalFileStream(target, options);
@@ -51,7 +77,7 @@ export async function openFileStream(
 
 async function openPersonalFileStream(
   target: FileFetchTarget,
-  options?: { priorFetchSucceeded?: boolean; fetch?: FileFetch; signal?: AbortSignal }
+  options?: OpenFileStreamOptions
 ): Promise<OpenedFileStream> {
   const url = target.downloadUrl;
 
@@ -63,21 +89,73 @@ async function openPersonalFileStream(
     throw new Error('cannot download file: download URL must use https');
   }
 
-  const doFetch = options?.fetch ?? defaultFetch;
-
-  // Plain GET with no bearer token: the download URL embeds its own `tempauth` credential, and attaching a credential can get the request rejected.
-  const response = await doFetch(url, { signal: options?.signal });
+  const response = await requestFile(url, options);
 
   if (response.status === 401 || response.status === 403) {
+    response.discard();
     throw new FileUrlExpiredError(options?.priorFetchSucceeded ? 'reread' : 'firstFetch');
   }
 
-  if (!response.ok || !response.body) {
+  if (!response.ok || !response.stream) {
+    response.discard();
     throw new Error(`failed to download file: ${response.status} ${response.statusText}`.trim());
   }
 
-  const contentType = response.headers.get('content-type') ?? target.contentType ?? 'application/octet-stream';
-  return { stream: response.body, sourceUrl: url, contentType };
+  const contentType = response.contentType ?? target.contentType ?? 'application/octet-stream';
+  return { stream: response.stream, sourceUrl: url, contentType };
+}
+
+async function requestFile(url: string, options?: OpenFileStreamOptions): Promise<TransportResponse> {
+  if (options?.fetch) {
+    return fromFetchResponse(await options.fetch(url, { signal: options.signal }));
+  }
+
+  if (options?.httpClient) {
+    return requestViaHttpClient(url, options.httpClient, options.signal);
+  }
+
+  throw new Error('cannot download file: no HTTP client is available');
+}
+
+async function requestViaHttpClient(
+  url: string,
+  client: HttpClient,
+  signal?: AbortSignal
+): Promise<TransportResponse> {
+  const response = await client.get<Readable>(url, {
+    responseType: 'stream',
+    signal,
+    // The URL carries its own `tempauth` credential; a bearer token on top of it can get the request rejected.
+    token: () => undefined,
+    // We map 401/403 onto FileUrlExpiredError ourselves, so keep axios from throwing first.
+    validateStatus: () => true,
+  });
+
+  const body: Readable | undefined = response.data;
+  const contentTypeHeader = response.headers?.['content-type'];
+
+  return {
+    status: response.status,
+    statusText: response.statusText ?? '',
+    ok: response.status >= 200 && response.status < 300,
+    contentType: typeof contentTypeHeader === 'string' ? contentTypeHeader : undefined,
+    // `packages/apps` is Node-only, so adapting Node's `Readable` to a web `ReadableStream` is safe here.
+    stream: body ? (Readable.toWeb(body) as unknown as ReadableStream<Uint8Array>) : undefined,
+    discard: () => body?.destroy(),
+  };
+}
+
+function fromFetchResponse(response: Response): TransportResponse {
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    ok: response.ok,
+    contentType: response.headers.get('content-type') ?? undefined,
+    stream: response.body ?? undefined,
+    discard: () => {
+      void response.body?.cancel().catch(() => { });
+    },
+  };
 }
 
 /**

--- a/packages/apps/src/files/download.ts
+++ b/packages/apps/src/files/download.ts
@@ -46,7 +46,7 @@ export async function openFileStream(
     return openPersonalFileStream(target, options);
   }
 
-  throw new FileScopeNotSupportedError(String(target.scope));
+  throw new FileScopeNotSupportedError(target.scope);
 }
 
 async function openPersonalFileStream(

--- a/packages/apps/src/files/downloaded-file.ts
+++ b/packages/apps/src/files/downloaded-file.ts
@@ -1,0 +1,46 @@
+import { writeFile } from 'fs/promises';
+
+import { IDownloadedFile } from './types';
+
+/**
+ * Constructor arguments for {@link DownloadedFile}.
+ */
+export interface IDownloadedFileInit {
+  bytes: Uint8Array;
+  contentType: string;
+  filename: string;
+  sourceUrl: string;
+}
+
+/**
+ * Buffered, point-in-time snapshot of a downloaded file. See {@link IDownloadedFile}.
+ */
+export class DownloadedFile implements IDownloadedFile {
+  readonly bytes: Uint8Array;
+  readonly contentType: string;
+  readonly filename: string;
+  readonly sourceUrl: string;
+
+  constructor(init: IDownloadedFileInit) {
+    this.bytes = init.bytes;
+    this.contentType = init.contentType;
+    this.filename = init.filename;
+    this.sourceUrl = init.sourceUrl;
+  }
+
+  text(encoding: string = 'utf-8'): string {
+    // TextDecoder is lossy by default (fatal: false): invalid bytes become U+FFFD and never throw.
+    return new TextDecoder(encoding).decode(this.bytes);
+  }
+
+  arrayBuffer(): ArrayBuffer {
+    // Copy into a fresh buffer so a pooled/oversized or shared backing buffer is never exposed.
+    const copy = new Uint8Array(this.bytes.byteLength);
+    copy.set(this.bytes);
+    return copy.buffer;
+  }
+
+  async saveAs(path: string): Promise<void> {
+    await writeFile(path, this.bytes);
+  }
+}

--- a/packages/apps/src/files/errors.ts
+++ b/packages/apps/src/files/errors.ts
@@ -1,3 +1,5 @@
+import { ConversationType } from '@microsoft/teams.api';
+
 /**
  * Raised when an inbound file's short-lived download URL has expired and can no longer fetch bytes.
  *
@@ -33,9 +35,9 @@ export class FileUrlExpiredError extends Error {
  */
 export class FileScopeNotSupportedError extends Error {
   /** The conversation scope that is not yet fetchable. */
-  readonly scope: string;
+  readonly scope: ConversationType;
 
-  constructor(scope: string, message?: string) {
+  constructor(scope: ConversationType, message?: string) {
     super(message ?? `downloading files from '${scope}' conversations is not supported via SDK at this time`);
     this.name = 'FileScopeNotSupportedError';
     this.scope = scope;

--- a/packages/apps/src/files/errors.ts
+++ b/packages/apps/src/files/errors.ts
@@ -31,7 +31,7 @@ export class FileUrlExpiredError extends Error {
  * Raised when file bytes are requested for a conversation scope whose download path is not implemented.
  *
  * Only `personal` (1:1) uploaded files download directly. 
- * `groupChat` and `channel` files are surfaced by `list()`, but fetching their bytes needs Graph; `download()`/`stream()` throws until that path lands.
+ * `groupChat` files are surfaced by `list()`, but fetching their bytes needs Graph; `download()`/`stream()` throws until that path lands.
  */
 export class FileScopeNotSupportedError extends Error {
   /** The conversation scope that is not yet fetchable. */

--- a/packages/apps/src/files/errors.ts
+++ b/packages/apps/src/files/errors.ts
@@ -1,0 +1,43 @@
+/**
+ * Raised when an inbound file's short-lived download URL has expired and can no longer fetch bytes.
+ *
+ * A personal file's pre-authorized `tempauth` download URL is valid only briefly. 
+ * A fetch after it lapses gets a `401`/`403` from the platform. A handler that downloads once (and does not keep the handle) should not hit this.
+ * `reason` distinguishes the two cases:
+ * - `firstFetch`: the first fetch came after the URL lapsed, so no bytes were retrieved. Recovery needs Graph drive-item re-resolution, not available via the SDK at this time.
+ * - `reread`: edge case. An earlier download succeeded, then a later re-fetch through the same handle lapsed. Avoid it by calling `download()` once and reusing the returned `DownloadedFile` rather than re-reading the handle.
+ */
+export class FileUrlExpiredError extends Error {
+  /** Lets callers branch without string-matching the message. 
+   * `firstFetch`: no bytes were ever fetched. 
+   * `reread`: the uncommon case, a previously successful handle re-fetched too late. */
+  readonly reason: 'firstFetch' | 'reread';
+
+  constructor(reason: 'firstFetch' | 'reread', message?: string) {
+    super(
+      message ??
+        (reason === 'firstFetch'
+          ? 'file download URL expired before any bytes were fetched; recovery needs Graph drive-item re-resolution (not available via the SDK at this time)'
+          : 'file download URL expired before a repeat read; reuse a single DownloadedFile from one download() call instead of re-reading the handle')
+    );
+    this.name = 'FileUrlExpiredError';
+    this.reason = reason;
+  }
+}
+
+/**
+ * Raised when file bytes are requested for a conversation scope whose download path is not implemented.
+ *
+ * Only `personal` (1:1) uploaded files download directly. 
+ * `groupChat` and `channel` files are surfaced by `list()`, but fetching their bytes needs Graph; `download()`/`stream()` throws until that path lands.
+ */
+export class FileScopeNotSupportedError extends Error {
+  /** The conversation scope that is not yet fetchable. */
+  readonly scope: string;
+
+  constructor(scope: string, message?: string) {
+    super(message ?? `downloading files from '${scope}' conversations is not supported via SDK at this time`);
+    this.name = 'FileScopeNotSupportedError';
+    this.scope = scope;
+  }
+}

--- a/packages/apps/src/files/files-accessor.spec.ts
+++ b/packages/apps/src/files/files-accessor.spec.ts
@@ -1,0 +1,130 @@
+import { Activity, Attachment, FILE_DOWNLOAD_INFO_CONTENT_TYPE, IMessageActivity, MessageActivity } from '@microsoft/teams.api';
+import { ConsoleLogger } from '@microsoft/teams.common';
+
+import { FilesAccessor } from './files-accessor';
+
+function activityWith(attachments: Attachment[], conversationType = 'personal'): MessageActivity {
+  return MessageActivity.from({
+    type: 'message',
+    conversation: { conversationType },
+    attachments,
+  } as unknown as IMessageActivity);
+}
+
+describe('FilesAccessor', () => {
+  const log = new ConsoleLogger('FilesAccessor.spec');
+
+  it('maps a file.download.info attachment to an IncomingFile', async () => {
+    const attachment: Attachment = {
+      contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+      contentUrl: 'https://contoso.sharepoint.com/report.pdf',
+      name: 'report.pdf',
+      content: {
+        downloadUrl: 'https://download.example/report.pdf?tempauth=abc',
+        uniqueId: 'odsp-unique-id',
+        fileType: 'pdf',
+      },
+    };
+
+    const accessor = new FilesAccessor(activityWith([attachment]), log);
+    const files = await accessor.list();
+
+    expect(files).toHaveLength(1);
+    const file = files[0];
+    expect(file.uniqueId).toBe('odsp-unique-id');
+    expect(file.name).toBe('report.pdf');
+    expect(file.extension).toBe('pdf');
+    expect(file.scope).toBe('personal');
+    expect(file.source).toBe('botActivity');
+    expect(file.webUrl).toBe('https://contoso.sharepoint.com/report.pdf');
+    expect(file.raw).toBe(attachment);
+  });
+
+  it('ignores attachments that are not uploaded files', async () => {
+    const card: Attachment = {
+      contentType: 'application/vnd.microsoft.card.adaptive',
+      content: {},
+    };
+
+    const files = await new FilesAccessor(activityWith([card]), log).list();
+
+    expect(files).toHaveLength(0);
+  });
+
+  it('skips a malformed file.download.info (missing downloadUrl)', async () => {
+    const attachment: Attachment = {
+      contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+      name: 'broken.pdf',
+      content: { uniqueId: 'no-url' },
+    };
+
+    const files = await new FilesAccessor(activityWith([attachment]), log).list();
+
+    expect(files).toHaveLength(0);
+  });
+
+  it('skips a file.download.info that is missing a name', async () => {
+    const attachment: Attachment = {
+      contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+      content: { downloadUrl: 'https://download.example/anon' },
+    };
+
+    const files = await new FilesAccessor(activityWith([attachment]), log).list();
+
+    expect(files).toHaveLength(0);
+  });
+
+  it('maps a file that has no uniqueId', async () => {
+    const attachment: Attachment = {
+      contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+      name: 'anon.pdf',
+      content: { downloadUrl: 'https://download.example/anon.pdf' },
+    };
+
+    const [file] = await new FilesAccessor(activityWith([attachment]), log).list();
+
+    expect(file.name).toBe('anon.pdf');
+    expect(file.uniqueId).toBeUndefined();
+  });
+
+  it('defaults the scope to personal when the conversation type is absent', async () => {
+    const attachment: Attachment = {
+      contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+      name: 'a.pdf',
+      content: { downloadUrl: 'https://download.example/a.pdf', uniqueId: 'a' },
+    };
+    const activity = MessageActivity.from({ type: 'message', attachments: [attachment] } as unknown as IMessageActivity);
+
+    const [file] = await new FilesAccessor(activity, log).list();
+
+    expect(file.scope).toBe('personal');
+  });
+
+  it('returns an empty list when the activity has no attachments', async () => {
+    const files = await new FilesAccessor(activityWith([]), log).list();
+    expect(files).toEqual([]);
+  });
+
+  it('returns an empty list when the attachments field is absent', async () => {
+    const activity = MessageActivity.from({ type: 'message' } as unknown as IMessageActivity);
+    const files = await new FilesAccessor(activity, log).list();
+    expect(files).toEqual([]);
+  });
+
+  it('returns an empty list for non-message activities', async () => {
+    const typing = { type: 'typing', conversation: { conversationType: 'personal' } } as unknown as Activity;
+    const files = await new FilesAccessor(typing, log).list();
+    expect(files).toEqual([]);
+  });
+
+  it('first() returns the first mapped file, or undefined when none', async () => {
+    const attachment: Attachment = {
+      contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+      name: 'a.pdf',
+      content: { downloadUrl: 'https://download.example/a.pdf', uniqueId: 'a' },
+    };
+
+    expect(await new FilesAccessor(activityWith([attachment]), log).first()).toBeDefined();
+    expect(await new FilesAccessor(activityWith([]), log).first()).toBeUndefined();
+  });
+});

--- a/packages/apps/src/files/files-accessor.spec.ts
+++ b/packages/apps/src/files/files-accessor.spec.ts
@@ -74,6 +74,60 @@ describe('FilesAccessor', () => {
     expect(files).toHaveLength(0);
   });
 
+  it('skips a file.download.info whose content is not an object', async () => {
+    const attachment: Attachment = {
+      contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+      name: 'weird.pdf',
+      content: 'https://download.example/not-an-object',
+    };
+
+    const files = await new FilesAccessor(activityWith([attachment]), log).list();
+
+    expect(files).toHaveLength(0);
+  });
+
+  it('skips a file.download.info whose downloadUrl is not a string', async () => {
+    const attachment: Attachment = {
+      contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+      name: 'weird.pdf',
+      content: { downloadUrl: { href: 'https://download.example/nested' }, uniqueId: 'x' },
+    };
+
+    const files = await new FilesAccessor(activityWith([attachment]), log).list();
+
+    expect(files).toHaveLength(0);
+  });
+
+  it('skips a file.download.info carrying a non-string uniqueId alongside a valid downloadUrl', async () => {
+    const attachment: Attachment = {
+      contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+      name: 'weird.pdf',
+      content: { downloadUrl: 'https://download.example/weird.pdf', uniqueId: 42 },
+    };
+
+    const files = await new FilesAccessor(activityWith([attachment]), log).list();
+
+    expect(files).toHaveLength(0);
+  });
+
+  it('ignores unknown extra properties on the content payload', async () => {
+    const attachment: Attachment = {
+      contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+      name: 'extra.pdf',
+      content: {
+        downloadUrl: 'https://download.example/extra.pdf',
+        uniqueId: 'extra-id',
+        fileType: 'pdf',
+        somethingNew: { nested: true },
+      },
+    };
+
+    const [file] = await new FilesAccessor(activityWith([attachment]), log).list();
+
+    expect(file.name).toBe('extra.pdf');
+    expect(file.uniqueId).toBe('extra-id');
+  });
+
   it('maps a file that has no uniqueId', async () => {
     const attachment: Attachment = {
       contentType: FILE_DOWNLOAD_INFO_CONTENT_TYPE,

--- a/packages/apps/src/files/files-accessor.ts
+++ b/packages/apps/src/files/files-accessor.ts
@@ -1,0 +1,99 @@
+import {
+  Activity,
+  Attachment,
+  ConversationType,
+  FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+  FileDownloadInfo,
+  MessageActivity,
+} from '@microsoft/teams.api';
+import { ILogger } from '@microsoft/teams.common';
+
+import { IncomingFile } from './incoming-file';
+import { IFilesAccessor, IIncomingFile } from './types';
+
+/**
+ * Reads the files attached to the current inbound activity and exposes them as lazy {@link IncomingFile} handles. Wired onto the activity context as `ctx.files`.
+ *
+ * See {@link IFilesAccessor} for the public contract.
+ */
+export class FilesAccessor implements IFilesAccessor {
+  constructor(
+    private readonly activity: Activity,
+    private readonly log: ILogger
+  ) {}
+
+  async list(): Promise<IIncomingFile[]> {
+    // Uploaded files only ride on inbound message activities so we validate the shape and return an empty list rather than throwing.
+    if (!(this.activity instanceof MessageActivity)) {
+      return [];
+    }
+
+    const attachments = this.activity.attachments ?? [];
+    const scope = this.detectScope();
+
+    const files: IIncomingFile[] = [];
+
+    attachments.forEach((attachment, index) => {
+      const file = this.toIncomingFile(attachment, index, scope);
+
+      if (file) {
+        files.push(file);
+      }
+    });
+
+    return files;
+  }
+
+  async first(): Promise<IIncomingFile | undefined> {
+    const files = await this.list();
+    return files[0];
+  }
+
+  /**
+   * Derive the conversation scope from the inbound activity.
+   */
+  private detectScope(): ConversationType {
+    return this.activity.conversation?.conversationType ?? 'personal';
+  }
+
+  /**
+   * Map a single activity attachment to an {@link IncomingFile}, or `undefined` when the attachment is not an uploaded file or is malformed. Never throws: unusable attachments are skipped so one bad entry cannot drop the rest.
+   */
+  private toIncomingFile(
+    attachment: Attachment,
+    index: number,
+    scope: ConversationType
+  ): IncomingFile | undefined {
+    // Not an uploaded file (card, mention, adaptive card, etc.). Silently ignored.
+    if (attachment.contentType !== FILE_DOWNLOAD_INFO_CONTENT_TYPE) {
+      return undefined;
+    }
+
+    const content: FileDownloadInfo | undefined = attachment.content;
+    const downloadUrl = content?.downloadUrl;
+    const name = attachment.name;
+
+    // A `file.download.info` without fetchable URL or name cannot be turned into a usable handle. Skip it and leave a breadcrumb rather than throwing.
+    if (!downloadUrl || !name) {
+      this.log.debug(
+        `files: skipping file.download.info attachment at index ${index}; missing ${!name ? 'name' : 'downloadUrl'}`
+      );
+      return undefined;
+    }
+
+    const uniqueId = content?.uniqueId;
+
+    return new IncomingFile({
+      uniqueId,
+      name,
+      // `fileType` is the platform-supplied extension (e.g. `pdf`); left `undefined` when the wire omits it, matching how peer SDKs surface it.
+      extension: content?.fileType,
+      scope,
+      source: 'botActivity',
+      // Maps the wire's `contentUrl` (a browsable link to the file in OneDrive/SharePoint) to `webUrl`; not fetchable like `downloadUrl`.
+      webUrl: attachment.contentUrl,
+      raw: attachment,
+      downloadUrl,
+    });
+  }
+}

--- a/packages/apps/src/files/files-accessor.ts
+++ b/packages/apps/src/files/files-accessor.ts
@@ -6,7 +6,7 @@ import {
   FileDownloadInfo,
   MessageActivity,
 } from '@microsoft/teams.api';
-import { ILogger } from '@microsoft/teams.common';
+import { Client as HttpClient, ILogger } from '@microsoft/teams.common';
 
 import { IncomingFile } from './incoming-file';
 import { IFilesAccessor, IIncomingFile } from './types';
@@ -19,7 +19,9 @@ import { IFilesAccessor, IIncomingFile } from './types';
 export class FilesAccessor implements IFilesAccessor {
   constructor(
     private readonly activity: Activity,
-    private readonly log: ILogger
+    private readonly log: ILogger,
+    /** The app's HTTP client, threaded into every {@link IncomingFile} so downloads go through the SDK's outbound pipeline rather than a bare `fetch`. */
+    private readonly httpClient?: HttpClient
   ) {}
 
   async list(): Promise<IIncomingFile[]> {
@@ -94,6 +96,7 @@ export class FilesAccessor implements IFilesAccessor {
       webUrl: attachment.contentUrl,
       raw: attachment,
       downloadUrl,
+      httpClient: this.httpClient,
     });
   }
 }

--- a/packages/apps/src/files/files-accessor.ts
+++ b/packages/apps/src/files/files-accessor.ts
@@ -11,6 +11,28 @@ import { Client as HttpClient, ILogger } from '@microsoft/teams.common';
 import { IncomingFile } from './incoming-file';
 import { IFilesAccessor, IIncomingFile } from './types';
 
+/** Narrow an unknown wire value to `string | undefined`, the shape every {@link FileDownloadInfo} field declares. */
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === 'string';
+}
+
+/**
+ * Coerce an attachment's `content` into a {@link FileDownloadInfo}. `Attachment.content` is typed `any`, so without this the wire payload would be trusted unchecked and a wrong-typed `downloadUrl` would only surface later as a confusing failure at fetch time. Returns `undefined` for anything that is not an object or that carries a non-string where a string is required; unknown extra properties are ignored, matching how the peer SDKs deserialize this payload.
+ */
+function asFileDownloadInfo(content: unknown): FileDownloadInfo | undefined {
+  if (typeof content !== 'object' || content === null) {
+    return undefined;
+  }
+
+  const { downloadUrl, uniqueId, fileType } = content as Record<string, unknown>;
+
+  if (!isOptionalString(downloadUrl) || !isOptionalString(uniqueId) || !isOptionalString(fileType)) {
+    return undefined;
+  }
+
+  return { downloadUrl, uniqueId, fileType };
+}
+
 /**
  * Reads the files attached to the current inbound activity and exposes them as lazy {@link IncomingFile} handles. Wired onto the activity context as `ctx.files`.
  *
@@ -71,7 +93,7 @@ export class FilesAccessor implements IFilesAccessor {
       return undefined;
     }
 
-    const content: FileDownloadInfo | undefined = attachment.content;
+    const content = asFileDownloadInfo(attachment.content);
     const downloadUrl = content?.downloadUrl;
     const name = attachment.name;
 

--- a/packages/apps/src/files/incoming-file.spec.ts
+++ b/packages/apps/src/files/incoming-file.spec.ts
@@ -139,6 +139,14 @@ describe('IncomingFile', () => {
       expect(calls).toHaveLength(0);
     });
 
+    it('throws when a personal file download URL is not https', async () => {
+      const { fetch, calls } = sequenceFetch([jsonBody('unused')]);
+      const file = personalFile({ fetch, downloadUrl: 'http://download.example/notes.txt' });
+
+      await expect(file.download()).rejects.toThrow(/must use https/);
+      expect(calls).toHaveLength(0);
+    });
+
     it('throws on a non-auth error response', async () => {
       const { fetch } = sequenceFetch([new Response(null, { status: 500, statusText: 'Server Error' })]);
       const file = personalFile({ fetch });

--- a/packages/apps/src/files/incoming-file.spec.ts
+++ b/packages/apps/src/files/incoming-file.spec.ts
@@ -1,0 +1,182 @@
+import { mkdtemp, readFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { FileFetch } from './download';
+import { FileScopeNotSupportedError, FileUrlExpiredError } from './errors';
+import { IncomingFile, IIncomingFileInit } from './incoming-file';
+
+function personalFile(init?: Partial<IIncomingFileInit>): IncomingFile {
+  return new IncomingFile({
+    name: 'notes.txt',
+    scope: 'personal',
+    source: 'botActivity',
+    downloadUrl: 'https://download.example/notes.txt?tempauth=abc',
+    ...init,
+  });
+}
+
+function jsonBody(text: string, headers?: Record<string, string>): Response {
+  return new Response(new TextEncoder().encode(text), { status: 200, headers });
+}
+
+/** A fetch stub that hands back the given responses in call order, and records the urls it saw. */
+function sequenceFetch(responses: Response[]): { fetch: FileFetch; calls: string[] } {
+  const calls: string[] = [];
+  let i = 0;
+  const fetch: FileFetch = async (url) => {
+    calls.push(url);
+    const response = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return response;
+  };
+  return { fetch, calls };
+}
+
+describe('IncomingFile', () => {
+  describe('download', () => {
+    it('fetches the download URL and buffers the bytes', async () => {
+      const { fetch, calls } = sequenceFetch([jsonBody('hello world', { 'content-type': 'text/plain' })]);
+      const file = personalFile({ fetch });
+
+      const downloaded = await file.download();
+
+      expect(calls).toEqual(['https://download.example/notes.txt?tempauth=abc']);
+      expect(downloaded.text()).toBe('hello world');
+      expect(downloaded.contentType).toBe('text/plain');
+      expect(downloaded.filename).toBe('notes.txt');
+      expect(downloaded.sourceUrl).toBe('https://download.example/notes.txt?tempauth=abc');
+    });
+
+    it('re-fetches on each call (no memoized bytes)', async () => {
+      const { fetch, calls } = sequenceFetch([jsonBody('a'), jsonBody('b')]);
+      const file = personalFile({ fetch });
+
+      expect((await file.download()).text()).toBe('a');
+      expect((await file.download()).text()).toBe('b');
+      expect(calls).toHaveLength(2);
+    });
+
+    it('falls back to the incoming file contentType when the response omits one', async () => {
+      const { fetch } = sequenceFetch([jsonBody('bytes')]);
+      const file = personalFile({ fetch, contentType: 'application/pdf' });
+
+      expect((await file.download()).contentType).toBe('application/pdf');
+    });
+  });
+
+  describe('text and arrayBuffer convenience readers', () => {
+    it('decode the downloaded bytes', async () => {
+      const { fetch } = sequenceFetch([jsonBody('hello'), jsonBody('hello')]);
+      const file = personalFile({ fetch });
+
+      expect(await file.text()).toBe('hello');
+      expect(new TextDecoder().decode(new Uint8Array(await file.arrayBuffer()))).toBe('hello');
+    });
+  });
+
+  describe('expired download URL', () => {
+    it('throws FileUrlExpiredError with reason "firstFetch" when the very first fetch is unauthorized', async () => {
+      const { fetch } = sequenceFetch([new Response(null, { status: 401 })]);
+      const file = personalFile({ fetch });
+
+      await expect(file.download()).rejects.toMatchObject({
+        constructor: FileUrlExpiredError,
+        reason: 'firstFetch',
+      });
+    });
+
+    it('treats 403 the same as 401', async () => {
+      const { fetch } = sequenceFetch([new Response(null, { status: 403 })]);
+      const file = personalFile({ fetch });
+
+      await expect(file.download()).rejects.toBeInstanceOf(FileUrlExpiredError);
+    });
+
+    it('throws reason "reread" when a later fetch lapses after an earlier success', async () => {
+      const { fetch } = sequenceFetch([jsonBody('first read ok'), new Response(null, { status: 401 })]);
+      const file = personalFile({ fetch });
+
+      expect((await file.download()).text()).toBe('first read ok');
+      await expect(file.download()).rejects.toMatchObject({
+        constructor: FileUrlExpiredError,
+        reason: 'reread',
+      });
+    });
+  });
+
+  describe('stream', () => {
+    it('returns the raw uncapped body stream', async () => {
+      const { fetch } = sequenceFetch([jsonBody('streamed')]);
+      const file = personalFile({ fetch });
+
+      const stream = await file.stream();
+      const reader = stream.getReader();
+      const { value } = await reader.read();
+
+      expect(new TextDecoder().decode(value)).toBe('streamed');
+    });
+  });
+
+  describe('unsupported scope', () => {
+    it('throws FileScopeNotSupportedError for group chat files', async () => {
+      const { fetch } = sequenceFetch([jsonBody('unused')]);
+      const file = personalFile({ fetch, scope: 'groupChat' });
+
+      await expect(file.download()).rejects.toMatchObject({
+        constructor: FileScopeNotSupportedError,
+        scope: 'groupChat',
+      });
+    });
+  });
+
+  describe('download failures', () => {
+    it('throws when a personal file has no download URL', async () => {
+      const { fetch, calls } = sequenceFetch([jsonBody('unused')]);
+      const file = personalFile({ fetch, downloadUrl: undefined });
+
+      await expect(file.download()).rejects.toThrow(/no download URL/);
+      expect(calls).toHaveLength(0);
+    });
+
+    it('throws on a non-auth error response', async () => {
+      const { fetch } = sequenceFetch([new Response(null, { status: 500, statusText: 'Server Error' })]);
+      const file = personalFile({ fetch });
+
+      await expect(file.download()).rejects.toThrow(/failed to download file: 500/);
+    });
+  });
+
+  describe('saveAs', () => {
+    let dir: string;
+
+    beforeEach(async () => {
+      dir = await mkdtemp(join(tmpdir(), 'incoming-file-spec-'));
+    });
+
+    afterEach(async () => {
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    it('streams the bytes straight to a local file', async () => {
+      const { fetch } = sequenceFetch([jsonBody('saved contents')]);
+      const file = personalFile({ fetch });
+      const path = join(dir, 'out.txt');
+
+      await file.saveAs(path);
+
+      expect((await readFile(path)).toString()).toBe('saved contents');
+    });
+
+    it('writes a buffered DownloadedFile snapshot to disk without re-fetching', async () => {
+      const { fetch, calls } = sequenceFetch([jsonBody('snapshot bytes')]);
+      const downloaded = await personalFile({ fetch }).download();
+      const path = join(dir, 'snapshot.txt');
+
+      await downloaded.saveAs(path);
+
+      expect((await readFile(path)).toString()).toBe('snapshot bytes');
+      expect(calls).toHaveLength(1);
+    });
+  });
+});

--- a/packages/apps/src/files/incoming-file.ts
+++ b/packages/apps/src/files/incoming-file.ts
@@ -1,0 +1,136 @@
+import { createWriteStream } from 'fs';
+
+import { ConversationType } from '@microsoft/teams.api';
+
+import { collectStream, FileFetch, FileFetchTarget, openFileStream } from './download';
+import { DownloadedFile } from './downloaded-file';
+import { FileSource, IDownloadedFile, IIncomingFile } from './types';
+
+/**
+ * Constructor arguments for {@link IncomingFile}.
+ */
+export interface IIncomingFileInit {
+  uniqueId?: string;
+  name: string;
+  contentType?: string;
+  extension?: string;
+  scope: ConversationType;
+  source: FileSource;
+  webUrl?: string;
+  raw?: unknown;
+  /** Short-lived, pre-authorized download URL (personal scope). */
+  downloadUrl?: string;
+  /** Injectable fetch, defaulting to the global `fetch`; used to keep tests off the network. */
+  fetch?: FileFetch;
+}
+
+/**
+ * Lazy handle to a file attached to the current inbound activity. See {@link IIncomingFile}.
+ */
+export class IncomingFile implements IIncomingFile {
+  readonly uniqueId?: string;
+  readonly name: string;
+  readonly contentType?: string;
+  readonly extension?: string;
+  readonly scope: ConversationType;
+  readonly source: FileSource;
+  readonly webUrl?: string;
+  readonly raw?: unknown;
+
+  private readonly downloadUrl?: string;
+  private readonly _fetch?: FileFetch;
+  private _priorFetchSucceeded = false;
+
+  constructor(init: IIncomingFileInit) {
+    this.uniqueId = init.uniqueId;
+    this.name = init.name;
+    this.contentType = init.contentType;
+    this.extension = init.extension;
+    this.scope = init.scope;
+    this.source = init.source;
+    this.webUrl = init.webUrl;
+    this.raw = init.raw;
+    this.downloadUrl = init.downloadUrl;
+    this._fetch = init.fetch;
+  }
+
+  async stream(): Promise<ReadableStream<Uint8Array>> {
+    const opened = await openFileStream(this.target(), {
+      priorFetchSucceeded: this._priorFetchSucceeded,
+      fetch: this._fetch,
+    });
+    this._priorFetchSucceeded = true;
+    return opened.stream;
+  }
+
+  async download(): Promise<IDownloadedFile> {
+    const opened = await openFileStream(this.target(), {
+      priorFetchSucceeded: this._priorFetchSucceeded,
+      fetch: this._fetch,
+    });
+    this._priorFetchSucceeded = true;
+
+    const bytes = await collectStream(opened.stream);
+
+    return new DownloadedFile({
+      bytes,
+      contentType: opened.contentType,
+      filename: this.name,
+      sourceUrl: opened.sourceUrl,
+    });
+  }
+
+  async text(encoding?: string): Promise<string> {
+    const downloaded = await this.download();
+    return downloaded.text(encoding);
+  }
+
+  async arrayBuffer(): Promise<ArrayBuffer> {
+    const downloaded = await this.download();
+    return downloaded.arrayBuffer();
+  }
+
+  async saveAs(path: string): Promise<void> {
+    const opened = await openFileStream(this.target(), {
+      priorFetchSucceeded: this._priorFetchSucceeded,
+      fetch: this._fetch,
+    });
+    this._priorFetchSucceeded = true;
+
+    const writable = createWriteStream(path);
+    const reader = opened.stream.getReader();
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+
+        if (done) {
+          break;
+        }
+
+        if (value) {
+          await new Promise<void>((resolve, reject) => {
+            writable.write(value, (err) => (err ? reject(err) : resolve()));
+          });
+        }
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        writable.end((err?: Error | null) => (err ? reject(err) : resolve()));
+      });
+    } catch (err) {
+      writable.destroy();
+      throw err;
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private target(): FileFetchTarget {
+    return {
+      scope: this.scope,
+      downloadUrl: this.downloadUrl,
+      contentType: this.contentType,
+    };
+  }
+}

--- a/packages/apps/src/files/incoming-file.ts
+++ b/packages/apps/src/files/incoming-file.ts
@@ -1,6 +1,7 @@
 import { createWriteStream } from 'fs';
 
 import { ConversationType } from '@microsoft/teams.api';
+import { Client as HttpClient } from '@microsoft/teams.common';
 
 import { collectStream, FileFetch, FileFetchTarget, openFileStream } from './download';
 import { DownloadedFile } from './downloaded-file';
@@ -20,8 +21,10 @@ export interface IIncomingFileInit {
   raw?: unknown;
   /** Short-lived, pre-authorized download URL (personal scope). */
   downloadUrl?: string;
-  /** Injectable fetch, defaulting to the global `fetch`; used to keep tests off the network. */
+  /** Injectable fetch used to keep tests off the network; takes precedence over `httpClient`. */
   fetch?: FileFetch;
+  /** The app's HTTP client, so downloads inherit its User-Agent, middleware, and user-supplied configuration. */
+  httpClient?: HttpClient;
 }
 
 /**
@@ -39,6 +42,7 @@ export class IncomingFile implements IIncomingFile {
 
   private readonly downloadUrl?: string;
   private readonly _fetch?: FileFetch;
+  private readonly _httpClient?: HttpClient;
   private _priorFetchSucceeded = false;
 
   constructor(init: IIncomingFileInit) {
@@ -52,12 +56,14 @@ export class IncomingFile implements IIncomingFile {
     this.raw = init.raw;
     this.downloadUrl = init.downloadUrl;
     this._fetch = init.fetch;
+    this._httpClient = init.httpClient;
   }
 
   async stream(): Promise<ReadableStream<Uint8Array>> {
     const opened = await openFileStream(this.target(), {
       priorFetchSucceeded: this._priorFetchSucceeded,
       fetch: this._fetch,
+      httpClient: this._httpClient,
     });
     this._priorFetchSucceeded = true;
     return opened.stream;
@@ -67,6 +73,7 @@ export class IncomingFile implements IIncomingFile {
     const opened = await openFileStream(this.target(), {
       priorFetchSucceeded: this._priorFetchSucceeded,
       fetch: this._fetch,
+      httpClient: this._httpClient,
     });
     this._priorFetchSucceeded = true;
 
@@ -94,6 +101,7 @@ export class IncomingFile implements IIncomingFile {
     const opened = await openFileStream(this.target(), {
       priorFetchSucceeded: this._priorFetchSucceeded,
       fetch: this._fetch,
+      httpClient: this._httpClient,
     });
     this._priorFetchSucceeded = true;
 

--- a/packages/apps/src/files/index.ts
+++ b/packages/apps/src/files/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './errors';

--- a/packages/apps/src/files/types.ts
+++ b/packages/apps/src/files/types.ts
@@ -1,0 +1,91 @@
+import { ConversationType } from '@microsoft/teams.api';
+
+/**
+ * Where the SDK found an inbound file. 
+ * - `botActivity` files come straight from the inbound activity's attachments; 
+ * - `graph` files are hydrated through Microsoft Graph.
+ */
+export type FileSource = 'botActivity' | 'graph';
+
+/**
+ * A buffered, point-in-time snapshot of a downloaded file's bytes that the caller owns.
+ *
+ * Returned by {@link IIncomingFile.download}. The bytes are already in memory, so the convenience readers here are synchronous and never re-download.
+ * Because it is a snapshot, holding one and reusing it is the way to read the same file several ways without re-fetching through the live {@link IIncomingFile} handle.
+ */
+export interface IDownloadedFile {
+  /** The file bytes, buffered from `stream()` read to completion. */
+  bytes: Uint8Array;
+  /** MIME type resolved from the response or the incoming file. */
+  contentType: string;
+  /** Resolved filename. */
+  filename: string;
+  /** The URL the bytes were actually fetched from. */
+  sourceUrl: string;
+
+  /** Decode bytes as UTF-8 (or a provided encoding). No content-type check. 
+   * Lossy: invalid bytes become the U+FFFD replacement character and never throw. 
+   * For strict or binary-safe reads, use `bytes`/`arrayBuffer()`. */
+  text(encoding?: string): string;
+  /** Return the bytes as an `ArrayBuffer`. Synchronous; no re-download. */
+  arrayBuffer(): ArrayBuffer;
+  /** Write the already-buffered bytes to a local file path (no re-fetch, unlike {@link IIncomingFile.saveAs} which streams a fresh download).
+   * Requires Node: it writes to the local filesystem, which is unavailable in the browser. */
+  saveAs(path: string): Promise<void>;
+}
+
+/**
+ * A lazy handle to a file attached to the current inbound activity.
+ *
+ * Nothing is downloaded until a byte method is called. The handle stays live and holds no memoized bytes, so each of `stream()`/`download()`/`text()`/`arrayBuffer()`/`saveAs()` fetches afresh. For a personal file that re-fetch is bounded by the short-lived download URL lifetime and may hit its expiry; to read the same file several ways, call {@link download} once and reuse the returned {@link IDownloadedFile}.
+ */
+export interface IIncomingFile {
+  /** The OneDrive/ODSP drive-item id when the platform reports it (`content.uniqueId`); the storage-specific locator a Graph fetch keys off. Present only when the wire provided it. */
+  uniqueId?: string;
+  /** Display name including extension when known. */
+  name: string;
+  /** MIME type when known. */
+  contentType?: string;
+  /** File extension without the dot (e.g. `pdf`), taken from the platform-supplied `fileType`. Absent when the wire omits it. */
+  extension?: string;
+  /** Conversation scope the file arrived in (the SDK's {@link ConversationType}). */
+  scope: ConversationType;
+  /** Where the SDK found the file. Only `botActivity` is produced today. */
+  source: FileSource;
+  /** Web URL to the file in OneDrive/SharePoint when known. */
+  webUrl?: string;
+  /** The raw underlying attachment/graph object for escape-hatch access. */
+  raw?: unknown;
+
+  /** Stream the bytes. Low-level primitive: returns the native stream directly from the fetch, single-consumption, not buffered or retained. Use for large files and pipelines (parse-as-you-go, pipe to disk). `download()` is built on this. Uncapped: the consumer bounds it by how much it reads. */
+  stream(): Promise<ReadableStream<Uint8Array>>;
+
+  /** Fetch the whole file and buffer it into a {@link IDownloadedFile} snapshot you own. Lazy and not memoized: calling again re-fetches. If you already hold a `DownloadedFile`, call its `saveAs()` rather than this handle's, which would re-fetch. */
+  download(): Promise<IDownloadedFile>;
+
+  /** Convenience: run `download()` then decode the bytes as UTF-8 (or a provided encoding). Re-fetches on each call (no memoized bytes); to read bytes several ways hold one `DownloadedFile` instead. No content-type check; decoding is lossy (invalid bytes become U+FFFD and never throw). For strict or binary-safe reads, use `download().bytes`/`arrayBuffer()`. */
+  text(encoding?: string): Promise<string>;
+  /** Convenience: run `download()` then return the bytes as an `ArrayBuffer`. Re-fetches on each call. */
+  arrayBuffer(): Promise<ArrayBuffer>;
+  /** Stream the bytes straight to a local file path, so saving a large file never materializes it in memory. Requires Node: it writes to the local filesystem, which is unavailable in the browser. */
+  saveAs(path: string): Promise<void>;
+};
+
+/**
+ * Accessor for the uploaded files on the current inbound activity, exposed as `ctx.files`.
+ *
+ * "Files" is the uploaded-file view over the raw `ctx.activity.attachments` array. Uploaded files arrive as attachments where `contentType` is `file.download.info`, carrying file metadata (a `downloadUrl` plus identifiers) rather than the bytes themselves, which are fetched from that URL. This accessor maps each to an {@link IIncomingFile}, and skips everything else in `attachments` (adaptive cards, mentions, other non-file content) as well as malformed file entries, never throwing. For each file it returns, the original wire attachment (the metadata object, not the bytes) is retained on {@link IIncomingFile.raw}. A malformed or non-file attachment is reachable only through the raw `activity.attachments` array.
+ *
+ * This covers the file-upload path, not "any uploaded media". What matters is how the content arrived, not the file's MIME type, so file *type* is unrestricted (pdf, docx, png, etc.) as long as it was sent as an uploaded file. An image sent as a file appears here, but the same image pasted inline does not.
+ */
+export interface IFilesAccessor {
+  /**
+   * The files attached to the current inbound activity. Async because later scopes hydrate through Graph; the personal path resolves synchronously from the activity but keeps the async signature so the shape never breaks.
+   *
+   * Currently takes no arguments and returns only uploaded files. The signature is reserved to grow an options object later (e.g. `list(options?: { includeInlineImages?; contentTypes?; includeRaw? })`) so coverage can widen opt-in without a break; the default stays narrow.
+   */
+  list(): Promise<IIncomingFile[]>;
+
+  /** Convenience: the first attached file, or `undefined` when none. Sugar over `list()[0]`; shares `list()`'s resolution so it stays correct when later scopes hydrate through Graph. */
+  first(): Promise<IIncomingFile | undefined>;
+}

--- a/packages/apps/src/files/types.ts
+++ b/packages/apps/src/files/types.ts
@@ -1,8 +1,8 @@
 import { ConversationType } from '@microsoft/teams.api';
 
 /**
- * Where the SDK found an inbound file. 
- * - `botActivity` files come straight from the inbound activity's attachments; 
+ * Where the SDK found an inbound file.
+ * - `botActivity` files come straight from the inbound activity's attachments;
  * - `graph` files are hydrated through Microsoft Graph.
  */
 export type FileSource = 'botActivity' | 'graph';
@@ -16,15 +16,15 @@ export type FileSource = 'botActivity' | 'graph';
 export interface IDownloadedFile {
   /** The file bytes, buffered from `stream()` read to completion. */
   bytes: Uint8Array;
-  /** MIME type resolved from the response or the incoming file. */
+  /** MIME type resolved from the download response header, or the incoming file's metadata type if the response omits one. Falls back to `application/octet-stream` when neither provides a type, so this is never empty. */
   contentType: string;
   /** Resolved filename. */
   filename: string;
   /** The URL the bytes were actually fetched from. */
   sourceUrl: string;
 
-  /** Decode bytes as UTF-8 (or a provided encoding). No content-type check. 
-   * Lossy: invalid bytes become the U+FFFD replacement character and never throw. 
+  /** Decode bytes as UTF-8 (or a provided encoding). No content-type check.
+   * Lossy: invalid bytes become the U+FFFD replacement character and never throw.
    * For strict or binary-safe reads, use `bytes`/`arrayBuffer()`. */
   text(encoding?: string): string;
   /** Return the bytes as an `ArrayBuffer`. Synchronous; no re-download. */
@@ -44,7 +44,9 @@ export interface IIncomingFile {
   uniqueId?: string;
   /** Display name including extension when known. */
   name: string;
-  /** MIME type when known. */
+  /**
+   * The file's MIME type, when Teams provides it with the file; otherwise unset. The type resolved from the download response is on the returned {@link IDownloadedFile}, not written back here.
+   */
   contentType?: string;
   /** File extension without the dot (e.g. `pdf`), taken from the platform-supplied `fileType`. Absent when the wire omits it. */
   extension?: string;
@@ -69,7 +71,7 @@ export interface IIncomingFile {
   arrayBuffer(): Promise<ArrayBuffer>;
   /** Stream the bytes straight to a local file path, so saving a large file never materializes it in memory. Requires Node: it writes to the local filesystem, which is unavailable in the browser. */
   saveAs(path: string): Promise<void>;
-};
+}
 
 /**
  * Accessor for the uploaded files on the current inbound activity, exposed as `ctx.files`.

--- a/packages/apps/src/files/types.ts
+++ b/packages/apps/src/files/types.ts
@@ -45,7 +45,7 @@ export interface IIncomingFile {
   /** Display name including extension when known. */
   name: string;
   /**
-   * The file's MIME type, when Teams provides it with the file; otherwise unset. The type resolved from the download response is on the returned {@link IDownloadedFile}, not written back here.
+   * The file's MIME type when the source provides one. Always unset for `botActivity` files: a `file.download.info` attachment carries no MIME type, only the `fileType` extension surfaced as {@link extension}. Populated for sources that do carry one, such as a `graph` drive item. To learn the type of the bytes you actually received, read {@link IDownloadedFile.contentType}, which is resolved from the download response.
    */
   contentType?: string;
   /** File extension without the dot (e.g. `pdf`), taken from the platform-supplied `fileType`. Absent when the wire omits it. */

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -2,8 +2,9 @@ export * from './app';
 export * from './plugins';
 export * from './types';
 export * from './contexts';
-export * from './oauth';
 export * from './events';
+export * from './files';
+export * from './oauth';
 // Only the interface is public: the implementing class is constructed from the
 // app's `TokenManager`, which is internal.
 export type { IAppTokenProvider } from './token-provider';

--- a/packages/common/src/http/client.spec.ts
+++ b/packages/common/src/http/client.spec.ts
@@ -234,6 +234,16 @@ describe('Client', () => {
           headers: { Authorization: 'Bearer test' },
         });
       });
+
+      it('should not send Authorization when a request token resolves to nothing', async () => {
+        const client = new HttpClient({ token: 'default' });
+        const spy = jest.spyOn(client.instance, 'get').mockResolvedValueOnce({});
+
+        await client.get('/test', { token: () => undefined });
+
+        const [, config] = spy.mock.calls[0];
+        expect(config?.headers?.Authorization).toBeUndefined();
+      });
     });
   });
 


### PR DESCRIPTION
Adds API for receiving files to the app in personal scope. A user uploads a file, which arrives on the activity, and `ctx.files.list()` provides metadata of the file(s) and lazy handlers to download it. The url is `tempauth` and will expire.

- **`ctx.files`**: `list()` / `first()` map inbound `file.download.info` attachments to `IIncomingFile`. Never throws: non-message activities and empty/malformed attachments yield an empty list; bad entries are skipped.
- **`IIncomingFile`**: file metadata with lazy `download()`, `stream()`, `text(encoding?)`, `arrayBuffer()`, `saveAs(path)`. Each read re-fetches (bounded by the short-lived URL).
- **`IDownloadedFile`**: buffered snapshot you own (`bytes`, `contentType`, `filename`, `sourceUrl`), with synchronous `text()`/`arrayBuffer()`/`saveAs()`.
- **Errors**: Differentiates between first fetch error (url expired before first fetch), reread error (url expired after first fetch), and scope not supported error (today, only 1:1).
- **Types**: new `FileDownloadInfo` model + `file.download.info` content-type constant; `ConversationType` extended with `channel` (forward-compatible).

## Testing

- Unit tests: `files-accessor.spec.ts`, `incoming-file.spec.ts`
- Manual e2e

## Note

- After investigating thumbnail url behavior, I adjusted `Attachments.thumbnailUrl` docstrings to indicate it will not be populated on incoming files.
- Similarly for `etag`, this field may be set by Graph, which is not in scope for this PR.