### PR TITLE
fix(ci): scope package-age gate to npm, add target_url and merge_group

### DIFF
--- a/.github/scripts/dependabot-pr-age-check.mjs
+++ b/.github/scripts/dependabot-pr-age-check.mjs
@@ -17,6 +17,11 @@ import { readFileSync } from 'node:fs';
  *
  * The gate deliberately fails safe: an un-verifiable age blocks the merge rather
  * than allowing a potentially-quarantined package through.
+ *
+ * Scope: only the npm ecosystem is gated. Dependabot PRs for other ecosystems
+ * (notably `github_actions`) resolve from github.com rather than the CFS npm
+ * feed, so their versions are never quarantined and report a passing
+ * "not applicable" status.
  */
 
 const AGE_THRESHOLD_DAYS = 7;
@@ -27,6 +32,16 @@ const LOCKFILE_SUFFIX = 'package-lock.json';
 const STATUS_DESCRIPTION_LIMIT = 140;
 
 /**
+ * Dependabot ecosystems whose packages are served by the CFS npm feed and are
+ * therefore subject to the quarantine window. Dependabot encodes the ecosystem
+ * in its branch name (`dependabot/<ecosystem>/<slug>`), which is the signal this
+ * script uses because it is not customizable, unlike PR labels.
+ */
+const QUARANTINED_ECOSYSTEMS = new Set(['npm_and_yarn']);
+
+const DEPENDABOT_BRANCH_PATTERN = /^dependabot\/(?<ecosystem>[^/]+)\//u;
+
+/**
  * Fallback parser for Dependabot PR prose when no lockfile diff is available.
  * Handles both single ("Bumps `X` from A to B") and grouped ("Updates `X` from
  * A to B") update wording.
@@ -35,6 +50,27 @@ const DEPENDENCY_UPDATE_PATTERN = /(?:Bumps|Updates)\s+(?:\[(?<linked>[^\]]+)\]\
 
 async function main() {
   const context = loadContext();
+
+  // The merge queue builds a temporary ref that is not attached to any pull
+  // request. A required status check must still report on it or the queue
+  // blocks forever, so publish the result the queued PRs already earned: they
+  // could only enter the queue after passing this gate, and packages only get
+  // older from there.
+  if (context.eventName === 'merge_group') {
+    const payload = readEventPayload(context.eventPath);
+    const headSha = payload.merge_group?.head_sha;
+
+    if (!headSha) {
+      throw new Error('merge_group event payload is missing merge_group.head_sha.');
+    }
+
+    await publishStatus(context, headSha, {
+      state: 'success',
+      description: 'Package-age gate satisfied on the queued pull request(s).',
+    }, 'merge_group');
+    return;
+  }
+
   const pullRequests = await getTargetPullRequests(context);
 
   for (const pullRequest of pullRequests) {
@@ -86,8 +122,27 @@ function loadContext() {
     eventPath: process.env.GITHUB_EVENT_PATH ?? '',
     owner,
     repo,
+    repository,
+    runId: process.env.GITHUB_RUN_ID ?? '',
+    serverUrl: process.env.GITHUB_SERVER_URL ?? 'https://github.com',
     token,
   };
+}
+
+/**
+ * URL of the workflow run that produced the status, used as the status
+ * `target_url`. It is a real GitHub-hosted page, so it gives reviewers the
+ * untruncated package list in the job log plus a native "Re-run all jobs"
+ * button to refresh the gate on demand.
+ *
+ * @returns {string|undefined} undefined outside of a GitHub Actions run.
+ */
+function workflowRunUrl(context) {
+  if (!context.runId) {
+    return undefined;
+  }
+
+  return `${context.serverUrl}/${context.repository}/actions/runs/${context.runId}`;
 }
 
 function readEventPayload(eventPath) {
@@ -143,6 +198,18 @@ function isDependabotPullRequest(pullRequest) {
 }
 
 /**
+ * Reads the Dependabot ecosystem from the PR head branch
+ * (`dependabot/<ecosystem>/<slug>`).
+ *
+ * @returns {string|null} the ecosystem, or null when the branch does not follow
+ * Dependabot's naming scheme (treated as unknown, so the full check still runs).
+ */
+function getDependabotEcosystem(pullRequest) {
+  const match = DEPENDABOT_BRANCH_PATTERN.exec(pullRequest.head?.ref ?? '');
+  return match?.groups?.ecosystem ?? null;
+}
+
+/**
  * Determines the age-eligibility of a PR by inspecting every package version it
  * changes. Prefers the lockfile diff (captures transitive changes CFS also
  * quarantines) and falls back to parsing the PR body when no lockfile changed.
@@ -150,6 +217,20 @@ function isDependabotPullRequest(pullRequest) {
  * @returns {Promise<{state: 'success'|'failure'|'pending', description: string}>}
  */
 async function assessPullRequest(context, pullRequest) {
+  // Only npm packages flow through the CFS feed that enforces the quarantine.
+  // `github_actions` (and any other non-npm ecosystem) resolves from github.com,
+  // so its versions can never be quarantined -- and looking them up on the npm
+  // registry would 404 and wrongly trip the fail-safe.
+  const ecosystem = getDependabotEcosystem(pullRequest);
+  if (ecosystem !== null && !QUARANTINED_ECOSYSTEMS.has(ecosystem)) {
+    return {
+      state: 'success',
+      description: truncate(
+        `Ecosystem "${ecosystem}" is not served by the CFS npm feed; package-age gate not applicable.`,
+      ),
+    };
+  }
+
   let changedVersions = await getChangedVersionsFromLockfiles(context, pullRequest);
   let source = 'lockfile';
 
@@ -430,9 +511,7 @@ async function getDependencyAge(dependency) {
 }
 
 /**
- * Publishes the age-gate result as a commit status on the PR head SHA. The
- * Commit Status API replaces any prior status for the same context, so repeated
- * runs update in place without spamming.
+ * Publishes the age-gate result as a commit status on the PR head SHA.
  */
 async function setCommitStatus(context, pullRequest, assessment) {
   const sha = pullRequest.head?.sha;
@@ -440,20 +519,34 @@ async function setCommitStatus(context, pullRequest, assessment) {
     throw new Error(`PR #${pullRequest.number} has no head SHA.`);
   }
 
+  await publishStatus(context, sha, assessment, `PR #${pullRequest.number}`);
+}
+
+/**
+ * Writes the `package-age/7-day` commit status for a SHA. The Commit Status API
+ * replaces any prior status for the same context, so repeated runs update in
+ * place without spamming.
+ */
+async function publishStatus(context, sha, assessment, label) {
+  /** @type {{state: string, context: string, description: string, target_url?: string}} */
+  const body = {
+    state: assessment.state,
+    context: STATUS_CONTEXT,
+    description: truncate(assessment.description),
+  };
+
+  const targetUrl = workflowRunUrl(context);
+  if (targetUrl) {
+    body.target_url = targetUrl;
+  }
+
   await githubRequest(
     context,
     `/repos/${context.owner}/${context.repo}/statuses/${sha}`,
-    {
-      method: 'POST',
-      body: JSON.stringify({
-        state: assessment.state,
-        context: STATUS_CONTEXT,
-        description: truncate(assessment.description),
-      }),
-    },
+    { method: 'POST', body: JSON.stringify(body) },
   );
 
-  console.log(`PR #${pullRequest.number} [${sha.slice(0, 7)}] -> ${assessment.state}: ${assessment.description}`);
+  console.log(`${label} [${sha.slice(0, 7)}] -> ${assessment.state}: ${assessment.description}`);
 }
 
 function truncate(value) {

--- a/.github/scripts/dependabot-pr-age-check.mjs
+++ b/.github/scripts/dependabot-pr-age-check.mjs
@@ -18,10 +18,11 @@ import { readFileSync } from 'node:fs';
  * The gate deliberately fails safe: an un-verifiable age blocks the merge rather
  * than allowing a potentially-quarantined package through.
  *
- * Scope: only the npm ecosystem is gated. Dependabot PRs for other ecosystems
- * (notably `github_actions`) resolve from github.com rather than the CFS npm
- * feed, so their versions are never quarantined and report a passing
- * "not applicable" status.
+ * Scope: only npm packages are gated. Dependabot PRs for ecosystems that do not
+ * resolve through the CFS npm feed (notably GitHub Actions, branched as
+ * `dependabot/github_actions/...`) report a passing "not applicable" status.
+ * Ecosystems the script does not recognize still run the full check, so an
+ * unexpected branch name can never bypass the fail-safe.
  */
 
 const AGE_THRESHOLD_DAYS = 7;
@@ -32,12 +33,27 @@ const LOCKFILE_SUFFIX = 'package-lock.json';
 const STATUS_DESCRIPTION_LIMIT = 140;
 
 /**
- * Dependabot ecosystems whose packages are served by the CFS npm feed and are
- * therefore subject to the quarantine window. Dependabot encodes the ecosystem
- * in its branch name (`dependabot/<ecosystem>/<slug>`), which is the signal this
- * script uses because it is not customizable, unlike PR labels.
+ * Dependabot ecosystems that are known not to resolve through the CFS npm feed
+ * and therefore can never be quarantined.
+ *
+ * These are Dependabot's *branch-name* slugs, which intentionally differ from
+ * the `package-ecosystem` keys in `.github/dependabot.yml`:
+ *
+ *   package-ecosystem: "github-actions"  ->  dependabot/github_actions/...
+ *   package-ecosystem: npm               ->  dependabot/npm_and_yarn/...
+ *
+ * The branch slug is the signal used here because, unlike PR labels, it is not
+ * customizable. Any ecosystem *not* listed is treated as potentially-npm and
+ * runs the full age check, so an unrecognized or newly-configured ecosystem
+ * fails safe rather than silently skipping the gate.
  */
-const QUARANTINED_ECOSYSTEMS = new Set(['npm_and_yarn']);
+const NON_NPM_ECOSYSTEMS = new Set([
+  'github_actions',
+  'docker',
+  'devcontainers',
+  'submodules',
+  'terraform',
+]);
 
 const DEPENDABOT_BRANCH_PATTERN = /^dependabot\/(?<ecosystem>[^/]+)\//u;
 
@@ -198,10 +214,12 @@ function isDependabotPullRequest(pullRequest) {
 }
 
 /**
- * Reads the Dependabot ecosystem from the PR head branch
- * (`dependabot/<ecosystem>/<slug>`).
+ * Reads the Dependabot ecosystem slug from the PR head branch
+ * (`dependabot/<slug>/<update>`). Note this slug differs from the
+ * `package-ecosystem` key in `dependabot.yml` -- `npm` is branched as
+ * `npm_and_yarn`, and `github-actions` as `github_actions`.
  *
- * @returns {string|null} the ecosystem, or null when the branch does not follow
+ * @returns {string|null} the slug, or null when the branch does not follow
  * Dependabot's naming scheme (treated as unknown, so the full check still runs).
  */
 function getDependabotEcosystem(pullRequest) {
@@ -217,24 +235,27 @@ function getDependabotEcosystem(pullRequest) {
  * @returns {Promise<{state: 'success'|'failure'|'pending', description: string}>}
  */
 async function assessPullRequest(context, pullRequest) {
-  // Only npm packages flow through the CFS feed that enforces the quarantine.
-  // `github_actions` (and any other non-npm ecosystem) resolves from github.com,
-  // so its versions can never be quarantined -- and looking them up on the npm
-  // registry would 404 and wrongly trip the fail-safe.
-  const ecosystem = getDependabotEcosystem(pullRequest);
-  if (ecosystem !== null && !QUARANTINED_ECOSYSTEMS.has(ecosystem)) {
-    return {
-      state: 'success',
-      description: truncate(
-        `Ecosystem "${ecosystem}" is not served by the CFS npm feed; package-age gate not applicable.`,
-      ),
-    };
-  }
-
+  // A changed lockfile is ground truth that npm versions are moving, so it is
+  // evaluated *before* any ecosystem shortcut: if npm packages changed they are
+  // gated no matter what the branch name claims.
   let changedVersions = await getChangedVersionsFromLockfiles(context, pullRequest);
   let source = 'lockfile';
 
   if (changedVersions.length === 0) {
+    // No npm versions moved. Only packages served by the CFS feed can be
+    // quarantined; GitHub Actions and friends resolve from github.com, and
+    // looking their names up on the npm registry would 404 and wrongly trip the
+    // fail-safe. Unrecognized ecosystems fall through to the full check.
+    const ecosystem = getDependabotEcosystem(pullRequest);
+    if (ecosystem !== null && NON_NPM_ECOSYSTEMS.has(ecosystem)) {
+      return {
+        state: 'success',
+        description: truncate(
+          `Ecosystem "${ecosystem}" is not served by the CFS npm feed; package-age gate not applicable.`,
+        ),
+      };
+    }
+
     changedVersions = extractDependencyUpdatesFromBody(pullRequest);
     source = 'pr-body';
   }

--- a/.github/workflows/dependabot-package-age-gate.yml
+++ b/.github/workflows/dependabot-package-age-gate.yml
@@ -1,18 +1,25 @@
 name: Dependabot Package Age Gate
 
 # Publishes a required commit status ("package-age/7-day") on every Dependabot
-# PR. The status is `success` only when all changed package versions (including
-# transitive lockfile changes) are at least 7 days old, matching the Microsoft
-# Central Feed Services (CFS) npm quarantine window. Configure this status as a
-# required check in branch protection so a `failure`/`pending` state blocks the
-# merge and prevents `npm ci` from breaking on quarantined packages.
+# PR. The status is `success` only when all changed npm package versions
+# (including transitive lockfile changes) are at least 7 days old, matching the
+# Microsoft Central Feed Services (CFS) npm quarantine window. Configure this
+# status as a required check in branch protection so a `failure`/`pending` state
+# blocks the merge and prevents `npm ci` from breaking on quarantined packages.
+#
+# Only the npm ecosystem is gated. Dependabot PRs for other ecosystems (notably
+# `github_actions`) resolve through github.com rather than the CFS npm feed, so
+# they are never quarantined and report a passing "not applicable" status.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+  merge_group:
+    # Required status checks must also report on the merge queue's temporary
+    # ref, otherwise the queue waits forever for a status that never arrives.
   schedule:
-    # Daily re-check so PRs that were too new auto-clear once packages age past
-    # the 7-day window.
-    - cron: '17 8 * * *'
+    # Twice-daily re-check so PRs that were too new auto-clear once packages age
+    # past the 7-day window, without waiting a full day for the next run.
+    - cron: '17 8,20 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/dependabot-package-age-gate.yml
+++ b/.github/workflows/dependabot-package-age-gate.yml
@@ -7,9 +7,12 @@ name: Dependabot Package Age Gate
 # status as a required check in branch protection so a `failure`/`pending` state
 # blocks the merge and prevents `npm ci` from breaking on quarantined packages.
 #
-# Only the npm ecosystem is gated. Dependabot PRs for other ecosystems (notably
-# `github_actions`) resolve through github.com rather than the CFS npm feed, so
-# they are never quarantined and report a passing "not applicable" status.
+# Only npm packages are gated. Dependabot PRs for ecosystems that do not resolve
+# through the CFS npm feed report a passing "not applicable" status -- notably
+# GitHub Actions, configured as `package-ecosystem: "github-actions"` but
+# branched by Dependabot as `dependabot/github_actions/...`. Ecosystems the
+# script does not recognize still run the full check, so an unexpected branch
+# name can never bypass the fail-safe.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
## Why

`package-age/7-day` was permanently red on #734 with:

> Could not confirm npm age for 4 package(s) (actions/checkout@7.0.1, actions/setup-node@7.0.0, step-security/harden-runner@2.20.1); blocking…

It is a  **`github_actions`** update, so no `package-lock.json` changed → the script fell back to parsing the PR body → produced names like `actions/checkout@7.0.1` → looked them up on `registry.npmjs.org/actions%2Fcheckout` → **404** → tripped the "unverifiable age" fail-safe. A status that could never clear, no matter how many days passed.

CFS quarantine only applies to npm packages resolved through the Azure Artifacts feed. GitHub Actions are fetched from github.com by the runner and are never quarantined, so a fresh action release can't break `npm ci`.

## What changed

**Ecosystem scoping.** Read the ecosystem from the Dependabot *branch slug* (`dependabot/<slug>/<update>`) — chosen over labels because labels are customized in this repo (`javascript`, not `npm_and_yarn`) while branch names are not. Note the slug differs from the `dependabot.yml` key: `package-ecosystem: "github-actions"` branches as `github_actions`, and `npm` as `npm_and_yarn`.

The skip is an **allowlist** of ecosystems known not to reach the CFS feed, and the lockfile diff is evaluated *before* the shortcut. So a changed `package-lock.json` is always gated regardless of what the branch claims, and an unrecognized slug runs the full check rather than being skipped. This matters because the naive form ("skip anything that is not `npm_and_yarn`") fails **open** — see the review thread; caught there and fixed in ba56199e.

**Status UX.** Every status now carries a `target_url` pointing at the workflow run. That's a real GitHub-hosted page, so it supplies both missing pieces at once: the job log has the untruncated package list (statuses clip at 140 chars), and the run page has a native **"Re-run all jobs"** button as an on-demand refresh. No page to manufacture, no Check Runs machinery needed.

**Freshness.** Cron goes from daily to twice daily (`17 8,20 * * *`), halving how long a cleared package sits yellow.

**Merge-queue safety.** Added a `merge_group:` trigger. `main` has a merge queue, and a required status check must also report on the queue's temporary ref — without this, adding `package-age/7-day` to the ruleset would stall the queue forever waiting on a status that never arrives. Queued PRs already passed the gate at PR time and packages only get older, so the merge-group path reports success.

## Verification

Dry-run harness against live GitHub + npm data, intercepting the status POST:

| Case | Before | After |
|---|---|---|
| #734 `github_actions` | ❌ `failure` | ✅ `success` — "Ecosystem \"github_actions\" is not served by the CFS npm feed" |
| #737 `npm_and_yarn`, aged deps | ✅ | ✅ `success` via lockfile path |
| npm PR w/ `hono@4.13.3` (1.3d old) | — | ⏳ **`pending`** — "hono@4.13.3 is 1d old (<7d CFS quarantine). Eligible 2026-08-25 UTC." |
| `merge_group` event | (never reported) | ✅ `success` on merge ref |
| slug `npm` (unrecognized) + `hono@4.13.3` (1.3d) | `success` — **skipped (fail-open)** | ⏳ `pending` — blocked |
| unknown slug + young package | `success` — **skipped** | ⏳ `pending` — blocked |

Rows 3-6 are the red-green checks. Row 3 confirms the npm gate still blocks young packages and reports the eligible date. Rows 5-6 are the fail-open regression from review — their **Before** column is the first commit on this branch (b0a4fc54), run directly against the same inputs to confirm the old logic really did return `success`. `target_url` is present on every status.

Workflow YAML re-parsed to confirm `merge_group` registers as a trigger key (`merge_group: null`, same shape as the existing `workflow_dispatch:`).

## Follow-up (needs repo admin, not in this PR)

`package-age/7-day` is **not** currently merge-blocking — the `main` ruleset's `required_status_checks` lists only `Build & Test & Lint (24.x)`. Once this merges, add `package-age/7-day` to that list to actually block quarantined packages. The `merge_group:` trigger here is the prerequisite that makes it safe to do.
