### PR TITLE
 fix(api): mark inbound channelData ids as optional

### DIFF
--- a/packages/api/src/models/channel-data/app-info.ts
+++ b/packages/api/src/models/channel-data/app-info.ts
@@ -8,7 +8,7 @@ export type AppInfo = {
   /**
    * @member {string} [id] Unique identifier representing an app
    */
-  id: string;
+  id?: string;
 
   /**
    * @member {string} [version] Version of the app

--- a/packages/api/src/models/channel-data/channel-info.ts
+++ b/packages/api/src/models/channel-data/channel-info.ts
@@ -8,7 +8,7 @@ export type ChannelInfo = {
   /**
    * @member {string} [id] Unique identifier representing a channel
    */
-  id: string;
+  id?: string;
 
   /**
    * @member {string} [name] Name of the channel

--- a/packages/api/src/models/channel-data/settings.ts
+++ b/packages/api/src/models/channel-data/settings.ts
@@ -8,7 +8,7 @@ export type ChannelDataSettings = {
   /**
    * @member {ChannelInfo} [selectedChannel] Information about the selected Teams channel.
    */
-  selectedChannel: ChannelInfo;
+  selectedChannel?: ChannelInfo;
 
   /**
    * @member {any} [any] Additional properties that are not otherwise defined by the TeamsChannelDataSettings

--- a/packages/api/src/models/channel-data/team-info.ts
+++ b/packages/api/src/models/channel-data/team-info.ts
@@ -8,7 +8,7 @@ export type TeamInfo = {
   /**
    * @member {string} [id] Unique identifier representing a team
    */
-  id: string;
+  id?: string;
 
   /**
    * @member {string} [name] Name of team.

--- a/packages/api/src/models/channel-data/tenant-info.ts
+++ b/packages/api/src/models/channel-data/tenant-info.ts
@@ -8,5 +8,5 @@ export type TenantInfo = {
   /**
    * @member {string} [id] Unique identifier representing a tenant
    */
-  id: string;
+  id?: string;
 };


### PR DESCRIPTION
Companion to the Python fix for teams.py#563, where `channelData.app` arriving as `{}`  caused a `ValidationError` that dropped the entire activity.

TypeScript has no runtime break. There's no runtime validator in this repo, so an empty object simply yields `undefined`. This is a type-accuracy fix only; no behavior change.

## Change
Mark `id`  optional on `AppInfo`, `ChannelInfo`, `TeamInfo`, `TenantInfo`, and `selectedChannel` on  `ChannelDataSettings`.

These are inbound-only types describing service-provided data that can legitimately be absent, so declaring them required when the service may set an empty object causes errors. The JSDoc already documented them as optional (`@member {string} [id]`). The declarations had drifted from their own docs. This also aligns with teams.net, where the equivalents are already nullable.

## Scope

Deliberately not changing `Attachment.contentType`, even though Python needed it. `Attachment` is dual-use; both inbound-parsed and developer-constructed for outbound, so required `contentType` is a useful authoring guardrail. Python had to relax it because Pydantic actually throws; TS gains nothing at runtime, so the guardrail is worth keeping.

## Validation

- `turbo build` : 39/39 packages including examples
-  `turbo test`: 554 tests pass
- `turbo lint`: clean

