### PR TITLE
Release 2.0.16

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+$"


### PR DESCRIPTION
Bumps the stable release version from `2.0.15` to `2.0.16` so the merged backport can be published as a new patch release.

_Created from a [Microsoft Teams conversation](https://teams.microsoft.com/l/chat/0/0?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&users=28%3A03abeb20-8ed4-4331-bf1c-31e607ee4e50)._