### PR TITLE
Fix targeted message updates by dropping recipient from wire payload (#738)

### DIFF
--- a/packages/apps/src/activity-sender.spec.ts
+++ b/packages/apps/src/activity-sender.spec.ts
@@ -134,7 +134,11 @@ describe('ActivitySender', () => {
       const conversations = (mockClient as any).conversations;
       expect(conversations.createTargetedActivity).toHaveBeenCalledWith(
         'conv-123',
-        expect.objectContaining({ type: 'message', text: 'targeted' })
+        expect.objectContaining({
+          type: 'message',
+          text: 'targeted',
+          recipient: expect.objectContaining({ isTargeted: true }),
+        })
       );
     });
 
@@ -150,7 +154,7 @@ describe('ActivitySender', () => {
         recipient: { id: 'user-1', name: 'User', role: 'user', isTargeted: true },
       } as ActivityParams;
 
-      await sender.send(activity, groupRef);
+      const result = await sender.send(activity, groupRef);
 
       const conversations = (mockClient as any).conversations;
       expect(conversations.updateTargetedActivity).toHaveBeenCalledWith(
@@ -164,6 +168,7 @@ describe('ActivitySender', () => {
       );
       expect(conversations.updateTargetedActivity.mock.calls[0][2]).not.toHaveProperty('recipient');
       expect(conversations.createActivity).not.toHaveBeenCalled();
+      expect(result.recipient).toEqual(expect.objectContaining({ isTargeted: true }));
     });
 
     it('should merge bot and conversation from ref into activity', async () => {
@@ -262,6 +267,7 @@ describe('ActivitySender', () => {
 
       const result = await sender.send(activity, groupRef);
       expect(result).toEqual(expect.objectContaining({ id: 'activity-1' }));
+      expect(result.recipient).toEqual(expect.objectContaining({ isTargeted: true }));
     });
   });
 

--- a/packages/apps/src/activity-sender.spec.ts
+++ b/packages/apps/src/activity-sender.spec.ts
@@ -156,8 +156,13 @@ describe('ActivitySender', () => {
       expect(conversations.updateTargetedActivity).toHaveBeenCalledWith(
         'conv-123',
         'existing-id',
-        expect.objectContaining({ recipient: expect.objectContaining({ isTargeted: true }) })
+        expect.objectContaining({
+          type: 'message',
+          text: 'targeted update',
+          id: 'existing-id',
+        })
       );
+      expect(conversations.updateTargetedActivity.mock.calls[0][2]).not.toHaveProperty('recipient');
       expect(conversations.createActivity).not.toHaveBeenCalled();
     });
 

--- a/packages/apps/src/activity-sender.ts
+++ b/packages/apps/src/activity-sender.ts
@@ -75,9 +75,17 @@ export class ActivitySender implements IActivitySender {
 
     // Decide create vs update, with targeted variants
     if (payload.id) {
-      const res = isTargeted
-        ? await api.conversations.updateTargetedActivity(ref.conversation.id, payload.id, this.stripRecipient(payload))
-        : await api.conversations.updateActivity(ref.conversation.id, payload.id, payload);
+      if (isTargeted) {
+        const { recipient: _recipient, ...targetedUpdate } = payload;
+        const res = await api.conversations.updateTargetedActivity(
+          ref.conversation.id,
+          payload.id,
+          targetedUpdate
+        );
+        return { ...payload, ...res };
+      }
+
+      const res = await api.conversations.updateActivity(ref.conversation.id, payload.id, payload);
       return { ...payload, ...res };
     }
 
@@ -85,11 +93,6 @@ export class ActivitySender implements IActivitySender {
       ? await api.conversations.createTargetedActivity(ref.conversation.id, payload)
       : await api.conversations.createActivity(ref.conversation.id, payload);
     return { ...payload, ...res };
-  }
-
-  private stripRecipient<T extends { recipient?: unknown }>(activity: T): Omit<T, 'recipient'> {
-    const { recipient: _recipient, ...updatePayload } = activity;
-    return updatePayload;
   }
 
 }

--- a/packages/apps/src/activity-sender.ts
+++ b/packages/apps/src/activity-sender.ts
@@ -87,9 +87,8 @@ export class ActivitySender implements IActivitySender {
     return { ...payload, ...res };
   }
 
-  private stripRecipient(activity: ActivityParams | DeprecatedInputActivity) {
-    const updatePayload = { ...activity };
-    delete updatePayload.recipient;
+  private stripRecipient<T extends { recipient?: unknown }>(activity: T): Omit<T, 'recipient'> {
+    const { recipient: _recipient, ...updatePayload } = activity;
     return updatePayload;
   }
 

--- a/packages/apps/src/activity-sender.ts
+++ b/packages/apps/src/activity-sender.ts
@@ -76,7 +76,7 @@ export class ActivitySender implements IActivitySender {
     // Decide create vs update, with targeted variants
     if (payload.id) {
       const res = isTargeted
-        ? await api.conversations.updateTargetedActivity(ref.conversation.id, payload.id, payload)
+        ? await api.conversations.updateTargetedActivity(ref.conversation.id, payload.id, this.stripRecipient(payload))
         : await api.conversations.updateActivity(ref.conversation.id, payload.id, payload);
       return { ...payload, ...res };
     }
@@ -85,6 +85,12 @@ export class ActivitySender implements IActivitySender {
       ? await api.conversations.createTargetedActivity(ref.conversation.id, payload)
       : await api.conversations.createActivity(ref.conversation.id, payload);
     return { ...payload, ...res };
+  }
+
+  private stripRecipient(activity: ActivityParams | DeprecatedInputActivity) {
+    const updatePayload = { ...activity };
+    delete updatePayload.recipient;
+    return updatePayload;
   }
 
 }


### PR DESCRIPTION
Summary:
- Route targeted `ctx.send` updates through `updateTargetedActivity` without sending `recipient`.
- Add a regression test that verifies the targeted update payload omits `recipient`.

Fixes #738