### PR TITLE
Rename IncomingFile.webUrl to contentUrl

### DIFF
--- a/packages/apps/src/files/files-accessor.spec.ts
+++ b/packages/apps/src/files/files-accessor.spec.ts
@@ -36,7 +36,7 @@ describe('FilesAccessor', () => {
     expect(file.extension).toBe('pdf');
     expect(file.scope).toBe('personal');
     expect(file.source).toBe('botActivity');
-    expect(file.webUrl).toBe('https://contoso.sharepoint.com/report.pdf');
+    expect(file.contentUrl).toBe('https://contoso.sharepoint.com/report.pdf');
     expect(file.raw).toBe(attachment);
   });
 

--- a/packages/apps/src/files/files-accessor.ts
+++ b/packages/apps/src/files/files-accessor.ts
@@ -114,8 +114,8 @@ export class FilesAccessor implements IFilesAccessor {
       extension: content?.fileType,
       scope,
       source: 'botActivity',
-      // Maps the wire's `contentUrl` (a browsable link to the file in OneDrive/SharePoint) to `webUrl`; not fetchable like `downloadUrl`.
-      webUrl: attachment.contentUrl,
+      // Browsable link to the file in OneDrive/SharePoint; not fetchable like `downloadUrl`.
+      contentUrl: attachment.contentUrl,
       raw: attachment,
       downloadUrl,
       httpClient: this.httpClient,

--- a/packages/apps/src/files/incoming-file.ts
+++ b/packages/apps/src/files/incoming-file.ts
@@ -17,7 +17,7 @@ export interface IIncomingFileInit {
   extension?: string;
   scope: ConversationType;
   source: FileSource;
-  webUrl?: string;
+  contentUrl?: string;
   raw?: unknown;
   /** Short-lived, pre-authorized download URL (personal scope). */
   downloadUrl?: string;
@@ -37,7 +37,7 @@ export class IncomingFile implements IIncomingFile {
   readonly extension?: string;
   readonly scope: ConversationType;
   readonly source: FileSource;
-  readonly webUrl?: string;
+  readonly contentUrl?: string;
   readonly raw?: unknown;
 
   private readonly downloadUrl?: string;
@@ -52,7 +52,7 @@ export class IncomingFile implements IIncomingFile {
     this.extension = init.extension;
     this.scope = init.scope;
     this.source = init.source;
-    this.webUrl = init.webUrl;
+    this.contentUrl = init.contentUrl;
     this.raw = init.raw;
     this.downloadUrl = init.downloadUrl;
     this._fetch = init.fetch;

--- a/packages/apps/src/files/types.ts
+++ b/packages/apps/src/files/types.ts
@@ -57,7 +57,7 @@ export interface IIncomingFile {
   /**
    * Browsable URL to the file in OneDrive/SharePoint, as sent on the attachment's `contentUrl`.
    *
-   * Not fetchable for bytes despite the name; those come from {@link downloadUrl}.
+   * Not fetchable for bytes despite the name; those come from {@link IIncomingFile.download} or {@link IIncomingFile.stream}.
    */
   contentUrl?: string;
   /** The raw underlying attachment/graph object for escape-hatch access. */

--- a/packages/apps/src/files/types.ts
+++ b/packages/apps/src/files/types.ts
@@ -54,8 +54,12 @@ export interface IIncomingFile {
   scope: ConversationType;
   /** Where the SDK found the file. Only `botActivity` is produced today. */
   source: FileSource;
-  /** Web URL to the file in OneDrive/SharePoint when known. */
-  webUrl?: string;
+  /**
+   * Browsable URL to the file in OneDrive/SharePoint, as sent on the attachment's `contentUrl`.
+   *
+   * Not fetchable for bytes despite the name; those come from {@link downloadUrl}.
+   */
+  contentUrl?: string;
   /** The raw underlying attachment/graph object for escape-hatch access. */
   raw?: unknown;
 


### PR DESCRIPTION
Renames the public `IncomingFile.webUrl` property to `contentUrl`.

## This is not a breaking change

**The property has never been published.** `webUrl` arrived with #712 ("Receive files in personal scope") on 2026-08-13, and no release has been cut since. Verified rather than assumed:

- `npm dist-tags`: `latest` is `2.0.15`, `next` is `2.1.0-preview.3`. There is no stable `2.1.0`.
- I downloaded and unpacked the `@microsoft/teams.apps@2.1.0-preview.3` tarball. It contains **zero occurrences of `webUrl`** and **no `files/` output in `dist` at all**. The whole `ctx.files` feature postdates it.
- `git tag --contains` on #712 is empty, and `release/v2.1` does not contain `packages/apps/src/files/` at all.

So there are no consumers to break, in any published form. This is also the last cheap moment: once 2.1 ships from `main`, the name is locked.

## Why

The value arrives on the wire as the attachment's `contentUrl`, and `Attachment.contentUrl` **already exposes it publicly** in this same SDK. That left the same value reachable under two different public names depending on which door you came through:

```ts
activity.attachments[0].contentUrl   // public
ctx.files[0].webUrl                  // public, same value, different name
```

Upstream doesn't call it a "web URL" either. APX sources it from `fileInfo.ObjectUrl` and writes it into the Bot Framework attachment's `ContentUrl` slot, so `webUrl` was a name this SDK invented at the boundary. The mapping comment in `files-accessor.ts` was the only thing holding the two vocabularies together, and it's now unnecessary: the value is a straight pass-through.

## The one real objection, and how it's handled

`contentUrl` sits next to `downloadUrl`, and it is the one that does **not** return content. That's a genuine footgun, but it already exists on `Attachment.contentUrl` regardless of what we do here, and it's a docs problem rather than a design problem. Two public names for one value is the design problem. So the docstring now states the trap directly:

> Browsable URL to the file in OneDrive/SharePoint, as sent on the attachment's `contentUrl`. Not fetchable for bytes despite the name; those come from `downloadUrl`.

## Cross-SDK

Matching PRs go up for `teams.py` (`web_url` → `content_url`) and `teams.net` (`WebUrl` → `ContentUrl`). The feature is unreleased in all three, so all three can move together. Published docs in `teams-sdk` are updated separately.

## Validation

30 suites / 585 tests pass; build and lint clean.
