### PR TITLE
refactor(dev): replace uuid with native randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20679,7 +20679,6 @@
         "@microsoft/teams.common": "*",
         "express": "^5.0.0",
         "jsonwebtoken": "^9.0.2",
-        "uuid": "^11.0.5",
         "ws": "^8.18.1"
       },
       "devDependencies": {

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -43,7 +43,6 @@
     "@microsoft/teams.common": "*",
     "express": "^5.0.0",
     "jsonwebtoken": "^9.0.2",
-    "uuid": "^11.0.5",
     "ws": "^8.18.1"
   },
   "peerDependencies": {

--- a/packages/dev/src/plugin.ts
+++ b/packages/dev/src/plugin.ts
@@ -1,9 +1,8 @@
+import { randomUUID } from 'crypto';
 import http from 'http';
 import path from 'path';
 
 import express from 'express';
-
-import * as uuid from 'uuid';
 
 import { WebSocket, WebSocketServer } from 'ws';
 
@@ -161,7 +160,7 @@ export class DevtoolsPlugin {
 
   onActivity({ activity, conversation }: IPluginActivityEvent) {
     this.emitActivityToSockets({
-      id: uuid.v4(),
+      id: randomUUID(),
       type: 'activity.received',
       chat: conversation,
       body: activity,
@@ -171,7 +170,7 @@ export class DevtoolsPlugin {
 
   onActivitySent({ activity, conversation }: IPluginActivitySentEvent) {
     this.emitActivityToSockets({
-      id: uuid.v4(),
+      id: randomUUID(),
       type: 'activity.sent',
       chat: conversation,
       body: activity as any,
@@ -189,12 +188,12 @@ export class DevtoolsPlugin {
   }
 
   protected onSocketConnection(socket: WebSocket) {
-    const id = uuid.v4();
+    const id = randomUUID();
     this.sockets.set(id, socket);
 
     socket.send(
       JSON.stringify({
-        id: uuid.v4(),
+        id: randomUUID(),
         type: 'metadata',
         body: {
           pages: this.pages,

--- a/packages/dev/src/routes/v3/conversations/activities/create.ts
+++ b/packages/dev/src/routes/v3/conversations/activities/create.ts
@@ -1,6 +1,7 @@
+import { randomUUID } from 'crypto';
+
 import express from 'express';
 import jwt from 'jsonwebtoken';
-import * as uuid from 'uuid';
 
 import { Activity, JsonWebToken } from '@microsoft/teams.api';
 
@@ -16,7 +17,7 @@ export function create({ port, log, process }: RouteContext) {
     res: express.Response
   ) => {
     const isClient = req.headers['x-teams-devtools'] === 'true';
-    const id = req.body.channelData?.streamId || uuid.v4();
+    const id = req.body.channelData?.streamId || randomUUID();
 
     if (!isClient) {
       res.status(201).send({ id });
@@ -27,7 +28,7 @@ export function create({ port, log, process }: RouteContext) {
       const activity = {
         ...req.body,
         type: req.body.type || 'message',
-        id: req.body.id || uuid.v4(),
+        id: req.body.id || randomUUID(),
         channelId: 'msteams',
         from: {
           id: 'devtools',


### PR DESCRIPTION
## Summary

- replace `uuid.v4()` calls in `@microsoft/teams.dev` with Node's built-in `crypto.randomUUID()`
- remove the `uuid` dependency instead of adopting its ESM-only v14 release
- preserve CommonJS and Jest compatibility while keeping UUID v4 behavior

Supersedes #777, whose UUID 14 update fails because the release is ESM-only.

## Validation

- `npm test --workspace @microsoft/teams.dev -- --coverage=false --runInBand`
- `npm run build --workspace @microsoft/teams.dev`
- `npm run lint --workspace @microsoft/teams.dev`