### PR TITLE
feat: add Anthropic support to AI MCP sample

### DIFF
--- a/examples/ai-mcp/README.md
+++ b/examples/ai-mcp/README.md
@@ -1,111 +1,122 @@
-# ai-mcp — Azure OpenAI + MCP sample
+# ai-mcp — multi-provider AI + MCP sample
 
-A Teams bot powered by **Azure OpenAI** (via the `openai` SDK's `AzureOpenAI` client) and the **Model Context Protocol** SDK. Demonstrates streaming responses, per-conversation memory, a local clarification-card tool, remote MCP server tools, inline citations, follow-up suggestions, and custom feedback.
+A Teams bot powered by either **Azure OpenAI** or **Anthropic Claude**, plus the **Model Context Protocol** SDK. It demonstrates streaming responses, per-conversation memory, a local clarification-card tool, remote MCP tools, inline citations, follow-up suggestions, and custom feedback.
 
-This is the TypeScript counterpart to the .NET [`ExtAIBot`](https://github.com/microsoft/teams.net/pull/486) sample. The structural shape matches: a single bot process owns the AI plumbing, runs the tool-call loop in-process, and connects to MCP servers directly. The auto-loop comes from `openai.chat.completions.runTools()` — the OpenAI SDK's helper that auto-executes each tool's `function` callback and feeds the result back to the model until it produces final text.
-
-> **Provider scope.** This sample is bound to the OpenAI chat-completions wire protocol — Azure OpenAI works; vanilla OpenAI works; non-OpenAI providers do not. (See the .NET sample for an `IChatClient` abstraction that's provider-agnostic — TS has no equivalent today.)
+The Teams layer is provider-neutral: activity handlers call `agent.run(conversationId, text, stream)`. Each provider implementation owns its message history and tool loop.
 
 ## Features
 
-- **Streaming** — `runner.on('content', delta => stream.emit(delta))` forwards text token-by-token
-- **Conversation memory** — each conversation keeps its own `Map<conv, ChatCompletionMessageParam[]>` in process
-- **Local tool** — `request_clarification`: a `RunnableToolFunction` whose `function` callback pushes an Adaptive Card into a per-turn bucket and returns a placeholder string. The agent discards its wrap-up text and sends only the card.
-- **MCP client** — connects to the [Microsoft Learn docs MCP server](https://learn.microsoft.com/api/mcp) at startup. Each MCP tool is wrapped as a `RunnableToolFunction` whose `function` callback invokes the server and feeds the raw result into the citation collector before returning it to the model.
-- **Inline citations** — `CitationCollector` parses MCP tool results for `{ contentUrl, title, content }` records; `[N]` markers in the final reply become clickable Teams citation entities.
-- **Follow-up suggestions** — a separate non-streaming `chat.completions.create({ response_format: { type: 'json_schema', ... }})` call produces two short prompts shown as suggested-action chips.
-- **Custom feedback** — every text reply enables `addFeedback('custom')`; clicking thumbs up/down opens a bot-rendered task module, and submissions hit `message.submit.feedback`.
+- **Provider selection** — set `AI_PROVIDER=azure-openai` or `AI_PROVIDER=anthropic`.
+- **Streaming** — forwards model text into the Teams `IStreamer`.
+- **Conversation memory** — keeps provider-native history per Teams conversation.
+- **Local tool** — shows an Adaptive Card when the request needs clarification.
+- **MCP client** — connects to the Microsoft Learn MCP server and exposes its tools to either provider.
+- **Inline citations** — turns `[N]` references from grounded answers into Teams citation entities.
+- **Follow-up suggestions** — generates two suggested-action prompts after a text response.
+- **Custom feedback** — enables Teams feedback controls and handles the feedback dialog.
 
 ## Prerequisites
 
 - Node.js 20+
-- An **Azure OpenAI resource** with a deployed model (e.g. `gpt-4o`) and an API key. No Foundry project required.
-- A Teams bot registration (App ID + secret).
+- A Teams bot registration with an App ID and secret
+- One model provider:
+  - An Azure OpenAI resource, deployment, and API key
+  - An Anthropic API key and supported Claude model
 
 ## Teams CLI
 
-Use the official Teams CLI (`@microsoft/teams.cli`) to create and manage the Teams app for this sample:
+Install the Teams CLI and create the app registration:
 
 ```bash
 npm install -g @microsoft/teams.cli
-teams --version
 teams login
-```
-
-Expose this sample's local `/api/messages` endpoint with a tunnel, then create the Teams app:
-
-```bash
 teams app create --name "ai-mcp" --endpoint "https://<your-tunnel>/api/messages" --env .env --json
 ```
 
-The CLI writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` to your `.env` file and prints an install link for Teams.
+The CLI writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` to `.env`.
 
-## Setup
+## Configure Azure OpenAI
 
-Add the Azure OpenAI settings to the `.env` created by the CLI:
+Azure OpenAI remains the default provider:
 
 ```env
+AI_PROVIDER=azure-openai
 AZURE_OPENAI_ENDPOINT=https://<your-resource>.openai.azure.com
 AZURE_OPENAI_API_KEY=<your-api-key>
 AZURE_OPENAI_MODEL_DEPLOYMENT_NAME=<deployment-name>
 AZURE_OPENAI_API_VERSION=2024-10-21
+```
 
-# Optional — defaults to the public MS Learn MCP endpoint.
+`AZURE_OPENAI_MODEL_DEPLOYMENT_NAME` is the deployment name, not the underlying model name.
+
+## Configure Anthropic
+
+```env
+AI_PROVIDER=anthropic
+ANTHROPIC_API_KEY=<your-api-key>
+ANTHROPIC_MODEL=<supported-claude-model>
+
+# Optional; defaults to 4096.
+ANTHROPIC_MAX_TOKENS=4096
+```
+
+The Anthropic implementation uses the Messages API directly. It streams text with `messages.stream()`, executes returned `tool_use` blocks, appends matching `tool_result` blocks, and continues until Claude returns a final response.
+
+## Optional MCP configuration
+
+Both providers use the same MCP client and tool dispatcher:
+
+```env
 MCP_SERVER_URL=https://learn.microsoft.com/api/mcp
 ```
 
-`AZURE_OPENAI_MODEL_DEPLOYMENT_NAME` is the **deployment name** on your Azure OpenAI resource, not the base model name.
+The Microsoft Learn endpoint is the default. Startup fails if the configured MCP server cannot be reached.
 
-## Running
+## Run
 
 ```bash
 npm install
 npm run dev --workspace=@examples/ai-mcp
 ```
 
-The bot connects to the MS Learn MCP server at startup and lists its tools before accepting messages. If the MCP server is unreachable, startup fails — by design, since the sample is meant to demonstrate the MCP path.
-
 ## Example interactions
 
-- `Tell me about streaming` — ambiguous: the agent calls `request_clarification`; the bot replies with a clarification card. Pick an option → that choice arrives as the next user turn and the agent answers based on it.
-- `How do I stream in teams.ts?` — agent calls an MS Learn search tool, replies with a docs-grounded answer and inline citations, plus two follow-up chips.
-- `How do I list users with Microsoft Graph?` — same MCP search path, lands on Graph docs.
+- `Tell me about streaming` — asks for clarification with an Adaptive Card.
+- `How do I stream in teams.ts?` — searches Microsoft Learn and returns a cited answer.
+- `How do I list users with Microsoft Graph?` — invokes an MCP search tool and suggests follow-up prompts.
 
-## How the pieces fit
+## Project structure
 
+```text
+src/index.ts              Provider selection, MCP initialization, Teams app startup
+src/agent.ts              Azure OpenAI agent and shared agent contract
+src/anthropic-agent.ts    Anthropic streaming and tool-use loop
+src/prompts.ts            Shared system and follow-up prompts
+src/local-tools.ts        Provider-neutral clarification behavior plus OpenAI adapter
+src/mcp-tools.ts          Provider-neutral MCP execution plus OpenAI adapter
+src/citation-collector.ts MCP citation parsing and Teams citation attachment
+src/handlers.ts           Provider-neutral Teams activity handlers
 ```
-src/index.ts             — AzureOpenAI client + MCP init + Agent + handler registration
-src/agent.ts             — per-conv chat history, runTools auto-loop, follow-ups
-src/local-tools.ts       — request_clarification RunnableToolFunction + card builder
-src/mcp-tools.ts         — MCP client lifecycle, tool listing, wraps each tool
-                           as a RunnableToolFunction
-src/citation-collector.ts — parses MCP results, attaches Teams citations to the reply
-src/handlers.ts          — message, card.action.clarification, message.fetch-task,
-                           message.submit.feedback
+
+## Anthropic tool loop
+
+For each model round, `AnthropicAgent`:
+
+1. Sends the provider-native conversation history, system prompt, and tools.
+2. Streams text deltas into Teams.
+3. Appends Claude's complete assistant content to history.
+4. Executes every returned `tool_use` block.
+5. Appends corresponding `tool_result` blocks as the next user message.
+6. Repeats until no tool calls remain.
+
+Tool failures are returned to Claude with `is_error: true`. A maximum-round guard prevents an unbounded tool loop.
+
+## Provider-neutral Teams boundary
+
+`handlers.ts` depends only on `IAgentRunner`:
+
+```typescript
+agent.run(activity.conversation.id, userText, stream);
 ```
 
-### Tool loop
-
-`openai.chat.completions.runTools({ stream: true, tools })` does the heavy lifting:
-
-1. Sends the request with our tool definitions to Azure OpenAI.
-2. If the model emits a `tool_calls` choice, the runner invokes the matching tool's `function` callback (passing parsed args).
-3. The tool's return value is appended as a `role: 'tool'` message and the model is re-prompted.
-4. Steps 2-3 repeat until the model produces a `content` message instead of a tool call.
-5. Throughout, `content` events fire for each text delta — we forward them straight to the Teams stream.
-
-Each tool function is responsible for its own side effects:
-
-- `request_clarification` pushes the card into `pendingCards[]`.
-- Each MCP tool invokes the server, feeds the raw result into `CitationCollector.tryExtract`, and returns the text to the model.
-
-After `runner.done()`, the agent inspects `pendingCards` and the citation collector to assemble the final Teams activity.
-
-### Clarification flow
-
-1. User: ambiguous question.
-2. Model calls `request_clarification`. The callback builds the card, pushes it onto `pendingCards`, returns `"Clarification card attached."`.
-3. The model is re-prompted with that tool result and produces a brief wrap-up (e.g. "I've asked for clarification — please pick an option"). We discard this — `pendingCard` is set, so `replyText` is forced to `''`.
-4. Bot sends an attachment-only message containing only the card.
-5. User picks an option, submits → `card.action.clarification` invoke → handler calls `agent.run(conv, choice, stream)` exactly as if the choice were a new user message.
-6. Model now has full context (its own previous tool call + the user's choice) and answers based on it.
+Switching providers does not change Teams routing, card actions, citations, feedback, or final activity construction.

--- a/examples/ai-mcp/appPackage/manifest.json
+++ b/examples/ai-mcp/appPackage/manifest.json
@@ -15,7 +15,7 @@
     "termsOfUseUrl": "https://www.microsoft.com/legal/terms-of-use"
   },
   "description": {
-    "short": "Teams bot powered by Azure OpenAI + MS Learn MCP",
+    "short": "Teams bot powered by AI + MS Learn MCP",
     "full": "A Teams bot that streams answers grounded in MS Learn docs via the MCP protocol, with inline citations, follow-up chips, a clarification card tool, and custom feedback."
   },
   "icons": {

--- a/examples/ai-mcp/package.json
+++ b/examples/ai-mcp/package.json
@@ -21,6 +21,7 @@
     "dev:teamsfx:launch-testtool": "npx env-cmd --silent -f env/.env.testtool teamsapptester start"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.71.2",
     "@microsoft/teams.api": "*",
     "@microsoft/teams.apps": "*",
     "@microsoft/teams.cards": "*",

--- a/examples/ai-mcp/src/agent.ts
+++ b/examples/ai-mcp/src/agent.ts
@@ -10,28 +10,7 @@ import { ILogger } from '@microsoft/teams.common';
 import { CitationCollector } from './citation-collector';
 import { buildClarificationTool } from './local-tools';
 import { McpToolSet } from './mcp-tools';
-
-
-const SYSTEM_PROMPT = `\
-You are a Teams docs assistant that can search Microsoft Learn (Teams, .NET, TypeScript, Microsoft Graph, Azure)
-and explain bot concepts (streaming, Adaptive Cards, citations, feedback).
-
-When you use information from a search tool, cite your sources inline using a 1-based numeric marker for each result
-you reference (e.g. [1], [2]). Use the same number consistently for the same source within a reply.
-Do not add a references or sources list at the end of your response — citations are displayed separately in the UI.
-
-If the user's request is ambiguous or could mean two or more things, call the request_clarification tool with a short
-question and 2-4 candidate interpretations rather than guessing.`;
-
-const FOLLOW_UPS_PROMPT = `\
-Produce 2 specific prompts the user might want to ask next, based on the conversation so far.
-
-Each prompt MUST:
-- Be phrased in the first person, as the user would type.
-- Stay under 8 words.
-
-Drill into a concrete topic, API, or concept that just came up — or, if the conversation just started, suggest
-prompts that showcase what you can help with.`;
+import { FOLLOW_UPS_PROMPT, SYSTEM_PROMPT } from './prompts';
 
 const FOLLOW_UPS_SCHEMA = {
   type: 'object',
@@ -49,6 +28,16 @@ export type AgentRunResult = {
   citations: CitationCollector;
   followUps: string[];
 };
+
+/**
+ * Provider-neutral contract consumed by the Teams activity handlers.
+ */
+export interface IAgentRunner {
+  /**
+   * Runs one serialized conversation turn and streams its text into Teams.
+   */
+  run(teamsConvId: string, userText: string, stream: IStreamer): Promise<AgentRunResult>;
+}
 
 export type AgentOptions = {
   client: AzureOpenAI;
@@ -72,7 +61,7 @@ export type AgentOptions = {
  * onto the previous turn's promise — concurrent submits (e.g. clarification
  * race) would otherwise interleave assistant/tool messages.
  */
-export class Agent {
+export class Agent implements IAgentRunner {
   private readonly _client: AzureOpenAI;
   private readonly _deployment: string;
   private readonly _mcpTools: McpToolSet;

--- a/examples/ai-mcp/src/anthropic-agent.ts
+++ b/examples/ai-mcp/src/anthropic-agent.ts
@@ -1,0 +1,246 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+import { IStreamer } from '@microsoft/teams.apps';
+import { AdaptiveCard } from '@microsoft/teams.cards';
+import { ILogger } from '@microsoft/teams.common';
+
+import type { IAgentRunner, AgentRunResult } from './agent';
+import { CitationCollector } from './citation-collector';
+import {
+  CLARIFICATION_TOOL_NAME,
+  CLARIFICATION_TOOL_SCHEMA,
+  executeClarificationTool,
+} from './local-tools';
+import { McpToolSet } from './mcp-tools';
+import { FOLLOW_UPS_PROMPT, SYSTEM_PROMPT } from './prompts';
+
+const MAX_TOOL_ROUNDS = 8;
+
+/**
+ * Configuration for the Anthropic-backed agent.
+ */
+export type AnthropicAgentOptions = {
+  /** Anthropic SDK client authenticated with the developer's API key. */
+  client: Anthropic;
+  /** Claude model identifier sent with every Messages API request. */
+  model: string;
+  /** Maximum output tokens allowed for each model request. */
+  maxTokens?: number;
+  /** Connected MCP tool set shared across conversations. */
+  mcpTools: McpToolSet;
+  /** Logger used for provider and tool diagnostics. */
+  log: ILogger;
+};
+
+/**
+ * Anthropic Messages API implementation of the provider-neutral Teams agent contract.
+ */
+export class AnthropicAgent implements IAgentRunner {
+  private readonly _client: Anthropic;
+  private readonly _model: string;
+  private readonly _maxTokens: number;
+  private readonly _mcpTools: McpToolSet;
+  private readonly _log: ILogger;
+  private readonly _histories = new Map<string, Anthropic.MessageParam[]>();
+  private readonly _locks = new Map<string, Promise<unknown>>();
+
+  constructor(options: AnthropicAgentOptions) {
+    this._client = options.client;
+    this._model = options.model;
+    this._maxTokens = options.maxTokens ?? 4096;
+    this._mcpTools = options.mcpTools;
+    this._log = options.log;
+  }
+
+  async run(
+    teamsConvId: string,
+    userText: string,
+    stream: IStreamer
+  ): Promise<AgentRunResult> {
+    const previous = this._locks.get(teamsConvId) ?? Promise.resolve();
+    const turn = previous.then(() => this._runTurn(teamsConvId, userText, stream));
+    this._locks.set(
+      teamsConvId,
+      turn.catch(() => {})
+    );
+    return turn;
+  }
+
+  private async _runTurn(
+    teamsConvId: string,
+    userText: string,
+    stream: IStreamer
+  ): Promise<AgentRunResult> {
+    const history = this._getOrCreateHistory(teamsConvId);
+    history.push({ role: 'user', content: userText });
+
+    const citations = new CitationCollector();
+    const pendingCards: AdaptiveCard[] = [];
+
+    stream.update('Thinking...');
+
+    const fullText = await this._streamWithTools(history, pendingCards, citations, stream);
+    const pendingCard = pendingCards[0] ?? null;
+    const replyText = pendingCard ? '' : fullText;
+    const followUps = pendingCard ? [] : await this._generateFollowUps(history);
+
+    return { fullText: replyText, pendingCard, citations, followUps };
+  }
+
+  private async _streamWithTools(
+    history: Anthropic.MessageParam[],
+    pendingCards: AdaptiveCard[],
+    citations: CitationCollector,
+    teamsStream: IStreamer
+  ): Promise<string> {
+    const tools = this._buildTools();
+    let fullText = '';
+
+    for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+      const modelStream = this._client.messages
+        .stream({
+          model: this._model,
+          max_tokens: this._maxTokens,
+          system: SYSTEM_PROMPT,
+          messages: history,
+          tools,
+        })
+        .on('text', (text) => {
+          fullText += text;
+          teamsStream.emit(text);
+        });
+
+      const response = await modelStream.finalMessage();
+      const assistantContent = toAssistantContent(response.content);
+      history.push({ role: 'assistant', content: assistantContent });
+
+      const toolUses = response.content.filter(
+        (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use'
+      );
+      if (toolUses.length === 0) {
+        return fullText;
+      }
+
+      const toolResults = await Promise.all(
+        toolUses.map((toolUse) => this._executeTool(toolUse, pendingCards, citations))
+      );
+      history.push({ role: 'user', content: toolResults });
+    }
+
+    throw new Error(`Anthropic tool loop exceeded ${MAX_TOOL_ROUNDS} rounds.`);
+  }
+
+  private _buildTools(): Anthropic.Tool[] {
+    return [
+      {
+        name: CLARIFICATION_TOOL_NAME,
+        description:
+          'Show an Adaptive Card asking the user to clarify an ambiguous request. ' +
+          'Use this when two or more interpretations are plausible.',
+        input_schema: {
+          ...CLARIFICATION_TOOL_SCHEMA,
+          type: 'object',
+        },
+      },
+      ...this._mcpTools.tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        input_schema: {
+          ...tool.parameters,
+          type: 'object' as const,
+        },
+      })),
+    ];
+  }
+
+  private async _executeTool(
+    toolUse: Anthropic.ToolUseBlock,
+    pendingCards: AdaptiveCard[],
+    citations: CitationCollector
+  ): Promise<Anthropic.ToolResultBlockParam> {
+    try {
+      const content =
+        toolUse.name === CLARIFICATION_TOOL_NAME
+          ? await executeClarificationTool(toolUse.input, pendingCards, this._log)
+          : await this._mcpTools.execute(toolUse.name, toRecord(toolUse.input), citations);
+
+      return {
+        type: 'tool_result',
+        tool_use_id: toolUse.id,
+        content,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this._log.error(`Tool ${toolUse.name} failed: ${message}`);
+      return {
+        type: 'tool_result',
+        tool_use_id: toolUse.id,
+        content: `Tool error: ${message}`,
+        is_error: true,
+      };
+    }
+  }
+
+  private _getOrCreateHistory(teamsConvId: string): Anthropic.MessageParam[] {
+    let history = this._histories.get(teamsConvId);
+    if (!history) {
+      history = [];
+      this._histories.set(teamsConvId, history);
+    }
+    return history;
+  }
+
+  private async _generateFollowUps(history: Anthropic.MessageParam[]): Promise<string[]> {
+    try {
+      const response = await this._client.messages.create({
+        model: this._model,
+        max_tokens: 200,
+        system: `${SYSTEM_PROMPT}\n\nReturn valid JSON only with string properties "prompt1" and "prompt2".`,
+        messages: [...history, { role: 'user', content: FOLLOW_UPS_PROMPT }],
+      });
+      const raw = response.content
+        .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+        .map((block) => block.text)
+        .join('');
+      const json = raw.match(/\{[\s\S]*\}/)?.[0];
+      if (!json) {
+        throw new Error('Claude did not return a JSON object.');
+      }
+
+      const parsed = JSON.parse(json) as { prompt1?: unknown; prompt2?: unknown };
+      return [parsed.prompt1, parsed.prompt2].filter(
+        (prompt): prompt is string => typeof prompt === 'string' && prompt.length > 0
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this._log.warn(`Follow-up generation failed: ${message}`);
+      return [];
+    }
+  }
+}
+
+function toAssistantContent(
+  content: Anthropic.ContentBlock[]
+): Anthropic.ContentBlockParam[] {
+  return content.flatMap((block): Anthropic.ContentBlockParam[] => {
+    if (block.type === 'text') {
+      return [{ type: 'text', text: block.text }];
+    }
+    if (block.type === 'tool_use') {
+      return [{
+        type: 'tool_use',
+        id: block.id,
+        name: block.name,
+        input: block.input,
+      }];
+    }
+    return [];
+  });
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Tool input must be a JSON object.');
+  }
+  return value as Record<string, unknown>;
+}

--- a/examples/ai-mcp/src/handlers.ts
+++ b/examples/ai-mcp/src/handlers.ts
@@ -12,7 +12,7 @@ import {
 } from '@microsoft/teams.cards';
 import { ILogger } from '@microsoft/teams.common';
 
-import { Agent, AgentRunResult } from './agent';
+import type { IAgentRunner, AgentRunResult } from './agent';
 import { CLARIFICATION_INPUT_ID } from './local-tools';
 
 const OK_RESPONSE: AdaptiveCardActionMessageResponse = {
@@ -30,7 +30,7 @@ const OK_RESPONSE: AdaptiveCardActionMessageResponse = {
  * Feedback routes are independent of the agent — `message.fetch-task` returns
  * a task module dialog and `message.submit.feedback` logs the result.
  */
-export function registerHandlers(app: App, agent: Agent, log: ILogger): void {
+export function registerHandlers(app: App, agent: IAgentRunner, log: ILogger): void {
   app.on('message', async ({ activity, stream }) => {
     const userText = activity.stripMentionsText().text ?? '';
     const result = await agent.run(activity.conversation.id, userText, stream);

--- a/examples/ai-mcp/src/index.ts
+++ b/examples/ai-mcp/src/index.ts
@@ -1,9 +1,11 @@
+import Anthropic from '@anthropic-ai/sdk';
 import { AzureOpenAI } from 'openai';
 
 import { App } from '@microsoft/teams.apps';
 import { ConsoleLogger } from '@microsoft/teams.common';
 
-import { Agent } from './agent';
+import { Agent, IAgentRunner } from './agent';
+import { AnthropicAgent } from './anthropic-agent';
 import { registerHandlers } from './handlers';
 import { McpToolSet } from './mcp-tools';
 
@@ -12,20 +14,8 @@ const MCP_SERVER_URL = process.env.MCP_SERVER_URL || 'https://learn.microsoft.co
 const logger = new ConsoleLogger('@examples/ai-mcp', { level: 'info' });
 
 async function main(): Promise<void> {
-  const endpoint = required('AZURE_OPENAI_ENDPOINT');
-  const apiKey = required('AZURE_OPENAI_API_KEY');
-  const deployment = required('AZURE_OPENAI_MODEL_DEPLOYMENT_NAME');
-  const apiVersion = process.env.AZURE_OPENAI_API_VERSION || '2024-10-21';
-
-  const client = new AzureOpenAI({ endpoint, apiKey, deployment, apiVersion });
-
   const mcpTools = await McpToolSet.create(MCP_SERVER_URL, logger.child('mcp'));
-  const agent = new Agent({
-    client,
-    deploymentName: deployment,
-    mcpTools,
-    log: logger.child('agent'),
-  });
+  const agent = createAgent(mcpTools);
 
   const app = new App({
     logger,
@@ -45,10 +35,54 @@ async function main(): Promise<void> {
   await app.start(Number(process.env.PORT) || 3978);
 }
 
+function createAgent(mcpTools: McpToolSet): IAgentRunner {
+  const provider = process.env.AI_PROVIDER || 'azure-openai';
+
+  if (provider === 'anthropic') {
+    const client = new Anthropic({
+      apiKey: required('ANTHROPIC_API_KEY'),
+    });
+    return new AnthropicAgent({
+      client,
+      model: required('ANTHROPIC_MODEL'),
+      maxTokens: optionalNumber('ANTHROPIC_MAX_TOKENS'),
+      mcpTools,
+      log: logger.child('agent/anthropic'),
+    });
+  }
+
+  if (provider === 'azure-openai') {
+    const endpoint = required('AZURE_OPENAI_ENDPOINT');
+    const apiKey = required('AZURE_OPENAI_API_KEY');
+    const deployment = required('AZURE_OPENAI_MODEL_DEPLOYMENT_NAME');
+    const apiVersion = process.env.AZURE_OPENAI_API_VERSION || '2024-10-21';
+    const client = new AzureOpenAI({ endpoint, apiKey, deployment, apiVersion });
+
+    return new Agent({
+      client,
+      deploymentName: deployment,
+      mcpTools,
+      log: logger.child('agent/azure-openai'),
+    });
+  }
+
+  throw new Error(`Unsupported AI_PROVIDER "${provider}". Use "azure-openai" or "anthropic".`);
+}
+
 function required(name: string): string {
   const value = process.env[name];
   if (!value) throw new Error(`${name} is required (set it in .env).`);
   return value;
+}
+
+function optionalNumber(name: string): number | undefined {
+  const value = process.env[name];
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number.`);
+  }
+  return parsed;
 }
 
 main().catch((err) => {

--- a/examples/ai-mcp/src/local-tools.ts
+++ b/examples/ai-mcp/src/local-tools.ts
@@ -33,6 +33,8 @@ export const CLARIFICATION_TOOL_SCHEMA: JSONSchema = {
     options: {
       type: 'array',
       items: { type: 'string' },
+      minItems: 2,
+      maxItems: 4,
       description: '2-4 candidate interpretations the user can pick between.',
     },
   },
@@ -49,7 +51,9 @@ export async function executeClarificationTool(
   log: ILogger
 ): Promise<string> {
   if (!isClarificationArgs(input)) {
-    throw new Error('request_clarification requires a question and 2-4 options.');
+    const message = 'request_clarification requires a question and 2-4 options.';
+    log.warn(message);
+    return message;
   }
 
   log.info(

--- a/examples/ai-mcp/src/local-tools.ts
+++ b/examples/ai-mcp/src/local-tools.ts
@@ -1,3 +1,4 @@
+import type { JSONSchema } from 'openai/lib/jsonschema';
 import type { RunnableToolFunction } from 'openai/lib/RunnableFunction';
 
 import {
@@ -20,6 +21,45 @@ export type ClarificationArgs = {
 };
 
 /**
+ * JSON Schema shared by the OpenAI and Anthropic tool definitions.
+ */
+export const CLARIFICATION_TOOL_SCHEMA: JSONSchema = {
+  type: 'object',
+  properties: {
+    question: {
+      type: 'string',
+      description: 'The clarification question to ask the user.',
+    },
+    options: {
+      type: 'array',
+      items: { type: 'string' },
+      description: '2-4 candidate interpretations the user can pick between.',
+    },
+  },
+  required: ['question', 'options'],
+  additionalProperties: false,
+};
+
+/**
+ * Executes the provider-neutral clarification tool.
+ */
+export async function executeClarificationTool(
+  input: unknown,
+  pendingCards: AdaptiveCard[],
+  log: ILogger
+): Promise<string> {
+  if (!isClarificationArgs(input)) {
+    throw new Error('request_clarification requires a question and 2-4 options.');
+  }
+
+  log.info(
+    `[tool] ${CLARIFICATION_TOOL_NAME}(question=${input.question}, options=[${input.options.join(', ')}])`
+  );
+  pendingCards.push(buildClarificationCard(input));
+  return 'Clarification card attached.';
+}
+
+/**
  * Builds the clarification tool as a RunnableToolFunction. The `function`
  * callback runs during the agent's tool loop: it pushes the card into a
  * per-turn bucket the agent inspects after `runner.done()`, and returns a
@@ -40,32 +80,23 @@ export function buildClarificationTool(
       description:
         'Show an Adaptive Card asking the user to clarify their request when ambiguous. ' +
         'The user picks one option and submits; their choice arrives as the next user turn.',
-      parameters: {
-        type: 'object',
-        properties: {
-          question: {
-            type: 'string',
-            description: 'The clarification question to ask the user.',
-          },
-          options: {
-            type: 'array',
-            items: { type: 'string' },
-            description: '2-4 candidate interpretations the user can pick between.',
-          },
-        },
-        required: ['question', 'options'],
-        additionalProperties: false,
-      },
-      function: async (args: ClarificationArgs) => {
-        log.info(
-          `[tool] ${CLARIFICATION_TOOL_NAME}(question=${args.question}, options=[${args.options.join(', ')}])`
-        );
-        pendingCards.push(buildClarificationCard(args));
-        return 'Clarification card attached.';
-      },
+      parameters: CLARIFICATION_TOOL_SCHEMA,
+      function: (args: ClarificationArgs) => executeClarificationTool(args, pendingCards, log),
       parse: (raw: string) => JSON.parse(raw) as ClarificationArgs,
     },
   };
+}
+
+function isClarificationArgs(value: unknown): value is ClarificationArgs {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const input = value as Record<string, unknown>;
+  return (
+    typeof input['question'] === 'string' &&
+    Array.isArray(input['options']) &&
+    input['options'].length >= 2 &&
+    input['options'].length <= 4 &&
+    input['options'].every((option) => typeof option === 'string')
+  );
 }
 
 function buildClarificationCard(args: ClarificationArgs): AdaptiveCard {

--- a/examples/ai-mcp/src/mcp-tools.ts
+++ b/examples/ai-mcp/src/mcp-tools.ts
@@ -28,6 +28,9 @@ export class McpToolSet {
     this._log = log;
   }
 
+  /**
+   * Connects to an MCP server and captures its available tools.
+   */
   static async create(serverUrl: string, log: ILogger): Promise<McpToolSet> {
     const client = new Client({ name: 'ai-mcp-sample', version: '0.0.0' });
     const transport = new StreamableHTTPClientTransport(new URL(serverUrl));
@@ -45,6 +48,37 @@ export class McpToolSet {
   }
 
   /**
+   * Provider-neutral MCP tool definitions discovered from the server.
+   */
+  get tools(): readonly McpTool[] {
+    return this._tools;
+  }
+
+  /**
+   * Executes a discovered MCP tool and records citation metadata from its result.
+   */
+  async execute(
+    name: string,
+    args: Record<string, unknown>,
+    citations: CitationCollector
+  ): Promise<string> {
+    const tool = this._tools.find((candidate) => candidate.name === name);
+    if (!tool) {
+      throw new Error(`MCP tool ${name} was not discovered.`);
+    }
+
+    this._log.info(
+      `[mcp] ${tool.name}(${Object.entries(args)
+        .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+        .join(', ')})`
+    );
+    const result = await this._client.callTool({ name: tool.name, arguments: args });
+    const text = stringifyResult(result.content);
+    citations.tryExtract(text);
+    return text;
+  }
+
+  /**
    * Returns a fresh array of RunnableToolFunctions for one turn. The
    * citation collector is captured by closure so every MCP tool call on
    * that turn writes into the same collector.
@@ -56,17 +90,7 @@ export class McpToolSet {
         name: tool.name,
         description: tool.description,
         parameters: tool.parameters,
-        function: async (args: Record<string, unknown>) => {
-          this._log.info(
-            `[mcp] ${tool.name}(${Object.entries(args)
-              .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
-              .join(', ')})`
-          );
-          const result = await this._client.callTool({ name: tool.name, arguments: args });
-          const text = stringifyResult(result.content);
-          citations.tryExtract(text);
-          return text;
-        },
+        function: (args: Record<string, unknown>) => this.execute(tool.name, args, citations),
         parse: (raw: string) => JSON.parse(raw) as Record<string, unknown>,
       },
     }));
@@ -77,9 +101,12 @@ export class McpToolSet {
   }
 }
 
-type McpTool = {
+export type McpTool = {
+  /** Name exposed to the model. */
   name: string;
+  /** Description exposed to the model. */
   description: string;
+  /** JSON Schema accepted by the MCP tool. */
   parameters: Record<string, unknown>;
 };
 

--- a/examples/ai-mcp/src/prompts.ts
+++ b/examples/ai-mcp/src/prompts.ts
@@ -1,0 +1,27 @@
+/**
+ * System instructions shared by every model-provider implementation.
+ */
+export const SYSTEM_PROMPT = `\
+You are a Teams docs assistant that can search Microsoft Learn (Teams, .NET, TypeScript, Microsoft Graph, Azure)
+and explain bot concepts (streaming, Adaptive Cards, citations, feedback).
+
+When you use information from a search tool, cite your sources inline using a 1-based numeric marker for each result
+you reference (e.g. [1], [2]). Use the same number consistently for the same source within a reply.
+Do not add a references or sources list at the end of your response — citations are displayed separately in the UI.
+
+If the user's request is ambiguous or could mean two or more things, call the request_clarification tool with a short
+question and 2-4 candidate interpretations rather than guessing.`;
+
+/**
+ * Instructions for generating Teams suggested-action follow-up prompts.
+ */
+export const FOLLOW_UPS_PROMPT = `\
+Produce 2 specific prompts the user might want to ask next, based on the conversation so far.
+
+Each prompt MUST:
+- Be phrased in the first person, as the user would type.
+- Stay under 8 words.
+
+Drill into a concrete topic, API, or concept that just came up — or, if the conversation just started, suggest
+prompts that showcase what you can help with.`;
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
       "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.71.2",
         "@microsoft/teams.api": "*",
         "@microsoft/teams.apps": "*",
         "@microsoft/teams.cards": "*",
@@ -720,6 +721,26 @@
           "optional": true
         },
         "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.71.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
+      "integrity": "sha1-Hj4Ip7LDEpgoSAo9DKRIdHL93j0=",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
           "optional": true
         }
       }
@@ -13779,6 +13800,19 @@
       "version": "0.4.0",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha1-gfOsr1o0c2SS9vX1GHDvns4cqFM=",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "dev": true,
@@ -18270,6 +18304,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha1-Tj4JU4ePJlGPzn9rsRUGSmU4i3o=",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -727,7 +727,7 @@
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.71.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
       "integrity": "sha1-Hj4Ip7LDEpgoSAo9DKRIdHL93j0=",
       "license": "MIT",
       "dependencies": {
@@ -13802,7 +13802,7 @@
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha1-gfOsr1o0c2SS9vX1GHDvns4cqFM=",
       "license": "MIT",
       "dependencies": {
@@ -18307,7 +18307,7 @@
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha1-Tj4JU4ePJlGPzn9rsRUGSmU4i3o=",
       "license": "MIT"
     },


### PR DESCRIPTION
## Summary
- add `AI_PROVIDER` selection for Azure OpenAI and Anthropic Claude
- implement Anthropic streaming and client tool execution while preserving the Teams handler boundary
- share MCP execution, citations, clarification cards, prompts, and follow-up generation across providers
- document both provider configurations

## Validation
- TypeScript compilation and ESLint
- local server startup and Microsoft Learn MCP discovery
- mocked Anthropic tool loop
- live Claude request using Microsoft Learn MCP, streaming text, citations, and follow-up prompts

## Related PRs
- C#: https://github.com/microsoft/teams.net/pull/650
- Python: https://github.com/microsoft/teams.py/pull/559
- Documentation: https://github.com/microsoft/teams-sdk/pull/2957
