### PR TITLE
Fix npm audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12947,9 +12947,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -15489,7 +15489,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15511,7 +15510,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15533,7 +15531,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15555,7 +15552,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15577,7 +15573,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15599,7 +15594,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15621,7 +15615,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15643,7 +15636,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15665,7 +15657,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15687,7 +15678,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15709,7 +15699,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -18021,9 +18010,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -21164,7 +21153,7 @@
         "@microsoft/teams.common": "*",
         "@opentelemetry/api": "^1.9.1",
         "jwt-decode": "^4.0.0",
-        "qs": "^6.15.3"
+        "qs": "^6.16.0"
       },
       "devDependencies": {
         "@microsoft/teams.config": "*",
@@ -21490,7 +21479,7 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/teams.common": "*",
-        "qs": "^6.15.3"
+        "qs": "^6.16.0"
       },
       "devDependencies": {
         "@microsoft/teams.config": "*",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -39,7 +39,7 @@
     "@microsoft/teams.common": "*",
     "@opentelemetry/api": "^1.9.1",
     "jwt-decode": "^4.0.0",
-    "qs": "^6.15.3"
+    "qs": "^6.16.0"
   },
   "devDependencies": {
     "@microsoft/teams.config": "*",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@microsoft/teams.common": "*",
-    "qs": "^6.15.3"
+    "qs": "^6.16.0"
   },
   "devDependencies": {
     "@microsoft/teams.config": "*",


### PR DESCRIPTION
## Summary

Clears the current npm audit findings without bundling unrelated dependency modernization. The vulnerable `qs` range is raised in the API and Graph workspaces so published manifests resolve to the patched 6.16 line, and the lockfile now resolves `fast-uri` to 3.1.7 for transitive AJV/MCP consumers.

## Decisions

- **Keep remediation narrow.** `npm outdated` still reports a broad upgrade surface, including many major-version tracks, so this PR avoids mixing audit remediation with compatibility work that needs separate review.
- **Patch direct bounds where consumers see them.** `qs` is a direct dependency of the public API and Graph packages; raising the declared range avoids leaving a vulnerable minimum in package metadata.

## Deferred

Broader dependency refreshes are left for follow-up work because they span examples, devtools, and several unrelated SDK tracks.