### PR TITLE
fix: correct openai range for ai-mcp example

### DIFF
--- a/examples/ai-mcp/package.json
+++ b/examples/ai-mcp/package.json
@@ -26,7 +26,7 @@
     "@microsoft/teams.cards": "*",
     "@microsoft/teams.common": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "openai": "^4.104.0"
+    "openai": "^6.37.0"
   },
   "devDependencies": {
     "@microsoft/teams.config": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,7 @@
         "@microsoft/teams.cards": "*",
         "@microsoft/teams.common": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "openai": "^4.104.0"
+        "openai": "^6.37.0"
       },
       "devDependencies": {
         "@microsoft/teams.config": "*",


### PR DESCRIPTION
`examples/ai-mcp` declares `openai: ^4.104.0`, but `src/agent.ts:140` calls `client.chat.completions.runTools()`, which only exists in openai 5 and later. In 4.x that helper lives at `client.beta.chat.completions.runTools()`.

The example has therefore never been buildable against its declared range. It only compiles because the lockfile pins an out-of-range `openai@6.37.0`, which has been the case since the example was added in #572. npm reports this as invalid:

```
openai@6.37.0 invalid: "^4.104.0" from examples/ai-mcp
```

The failure is latent today, but any tooling that re-resolves this workspace to honor `package.json` breaks the build. Forcing the declared range reproduces it:

```
src/agent.ts:140 - error TS2339: Property 'runTools' does not exist on type 'Completions'.
```

### Fix

Declare `^6.37.0` so `package.json` matches both the source and the version already installed. This aligns `ai-mcp` with `examples/a2a`, which is also on openai 6.x. `packages/openai` stays on `^4.55.0`, since that is the published SDK plugin's own supported range.

The installed tree is unchanged: no dependency versions move, and no lockfile entries are added or removed. The diff is two lines.

### Validation

Full CI pipeline locally on Node 24.18.0: lockfile registry check pass, `npm ci` clean, `npx knip` clean, lint 37/37, build 39/39, test 15/15. `npm ls openai --workspaces` no longer reports `invalid`.
