### PR TITLE
fix(api): support installation upgrade activities

### DIFF
--- a/packages/api/src/activities/install-update/index.ts
+++ b/packages/api/src/activities/install-update/index.ts
@@ -1,7 +1,15 @@
 import { IInstalledActivity } from './add';
 import { IUnInstalledActivity } from './remove';
+import { IInstalledUpgradeActivity } from './upgrade';
 
-export type InstallUpdateActivity = IInstalledActivity | IUnInstalledActivity;
+/**
+ * An activity sent when an app installation is added, removed, or upgraded.
+ */
+export type InstallUpdateActivity =
+  | IInstalledActivity
+  | IUnInstalledActivity
+  | IInstalledUpgradeActivity;
 
 export * from './add';
 export * from './remove';
+export * from './upgrade';

--- a/packages/api/src/activities/install-update/upgrade.ts
+++ b/packages/api/src/activities/install-update/upgrade.ts
@@ -1,0 +1,11 @@
+import { IActivity } from '../activity';
+
+/**
+ * An installation update activity sent when an installed app is upgraded.
+ */
+export interface IInstalledUpgradeActivity extends IActivity<'installationUpdate'> {
+  /**
+   * Install update action indicating the app was upgraded.
+   */
+  action: 'upgrade';
+}

--- a/packages/apps/src/installation-update.spec.ts
+++ b/packages/apps/src/installation-update.spec.ts
@@ -1,0 +1,58 @@
+import express from 'express';
+import supertest from 'supertest';
+
+import { IInstalledUpgradeActivity } from '@microsoft/teams.api';
+
+import { App } from './app';
+import { ExpressAdapter } from './http';
+
+describe('installationUpdate', () => {
+  it('processes an upgrade activity through the inbound HTTP pipeline', async () => {
+    const expressApp = express();
+    const app = new App({
+      dangerouslyAllowUnauthenticatedRequests: true,
+      httpServerAdapter: new ExpressAdapter(expressApp),
+    });
+    let receivedActivity: IInstalledUpgradeActivity | undefined;
+
+    app.on('install.upgrade', ({ activity }) => {
+      receivedActivity = activity;
+    });
+
+    await app.initialize();
+    await supertest(expressApp)
+      .post('/api/messages')
+      .send({
+        action: 'upgrade',
+        channelId: 'msteams',
+        conversation: {
+          conversationType: 'personal',
+          id: 'xxx',
+          tenantId: 'xxx',
+        },
+        entities: [
+          {
+            locale: 'en-US',
+            type: 'clientInfo',
+          },
+        ],
+        from: {
+          aadObjectId: 'xxx',
+          id: 'xxx',
+        },
+        id: 'xxx',
+        recipient: {
+          id: 'xxx',
+          name: 'xxx',
+        },
+        serviceUrl: 'https://smba.trafficmanager.net/emea/xxx/',
+        timestamp: '2026-08-26T13:38:36.356Z',
+        type: 'installationUpdate',
+      })
+      .expect(200);
+
+    expect(receivedActivity).toBeDefined();
+    expect(receivedActivity!.type).toBe('installationUpdate');
+    expect(receivedActivity!.action).toBe('upgrade');
+  });
+});

--- a/packages/apps/src/router/router.spec.ts
+++ b/packages/apps/src/router/router.spec.ts
@@ -105,6 +105,7 @@ describe('Router', () => {
       router.on('installationUpdate', handler);
       router.on('install.add', handler);
       router.on('install.remove', handler);
+      router.on('install.upgrade', handler);
 
       expect(router.select({
         type: 'installationUpdate',
@@ -114,6 +115,11 @@ describe('Router', () => {
       expect(router.select({
         type: 'installationUpdate',
         action: 'remove'
+      } as any)).toHaveLength(2);
+
+      expect(router.select({
+        type: 'installationUpdate',
+        action: 'upgrade'
       } as any)).toHaveLength(2);
     });
   });


### PR DESCRIPTION
## Summary

- add and export `IInstalledUpgradeActivity` with the `upgrade` action discriminator
- include upgrades in `InstallUpdateActivity`, enabling the typed `install.upgrade` app route while retaining add/remove handling
- cover a representative Bot Framework payload through the Express-to-App inbound processing path

Parity fix based on microsoft/teams.py#583.

## Validation

- `npm test --workspace @microsoft/teams.apps -- --runTestsByPath src/installation-update.spec.ts src/router/router.spec.ts --runInBand --coverage=false`
- `npx turbo build --filter=@microsoft/teams.apps`
- package-configured ESLint on all changed TypeScript files
- `npx turbo build --filter=@examples/echo`