### PR TITLE
chore(deps): bump jwks-rsa from 3.2.2 to 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,6 @@
         "examples/*",
         "test/integration"
       ],
-      "dependencies": {
-        "@rollup/rollup-linux-x64-gnu": "4.62.4"
-      },
       "devDependencies": {
         "@turbo/gen": "^2.5.7",
         "nerdbank-gitversioning": "^3.10.91",
@@ -46,7 +43,7 @@
         "@types/express": "^5.0.0",
         "@types/node": "^22.5.4",
         "dotenv": "^17.4.2",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.23.12",
         "typescript": "^5.4.5"
@@ -152,7 +149,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^17.4.2",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.23.12",
         "typescript": "^5.4.5"
@@ -234,7 +231,7 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "dotenv": "^17.4.2",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.23.12",
         "typescript": "^5.4.5"
@@ -264,7 +261,7 @@
       "devDependencies": {
         "@types/node": "^22.5.4",
         "dotenv": "^17.4.2",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.23.12",
         "typescript": "^5.4.5"
@@ -294,7 +291,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^17.4.2",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.23.12",
         "typescript": "^5.4.5"
@@ -355,7 +352,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^17.4.2",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.23.12",
         "typescript": "^5.4.5"
@@ -534,7 +531,7 @@
         "@types/express": "^5.0.0",
         "@types/node": "^22.5.4",
         "dotenv": "^17.4.2",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.23.12",
         "typescript": "^5.4.5"
@@ -674,7 +671,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^17.4.2",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.23.12",
         "typescript": "^5.4.5"
@@ -704,7 +701,7 @@
         "@microsoft/teams.config": "*",
         "@types/node": "^22.5.4",
         "dotenv": "^17.4.2",
-        "env-cmd": "*",
+        "env-cmd": "latest",
         "rimraf": "^6.0.1",
         "tsx": "^4.23.12",
         "typescript": "^5.4.5"
@@ -6057,9 +6054,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6077,9 +6071,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6097,9 +6088,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6117,9 +6105,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6137,9 +6122,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7181,9 +7163,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7201,9 +7180,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7221,9 +7197,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7241,9 +7214,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7261,9 +7231,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7281,9 +7248,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7635,9 +7599,6 @@
       "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -14336,27 +14297,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/jwks-rsa": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "@types/jsonwebtoken": "^9.0.4",
-        "debug": "^4.3.4",
-        "jose": "^4.15.4",
-        "limiter": "^1.1.5",
-        "lru-memoizer": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/jwks-rsa/node_modules/jose": {
-      "version": "4.15.9",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/jws": {
       "version": "4.0.1",
       "license": "MIT",
@@ -14457,6 +14397,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14478,6 +14419,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14499,6 +14441,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14520,6 +14463,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14541,6 +14485,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14557,14 +14502,12 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14581,14 +14524,12 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14605,14 +14546,12 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14629,14 +14568,12 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14658,6 +14595,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14679,6 +14617,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14816,28 +14755,6 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
-    },
-    "node_modules/lru-memoizer": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.clonedeep": "^4.5.0",
-        "lru-cache": "6.0.0"
-      }
-    },
-    "node_modules/lru-memoizer/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/lru-memoizer/node_modules/yallist": {
-      "version": "4.0.0",
-      "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -17661,9 +17578,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18951,6 +18865,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18968,6 +18883,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18985,6 +18901,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19002,6 +18919,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19019,6 +18937,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19036,6 +18955,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19053,6 +18973,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19070,6 +18991,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19087,6 +19009,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19104,6 +19027,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19121,6 +19045,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19138,6 +19063,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19155,6 +19081,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19172,6 +19099,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19189,6 +19117,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19206,6 +19135,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19223,6 +19153,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19240,6 +19171,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19257,6 +19189,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19274,6 +19207,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19291,6 +19225,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19308,6 +19243,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19325,6 +19261,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19342,6 +19279,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19359,6 +19297,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19376,6 +19315,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20534,7 +20474,7 @@
         "cors": "^2.8.5",
         "express": "^5.0.0",
         "jsonwebtoken": "^9.0.2",
-        "jwks-rsa": "^3.2.0",
+        "jwks-rsa": "^4.1.0",
         "reflect-metadata": "^0.2.2"
       },
       "devDependencies": {
@@ -20552,7 +20492,43 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
+      }
+    },
+    "packages/apps/node_modules/jwks-rsa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-4.1.0.tgz",
+      "integrity": "sha512-sbkByqyATKYJP5F4RXj03N5TUNC0QLTjCAZvwTzC4BwJZ8e0/cWxN8YROnyUth2g1/ONWi4eSFHeu6oYalrc3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^6.1.3",
+        "limiter": "^1.1.5",
+        "lru-cache": "^11.0.0",
+        "lru-memoizer": "^3.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
+      }
+    },
+    "packages/apps/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/apps/node_modules/lru-memoizer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-3.0.0.tgz",
+      "integrity": "sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "^11.0.1"
       }
     },
     "packages/botbuilder": {
@@ -20573,7 +20549,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
       },
       "peerDependencies": {
         "@microsoft/teams.apps": "*",
@@ -20866,7 +20842,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
       },
       "peerDependencies": {
         "@microsoft/agents-activity": "^1.5.0",

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
   },
   "repository": {
     "type": "git",
@@ -46,7 +46,7 @@
     "cors": "^2.8.5",
     "express": "^5.0.0",
     "jsonwebtoken": "^9.0.2",
-    "jwks-rsa": "^3.2.0",
+    "jwks-rsa": "^4.1.0",
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {

--- a/packages/apps/src/middleware/auth/jose-interop.spec.ts
+++ b/packages/apps/src/middleware/auth/jose-interop.spec.ts
@@ -1,0 +1,46 @@
+import { generateKeyPairSync } from 'crypto';
+
+import { JwksClient } from 'jwks-rsa';
+
+/**
+ * `jwks-rsa` performs its JWK -> PEM conversion through `jose`, which publishes ESM
+ * only. Jest runs CommonJS, so `jose` is down-levelled by the transform and
+ * `transformIgnorePatterns` pair in `@microsoft/teams.config/jest.config`.
+ *
+ * That conversion sits inside a `try { ... } catch { continue; }` in jwks-rsa, so a
+ * `jose` that loads but does not work yields *no signing keys* rather than an error,
+ * and inbound token validation would fail silently at runtime. These tests therefore
+ * assert that a real key round-trips through the public API, not merely that the
+ * module imports.
+ */
+describe('jwks-rsa / jose interop under the CommonJS test runtime', () => {
+  const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const jwk = publicKey.export({ format: 'jwk' }) as Record<string, unknown>;
+  const expectedPem = publicKey.export({ format: 'pem', type: 'spki' }).toString().trim();
+
+  // `fetcher` keeps this offline and deterministic; the JWK itself is a real RSA key.
+  const client = new JwksClient({
+    jwksUri: 'https://example.test/discovery/v2.0/keys',
+    fetcher: async () => ({ keys: [{ ...jwk, use: 'sig', kid: 'test-kid' }] }),
+  });
+
+  it('resolves a signing key instead of silently returning none', async () => {
+    const key = await client.getSigningKey('test-kid');
+
+    expect(key).toBeDefined();
+    expect(key.kid).toBe('test-kid');
+  });
+
+  it('returns the SPKI PEM of the exact key published in the JWKS', async () => {
+    const key = await client.getSigningKey('test-kid');
+
+    // `jose.exportSPKI` omits the trailing newline that Node's `KeyObject.export`
+    // emits. Only that surrounding whitespace differs, and `jsonwebtoken.verify`
+    // accepts either form, so compare trimmed.
+    expect(key.getPublicKey().trim()).toBe(expectedPem);
+  });
+
+  it('reports unknown key ids as an error rather than an empty result', async () => {
+    await expect(client.getSigningKey('missing-kid')).rejects.toThrow();
+  });
+});

--- a/packages/botbuilder/package.json
+++ b/packages/botbuilder/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/config/jest.config.js
+++ b/packages/config/jest.config.js
@@ -3,7 +3,19 @@ module.exports = {
   roots: ['<rootDir>/src'],
   transform: {
     '^.+\\.ts?$': 'ts-jest',
+    // `jose` (reached via `jwks-rsa`) publishes ESM only, with no CommonJS build.
+    // Jest's default runtime is CommonJS and cannot `require()` it, so the files
+    // un-ignored below are down-levelled to CommonJS here.
+    '^.+\\.m?js$': [
+      'ts-jest',
+      { tsconfig: { allowJs: true, module: 'CommonJS', target: 'ES2022' }, isolatedModules: true },
+    ],
   },
+  // Jest skips node_modules when transforming. Un-ignore ESM-only dependencies so the
+  // transform above can reach them. The negative lookahead is relative to whichever
+  // `/node_modules/` segment matched, so it covers hoisted and nested copies alike.
+  // Add a package here only when it ships ESM without a `require` export condition.
+  transformIgnorePatterns: ['/node_modules/(?!jose/)'],
   collectCoverage: true,
   preset: 'ts-jest',
   coverageDirectory: 'coverage',

--- a/packages/m365extensions/package.json
+++ b/packages/m365extensions/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps `jwks-rsa` from 3.2.2 to 4.1.0 in `@microsoft/teams.apps`.

Supersedes #750. Dependabot's branch can only carry the version bump, and this upgrade does not build or test green without two supporting changes that have to land in the same commit.

### Why this needs more than a version bump

jwks-rsa 4 drops its bundled CommonJS `jose@4` and depends on `jose@^6.1.3`, which publishes **ESM only** (there is no CommonJS build in the package at all). Two things follow from that.

**1. Jest could not load it.** Our shared Jest config is CommonJS ts-jest and had no `transformIgnorePatterns`, so it could not `require()` any ESM dependency. This surfaced as `SyntaxError: Unexpected token 'export'` in the botbuilder suite, while lint and build stayed green. `packages/config/jest.config.js` now un-ignores `jose` and down-levels it to CommonJS. This is the first ESM-only dependency to reach our test runtime, which is why the config had no such handling before. To allow another one later, add it to the negative lookahead.

**2. `engines.node` understated what we require.** jwks-rsa 4 narrows its own `engines.node` to `^20.19.0 || ^22.12.0 || >= 23.0.0`, which is exactly Node's `require(ESM)` support matrix. `@microsoft/teams.apps` still advertised `>=20`, so a consumer on Node 20.0 through 20.18 or 22.0 through 22.11 would have installed cleanly and then hit `ERR_REQUIRE_ESM` at runtime. This copies that range verbatim onto `teams.apps`, plus `teams.botbuilder` and `teams.m365extensions`, which cannot function without `teams.apps` (a required peer and a hard dependency respectively).

> [!IMPORTANT]
> This narrows the supported Node range for three published packages and should be called out in release notes. Node 20.0 to 20.18, 21.x, and 22.0 to 22.11 are no longer supported by these packages. Node 21 is excluded because `require(ESM)` was backported to 20.19 and shipped in 22.12 but never landed in 21, which is non-LTS and has been EOL since June 2024.

### Why bump now rather than defer

Staying on jwks-rsa 3 was considered. It pins us to `jose@4`, whose last release was July 2024, so we would be depending on an unmaintained crypto library and a future advisory there might never be patched. The ESM and `engines` work does not disappear by waiting either, it just moves to a worse moment: doing it now is a planned change with a regression test, whereas doing it after a `jose@4` advisory would be the same migration under time pressure.

Replacing jwks-rsa with Node's native `crypto.createPublicKey({ format: 'jwk' })` was also considered and rejected. It would avoid the `engines` change, but it would move JWKS fetching, caching, key rotation, `use`/`alg` filtering, and rate limiting into this repo. That is security-sensitive logic on the inbound token validation path, and it is better maintained upstream.

### Behavior

The public jwks-rsa API used by `JwtValidator` is unchanged: `jwksRsa({ jwksUri })`, `client.getSigningKey(kid, cb)`, and `key.getPublicKey()` all behave the same.

One cosmetic difference: `jose.exportSPKI` omits the trailing newline that Node's `KeyObject.export` emits. The key material is byte-identical and `jsonwebtoken.verify` accepts either form.

### On the added test

`packages/apps/src/middleware/auth/jose-interop.spec.ts` covers the interop specifically because jwks-rsa swallows key-conversion errors with `try { ... } catch { continue; }` in `retrieveSigningKeys`. A `jose` that imports but does not actually work returns an **empty key list** rather than raising, which means inbound token validation would fail silently rather than loudly. A test that only asserted "the module imports" would not have caught that.

Instead it drives the real `JwksClient.getSigningKey` through an injected `fetcher`, which keeps it offline and deterministic, and asserts the returned PEM matches the exact RSA key published in the JWKS. Confirmed red before the Jest change and green after.

### Verification

Full CI sequence from a clean `npm ci` on Node 24, re-run after rebasing onto latest `main`:

| Step | Result |
| --- | --- |
| `check:lockfile-registry` | pass |
| `knip` | pass |
| `lint` | 37/37 |
| `build` | 39/39 |
| `test` | 15/15 (apps 554 -> 557) |

Also exercised the real runtime path outside Jest on Node 22 and 24, since the Jest transform would otherwise mask a genuine `require(ESM)` break in shipped code. Every changed lockfile entry was verified against the npm registry: integrity hashes match, all resolve to `registry.npmjs.org`, and all are signed.

### Note

Root `engines` is deliberately left at `>=20`. The root package is private and its own build, lint, and test scripts still work on older Node 20 because of the Jest transform, so narrowing it would warn contributors inaccurately.