### PR TITLE
[2.0] fix(apps): allow targeted messages in personal chats

### DIFF
--- a/packages/apps/src/activity-sender.spec.ts
+++ b/packages/apps/src/activity-sender.spec.ts
@@ -151,16 +151,27 @@ describe('ActivitySender', () => {
       );
     });
 
-    it('should throw when sending targeted message in personal chat', async () => {
+    it('should send a targeted message in a personal conversation', async () => {
       const activity: ActivityParams = {
         type: 'message',
         text: 'hello',
         recipient: { id: 'user-1', name: 'User', role: 'user', isTargeted: true },
       };
 
-      await expect(sender.send(activity, ref)).rejects.toThrow(
-        'Targeted messages are not supported in 1:1 (personal) chats.'
+      const result = await sender.send(activity, ref);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        'https://smba.trafficmanager.net/teams/v3/conversations/conv-123/activities?isTargetedActivity=true',
+        expect.objectContaining({
+          type: 'message',
+          text: 'hello',
+          recipient: expect.objectContaining({
+            id: 'user-1',
+            isTargeted: true,
+          }),
+        })
       );
+      expect(result).toEqual(expect.objectContaining({ id: 'activity-1' }));
     });
 
     it('should allow targeted message in group chat', async () => {

--- a/packages/apps/src/activity-sender.ts
+++ b/packages/apps/src/activity-sender.ts
@@ -39,12 +39,7 @@ export class ActivitySender implements IActivitySender {
       conversation: ref.conversation,
     };
 
-    // Check if this is a targeted message
     const isTargeted = payload.recipient?.isTargeted === true;
-
-    if (isTargeted && ref.conversation.conversationType === 'personal') {
-      throw new Error('Targeted messages are not supported in 1:1 (personal) chats.');
-    }
 
     // Decide create vs update, with targeted variants
     if (payload.id) {


### PR DESCRIPTION
## Summary

Backports [#795](https://github.com/microsoft/teams.ts/pull/795) to the 2.0 release line so targeted activity sends work in personal chats. The Teams API supports this flow; the SDK guard incorrectly rejected it before making the request.

## Backport notes

The behavior change is unchanged from `main`. The regression test uses the 2.0 branch's direct HTTP client fixture because the newer API client mock does not exist on this release line.