### PR TITLE
chore: raise Node floor to >=22.12 and refresh CI matrix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,7 +59,7 @@ body:
     attributes:
       label: Node.js Version
       description: Which version of Node.js are you using?
-      placeholder: e.g., 20.0.0
+      placeholder: e.g., 22.12.0
     validations:
       required: true
 

--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['24.x', '25.x']
+        node-version: ['22.x', '24.x']
     permissions:
       contents: read
     steps:

--- a/examples/a2a/src/a2a-client.ts
+++ b/examples/a2a/src/a2a-client.ts
@@ -79,6 +79,6 @@ export class A2APeerClient {
 }
 
 function cryptoRandomId(): string {
-  // Node 20+ exposes crypto.randomUUID globally.
+  // Node 22+ exposes crypto.randomUUID globally.
   return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }

--- a/examples/ai-mcp/README.md
+++ b/examples/ai-mcp/README.md
@@ -18,7 +18,7 @@ This is the TypeScript counterpart to the .NET [`ExtAIBot`](https://github.com/m
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22.12+
 - An **Azure OpenAI resource** with a deployed model (e.g. `gpt-4o`) and an API key. No Foundry project required.
 - A Teams bot registration (App ID + secret).
 

--- a/examples/cards/README.md
+++ b/examples/cards/README.md
@@ -5,7 +5,7 @@ a demo of adaptive cards
 ## Prerequisites
 
 - Node.js version 22.12 or later
-- An Microsoft 365 development account. If you don't have one, you can get one for free by signing up for the [Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program).
+- A Microsoft 365 development account. If you don't have one, you can get one for free by signing up for the [Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program).
 
 ## Run
 

--- a/examples/cards/README.md
+++ b/examples/cards/README.md
@@ -4,7 +4,7 @@ a demo of adaptive cards
 
 ## Prerequisites
 
-- Node.js version 20 or later
+- Node.js version 22.12 or later
 - An Microsoft 365 development account. If you don't have one, you can get one for free by signing up for the [Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program).
 
 ## Run

--- a/examples/dialogs/README.md
+++ b/examples/dialogs/README.md
@@ -12,7 +12,7 @@ A demo of dialogs (task modules) in Teams.
 ## Prerequisites
 
 - Node.js version 22.12 or later
-- An Microsoft 365 development account. If you don't have one, you can get one for free by signing up for the [Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program).
+- A Microsoft 365 development account. If you don't have one, you can get one for free by signing up for the [Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program).
 
 ## Run
 

--- a/examples/dialogs/README.md
+++ b/examples/dialogs/README.md
@@ -11,7 +11,7 @@ A demo of dialogs (task modules) in Teams.
 
 ## Prerequisites
 
-- Node.js version 20 or later
+- Node.js version 22.12 or later
 - An Microsoft 365 development account. If you don't have one, you can get one for free by signing up for the [Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program).
 
 ## Run

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.62.4"
@@ -20430,7 +20430,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "packages/api": {
@@ -20457,7 +20457,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "packages/apps": {
@@ -20492,7 +20492,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
+        "node": ">=22.12.0"
       }
     },
     "packages/apps/node_modules/jwks-rsa": {
@@ -20549,7 +20549,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
+        "node": ">=22.12.0"
       },
       "peerDependencies": {
         "@microsoft/teams.apps": "*",
@@ -20570,7 +20570,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "packages/client": {
@@ -20592,7 +20592,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       },
       "peerDependencies": {
         "@microsoft/teams-js": "^2.35.0"
@@ -20615,7 +20615,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "packages/config": {
@@ -20659,7 +20659,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       },
       "peerDependencies": {
         "@microsoft/teams.apps": "*"
@@ -20748,7 +20748,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "packages/graph-endpoints": {
@@ -20762,7 +20762,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "packages/graph-endpoints-beta": {
@@ -20776,7 +20776,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "packages/graph-tools": {
@@ -20806,7 +20806,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "packages/graph-tools/node_modules/camelcase": {
@@ -20842,7 +20842,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
+        "node": ">=22.12.0"
       },
       "peerDependencies": {
         "@microsoft/agents-activity": "^1.5.0",
@@ -20870,7 +20870,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       },
       "peerDependencies": {
         "openai": "^4.55.0"
@@ -20886,21 +20886,11 @@
       "devDependencies": {
         "@azure/msal-node": "^5.6.0",
         "@types/jest": "^29.5.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.2",
         "dotenv-cli": "^7.4.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.0",
         "typescript": "~5.8.0"
-      }
-    },
-    "test/integration/node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "test/integration/node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/microsoft/teams.ts/issues",
   "packageManager": "npm@11.12.1",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/botbuilder/package.json
+++ b/packages/botbuilder/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/cards/package.json
+++ b/packages/cards/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/graph-endpoints-beta/package.json
+++ b/packages/graph-endpoints-beta/package.json
@@ -23,7 +23,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/graph-endpoints/package.json
+++ b/packages/graph-endpoints/package.json
@@ -23,7 +23,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/graph-tools/package.json
+++ b/packages/graph-tools/package.json
@@ -19,7 +19,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/m365extensions/package.json
+++ b/packages/m365extensions/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -4,7 +4,7 @@ Outbound API integration tests that run against live Teams service endpoints.
 
 ## Prerequisites
 
-- Node.js >= 20
+- Node.js >= 22.12
 - A configured bot app registration (see the [integration test runbook](https://dev.azure.com/DomoreexpGithub/Github_Pipelines/_wiki/wikis/Github%20Pipelines%20Wiki/1/Teams-SDK-Integration-Test-Runbook) (internal only))
 
 ## Setup

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@azure/msal-node": "^5.6.0",
     "@types/jest": "^29.5.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.2",
     "dotenv-cli": "^7.4.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.0",

--- a/turbo/generators/templates/examples/README.md.hbs
+++ b/turbo/generators/templates/examples/README.md.hbs
@@ -5,7 +5,7 @@
 ## Prerequisites
 
 - Node.js version 22.12 or later
-- An Microsoft 365 development account. If you don't have one, you can get one for free by signing up for the [Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program).
+- A Microsoft 365 development account. If you don't have one, you can get one for free by signing up for the [Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program).
 
 ## Run
 

--- a/turbo/generators/templates/examples/README.md.hbs
+++ b/turbo/generators/templates/examples/README.md.hbs
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-- Node.js version 20 or later
+- Node.js version 22.12 or later
 - An Microsoft 365 development account. If you don't have one, you can get one for free by signing up for the [Microsoft 365 Developer Program](https://developer.microsoft.com/microsoft-365/dev-program).
 
 ## Run

--- a/turbo/generators/templates/package/package.json.hbs
+++ b/turbo/generators/templates/package/package.json.hbs
@@ -11,6 +11,9 @@
     "dist",
     "README.md"
   ],
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/teams.ts.git",


### PR DESCRIPTION
Node 20 reached EOL on 2026-04-30, and the CI matrix was testing 25.x, which went EOL on 2026-06-01. This raises `engines.node` to `>=22.12.0` across the repo and moves CI to `['22.x', '24.x']`, both of which are in support (22 is Maintenance LTS through 2027-04-30, 24 is Active LTS "Krypton" through 2028-04-30).

## Why `>=22.12.0` and not a bare `>=22`

`jwks-rsa` 4.1.0 landed on `main` in #754 as a direct dependency of `@microsoft/teams.apps`, and it declares `"^20.19.0 || ^22.12.0 || >= 23.0.0"`. A bare `>=22` would claim support for Node 22.0 through 22.11, which that range rejects, so installs on those versions would emit `EBADENGINE`. Dropping the now-EOL Node 20 branch of that range leaves `>=22.12.0` as the honest floor. It is applied uniformly rather than only to `apps`, so every package states the same requirement instead of each one encoding its own transitive constraints.

That number is also the ecosystem convention rather than an arbitrary pick: 22.12.0 is where `require(esm)` became available, and 17 packages already in this tree's dependency graph use it as their own floor.

## Changes

- 15 `package.json` files bumped to `>=22.12.0` (root plus `ai`, `api`, `apps`, `botbuilder`, `cards`, `client`, `common`, `dev`, `graph`, `graph-endpoints`, `graph-endpoints-beta`, `graph-tools`, `m365extensions`, `openai`). Three of these (`apps`, `botbuilder`, `m365extensions`) replace the compound range `#754` introduced.
- `turbo/generators/templates/package/package.json.hbs` had **no** `engines` block at all, so every scaffolded package silently shipped without one. Added.
- `turbo/generators/templates/examples/README.md.hbs` would have re-seeded "version 20 or later" into every newly generated example.
- `test/integration` `@types/node` `^20.0.0` → `^22.0.2`, the last remaining outlier. Its stale nested lockfile entry (`20.19.43`, which `npm ls` flagged as `invalid: "^22.0.2" from test/integration`) is removed, so the workspace now resolves the hoisted 22.x instead of silently typechecking against Node 20 types.
- 4 READMEs (`test/integration`, `examples/ai-mcp`, `examples/cards`, `examples/dialogs`), the bug-report issue template placeholder, and one code comment in `examples/a2a/src/a2a-client.ts`.

## Deliberately unchanged

- `packages/config` and `packages/devtools`: both `private: true` with no `engines` field today, and devtools is slated for deletion.
- `examples/a2a/README.md`: keeps its higher `Node.js 24+` requirement.
- Other CI Node pins (`issue-analysis.yml`, `dependabot-package-age-gate.yml`, `.azdo/publish.yml`) were already on 24.x.

## Note on the lockfile

`package-lock.json` is edited in place rather than regenerated, so its diff carries only what this change actually requires: the 15 workspace `engines` mirrors, the `test/integration` `@types/node` declared range, and the removal of that one stale nested entry. 17 entries differ, across 42 lines.

Regenerating instead would have been noisier without being more correct. `main`'s lockfile carries some drift from having been generated by a different npm than the pinned `npm@11.12.1`, and a clean regeneration sweeps that in as unrelated churn. Confirmed by regenerating a pristine copy of `main` with zero other input and reproducing the same churn, so it is not something this branch introduced or needs to fix.

The result is structurally verified: **no package added, removed, or resolved to a different version**, and `npm ci` accepts it on both matrix legs.

## Verification

The `22.x` leg brings **npm 10.9.8** into the matrix for the first time (the previous 24/25 matrix only exercised npm 11.x), so the full CI sequence was run locally against both pairings CI actually uses, in addition to CI itself being green.

| Leg | Node | npm | Result |
| --- | --- | --- | --- |
| `22.x` | v22.23.2 | 10.9.8 | green |
| `24.x` | v24.18.0 | 11.17.0 | green |

Each leg ran `check:lockfile-registry` → `npm ci` → `knip` → `lint` → `build` → `test`: 1404 packages installed with **zero `EBADENGINE`**, knip exit 0, lint 38/38, build 40/40, test 15/15. `test/integration` sits outside the turbo task graph, so it was typechecked separately with `tsc --noEmit` (exit 0) against `@types/node` 22.19.12, with `npm ls` reporting no `invalid` entries.

The `jose-interop` spec that came in with the `jwks-rsa` 4.x bump passes 3/3 on the 22.x leg, so the new auth path is exercised at the floor this PR claims.

## Follow-ups (out of scope)

- Add `26.x` to the matrix after Node 26 is promoted to LTS on 2026-10-28.
- Pre-existing duplicate `"test"` key in `turbo/generators/templates/package/package.json.hbs`.
