### PR TITLE
feat(apps): deprecate reactive conversation ref

### DIFF
--- a/packages/apps/README.md
+++ b/packages/apps/README.md
@@ -49,6 +49,12 @@ By default, the app receives Teams activities at `/api/messages`.
 For local-only testing without Teams service token validation, set `dangerouslyAllowUnauthenticatedRequests: true` or
 `DANGEROUSLY_ALLOW_UNAUTHENTICATED_REQUESTS=true`.
 
+## Reactive and proactive sends
+
+Use `ActivityContext.send(activity)` while handling an inbound activity to send to its current conversation. To send to
+a different conversation, use proactive `App.send()`. The legacy `ActivityContext.send(activity, conversationRef)`
+overload remains runtime-compatible but is deprecated.
+
 ## Use your existing server
 
 `@microsoft/teams.apps` can start its own HTTP server, or plug into an existing server/framework with an HTTP adapter.
@@ -85,3 +91,4 @@ See the [HTTP adapter examples](https://github.com/microsoft/teams.ts/tree/main/
 ## Examples
 
 See the [examples folder](https://github.com/microsoft/teams.ts/tree/main/examples) for agents, tabs, message extensions, proactive messaging, Graph, AI/MCP, A2A, and more.
+

--- a/packages/apps/src/contexts/activity.test.ts
+++ b/packages/apps/src/contexts/activity.test.ts
@@ -314,7 +314,7 @@ describe('ActivityContext', () => {
   });
 
   describe('send', () => {
-    it('sends the activity to the sender plugin', async () => {
+    it('routes a one-argument send to the current inbound conversation', async () => {
       const activity = buildIncomingMessageActivity('Hello world');
       context = buildActivityContext(activity);
       await context.send('What is up?');
@@ -434,7 +434,7 @@ describe('ActivityContext', () => {
         );
       });
 
-      it('does not default send to targeted for a different conversation', async () => {
+      it('routes a legacy two-argument send to the alternate conversation', async () => {
         const activity = new MessageActivity('Hello world')
           .withFrom({ id: 'test-user', name: 'Test User', role: 'user' })
           .withRecipient({ id: 'bot-id', name: 'Bot', role: 'bot' }, true)
@@ -1092,3 +1092,4 @@ describe('ActivityContext', () => {
     });
   });
 });
+

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -205,10 +205,10 @@ export interface IBaseActivityContext<T extends Activity = Activity, TExtraCtx e
    * @deprecated Reactive sends should target the current inbound conversation. Use App.send() to send to a different conversation.
    */
   send(activity: DeprecatedInputActivity, conversationRef: ConversationReference): Promise<SentActivity>;
-   /**
-    * @deprecated Reactive sends should target the current inbound conversation. Use App.send() to send to a different conversation.
-    */
-   send(activity: ActivityLike, conversationRef: ConversationReference): Promise<SentActivity>;
+  /**
+   * @deprecated Reactive sends should target the current inbound conversation. Use App.send() to send to a different conversation.
+   */
+  send(activity: ActivityLike, conversationRef: ConversationReference): Promise<SentActivity>;
 
   /**
    * reply to the inbound activity, automatically quoting the inbound message
@@ -372,10 +372,10 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
    * @deprecated Reactive sends should target the current inbound conversation. Use App.send() to send to a different conversation.
    */
   async send(activity: DeprecatedInputActivity, conversationRef: ConversationReference): Promise<SentActivity>;
-   /**
-    * @deprecated Reactive sends should target the current inbound conversation. Use App.send() to send to a different conversation.
-    */
-   async send(activity: ActivityLike, conversationRef: ConversationReference): Promise<SentActivity>;
+  /**
+   * @deprecated Reactive sends should target the current inbound conversation. Use App.send() to send to a different conversation.
+   */
+  async send(activity: ActivityLike, conversationRef: ConversationReference): Promise<SentActivity>;
   async send(activity: ActivityLike | DeprecatedInputActivity, conversationRef?: ConversationReference) {
     const params = toActivityParams(activity);
 
@@ -623,4 +623,3 @@ const PROTECTED_METHOD_NAMES: ReadonlySet<string> = (() => {
   }
   return names;
 })();
-

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -185,16 +185,27 @@ export interface IBaseActivityContext<T extends Activity = Activity, TExtraCtx e
   ) => (void | InvokeResponse) | Promise<void | InvokeResponse>;
 
   /**
-   * send an activity to the conversation
+   * send an activity to the current inbound conversation.
+   *
+   * In channels, sends to the current thread. In other scopes, sends as a normal message.
+   *
    * @param activity activity to send
-   * @param conversationRef optional conversation reference to send the activity to. By default, it will use the activity's conversation reference.
    */
   /**
    * @deprecated Use MessageActivityInput or TypingActivityInput instead.
    */
-  send(activity: DeprecatedInputActivity, conversationRef?: ConversationReference): Promise<SentActivity>;
-  send(activity: ActivityLike, conversationRef?: ConversationReference): Promise<SentActivity>;
-  send(activity: ActivityLike | DeprecatedInputActivity, conversationRef?: ConversationReference): Promise<SentActivity>;
+  send(activity: DeprecatedInputActivity): Promise<SentActivity>;
+  send(activity: ActivityLike): Promise<SentActivity>;
+
+  /**
+   * send an activity to a specific conversation.
+   *
+   * @param activity activity to send
+   * @param conversationRef conversation reference to send to
+   * @deprecated Reactive sends should target the current inbound conversation. Use App.send() to send to a different conversation.
+   */
+  send(activity: DeprecatedInputActivity, conversationRef: ConversationReference): Promise<SentActivity>;
+  send(activity: ActivityLike, conversationRef: ConversationReference): Promise<SentActivity>;
 
   /**
    * reply to the inbound activity, automatically quoting the inbound message
@@ -336,21 +347,29 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
   }
 
   /**
-   * send an activity in the current conversation without quoting.
+   * send an activity to the current inbound conversation.
    *
    * In channels, sends to the current thread. In group chats, a reply stays in
    * its thread while a root message produces another root message. Personal
    * chats and meetings send as normal messages.
    *
    * @param activity the activity to send
-   * @param conversationRef optional conversation reference to send to a different conversation or thread
    */
   /**
    * @deprecated Use MessageActivityInput or TypingActivityInput instead.
    */
-  async send(activity: DeprecatedInputActivity, conversationRef?: ConversationReference): Promise<SentActivity>;
-  async send(activity: ActivityLike, conversationRef?: ConversationReference): Promise<SentActivity>;
-  async send(activity: ActivityLike | DeprecatedInputActivity, conversationRef?: ConversationReference): Promise<SentActivity>;
+  async send(activity: DeprecatedInputActivity): Promise<SentActivity>;
+  async send(activity: ActivityLike): Promise<SentActivity>;
+
+  /**
+   * send an activity to a specific conversation.
+   *
+   * @param activity the activity to send
+   * @param conversationRef conversation reference to send to
+   * @deprecated Reactive sends should target the current inbound conversation. Use App.send() to send to a different conversation.
+   */
+  async send(activity: DeprecatedInputActivity, conversationRef: ConversationReference): Promise<SentActivity>;
+  async send(activity: ActivityLike, conversationRef: ConversationReference): Promise<SentActivity>;
   async send(activity: ActivityLike | DeprecatedInputActivity, conversationRef?: ConversationReference) {
     const params = toActivityParams(activity);
 
@@ -598,3 +617,4 @@ const PROTECTED_METHOD_NAMES: ReadonlySet<string> = (() => {
   }
   return names;
 })();
+

--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -205,7 +205,10 @@ export interface IBaseActivityContext<T extends Activity = Activity, TExtraCtx e
    * @deprecated Reactive sends should target the current inbound conversation. Use App.send() to send to a different conversation.
    */
   send(activity: DeprecatedInputActivity, conversationRef: ConversationReference): Promise<SentActivity>;
-  send(activity: ActivityLike, conversationRef: ConversationReference): Promise<SentActivity>;
+   /**
+    * @deprecated Reactive sends should target the current inbound conversation. Use App.send() to send to a different conversation.
+    */
+   send(activity: ActivityLike, conversationRef: ConversationReference): Promise<SentActivity>;
 
   /**
    * reply to the inbound activity, automatically quoting the inbound message
@@ -369,7 +372,10 @@ export class ActivityContext<T extends Activity = Activity, TExtraCtx extends {}
    * @deprecated Reactive sends should target the current inbound conversation. Use App.send() to send to a different conversation.
    */
   async send(activity: DeprecatedInputActivity, conversationRef: ConversationReference): Promise<SentActivity>;
-  async send(activity: ActivityLike, conversationRef: ConversationReference): Promise<SentActivity>;
+   /**
+    * @deprecated Reactive sends should target the current inbound conversation. Use App.send() to send to a different conversation.
+    */
+   async send(activity: ActivityLike, conversationRef: ConversationReference): Promise<SentActivity>;
   async send(activity: ActivityLike | DeprecatedInputActivity, conversationRef?: ConversationReference) {
     const params = toActivityParams(activity);
 


### PR DESCRIPTION
## Summary

This PR implements an API change to clarify and deprecate the reactive conversation reference pattern in `ActivityContext.send()`.

### Changes

- **API Signatures**: Added explicit visible overloads to `IBaseActivityContext.send()` and `ActivityContext.send()`:
  1. One-argument overloads for `DeprecatedInputActivity` and `ActivityLike` routing to current inbound conversation
  2. Two-argument overloads with required `ConversationReference` marked as `@deprecated`

- **Documentation**: 
  - Updated JSDoc to distinguish between reactive sends (current conversation) and proactive sends (different conversation)
  - Added guidance directing users to `App.send()` for proactive sends to different conversations
  - New "Reactive and proactive sends" section in packages/apps/README.md

- **Tests**: Renamed ActivityContext tests to clarify routing behavior:
  - "sends the activity to the sender plugin" → "routes a one-argument send to the current inbound conversation"
  - "does not default send to targeted for a different conversation" → "routes a legacy two-argument send to the alternate conversation"

### Compatibility

- Implementation signature remains exactly optional: `async send(activity: ActivityLike | DeprecatedInputActivity, conversationRef?: ConversationReference)`
- Runtime behavior unchanged - the legacy two-argument pattern remains fully functional
- `app.process.ts` remains unchanged and continues to accept optional conversationRef at runtime

### Files Modified

- `packages/apps/src/contexts/activity.ts`: API overload signatures and JSDoc
- `packages/apps/src/contexts/activity.test.ts`: Test name updates
- `packages/apps/README.md`: New guidance section